### PR TITLE
allow travis to build + cut deps

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>pnmlframework</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,7 @@
 language: java
-env:
-  global:
-   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-   #   via the "travis encrypt" command using the project repo's public key
-   - secure: "gsvRBOQLk6TdWbfiNZGuF+40DSdMIFaicO85/TbZT8oMkVeATD0DZoYxPdQ00LBVMXSawSdQlXv/FBx949USqbMEIXAaWcQOIwMaqPfQu9jrC74COgbKpSvJx6lYuwF/i7UzMT968V+0Jzai/oZ7kWd/IEBXLlXTna5GecwYKzE="
 
 before_script:
  - echo "MAVEN_OPTS='-Xmx3g'" > ~/.mavenrc
-
-addons:
-  coverity_scan:
-    project:
-      name: "lhillah/pnmlframework"
-      description: "Build submitted via Travis CI"
-    notification_email: lhillah@gmail.com
-    build_command_prepend: "mvn -f ./pnmlFw-Releng/pom.xml clean"
-    build_command:   "mvn -f ./pnmlFw-Releng/pom.xml -DskipTests=true -Dmaven.javadoc.skip=true compile"
-    branch_pattern: master
 
 script: 
   - "./build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+jdk: oraclejdk8
+
 before_script:
  - echo "MAVEN_OPTS='-Xmx3g'" > ~/.mavenrc
 

--- a/pnmlFw-PTNet/META-INF/MANIFEST.MF
+++ b/pnmlFw-PTNet/META-INF/MANIFEST.MF
@@ -40,7 +40,6 @@ Export-Package: fr.lip6.move.pnml.ptnet;
 Require-Bundle: fr.lip6.pnml.framework.3rdpartimports;bundle-version="2.2.12",
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.ocl.ecore;visibility:=reexport,
  fr.lip6.pnml.framework.utils
 Bundle-ActivationPolicy: lazy
 Eclipse-RegisterBuddy: fr.lip6.pnml.framework.utils

--- a/pnmlFw-Releng/pom.xml
+++ b/pnmlFw-Releng/pom.xml
@@ -20,7 +20,7 @@
 		<pnml.snapshot>2.2.12-SNAPSHOT</pnml.snapshot>
 		<tycho.version>0.24.0</tycho.version>
 		<tycho-extras.version>0.24.0</tycho-extras.version>
-		<luna-repo.url>http://download.eclipse.org/releases/luna</luna-repo.url>
+		<eclipse-repo.url>http://download.eclipse.org/releases/neon</eclipse-repo.url>
 		<testng-repo.url>http://beust.com/eclipse</testng-repo.url>
 		<tycho-repo.url>https://oss.sonatype.org/content/groups/public/</tycho-repo.url>
 		<license-p2-repo>http://download.eclipse.org/cbi/updates/license/</license-p2-repo>
@@ -83,7 +83,7 @@
 	<repositories>
 		<repository>
 			<id>luna</id>
-			<url>${luna-repo.url}</url>
+			<url>${eclipse-repo.url}</url>
 			<layout>p2</layout>
 		</repository>
 		<repository>

--- a/pnmlFw-Releng/pom.xml
+++ b/pnmlFw-Releng/pom.xml
@@ -202,8 +202,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pnmlFw-Releng/pom.xml
+++ b/pnmlFw-Releng/pom.xml
@@ -18,8 +18,8 @@
 		<pnml.release>2.2.12</pnml.release>
 		<pnml.release.doc>2.2.12</pnml.release.doc>
 		<pnml.snapshot>2.2.12-SNAPSHOT</pnml.snapshot>
-		<tycho.version>0.24.0</tycho.version>
-		<tycho-extras.version>0.24.0</tycho-extras.version>
+		<tycho.version>0.26.0</tycho.version>
+		<tycho-extras.version>0.26.0</tycho-extras.version>
 		<eclipse-repo.url>http://download.eclipse.org/releases/neon</eclipse-repo.url>
 		<testng-repo.url>http://beust.com/eclipse</testng-repo.url>
 		<tycho-repo.url>https://oss.sonatype.org/content/groups/public/</tycho-repo.url>

--- a/pnmlFw-Releng/pom.xml
+++ b/pnmlFw-Releng/pom.xml
@@ -86,7 +86,7 @@
 			<url>${eclipse-repo.url}</url>
 			<layout>p2</layout>
 		</repository>
-		<repository>
+<!-- 		<repository>
 			<id>license</id>
 			<url>${license-p2-repo}</url>
 			<layout>p2</layout>
@@ -94,7 +94,7 @@
 		<repository>
 			<id>miage11</id>
 			<url>${miage-repo.url}</url>
-		</repository>
+		</repository> -->
 	</repositories>
 
 	<dependencyManagement>

--- a/pnmlFw-SNNet/META-INF/MANIFEST.MF
+++ b/pnmlFw-SNNet/META-INF/MANIFEST.MF
@@ -381,7 +381,6 @@ Export-Package: fr.lip6.move.pnml.symmetricnet.booleans;
    org.eclipse.emf.ecore.util"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.ocl.ecore;visibility:=reexport,
  fr.lip6.pnml.framework.utils,
  fr.lip6.pnml.framework.3rdpartimports;bundle-version="2.2.12"
 Bundle-ActivationPolicy: lazy

--- a/pnmlFw-Utils/META-INF/MANIFEST.MF
+++ b/pnmlFw-Utils/META-INF/MANIFEST.MF
@@ -14,8 +14,8 @@ Export-Package: fr.lip6.move.pnml.framework.general;
  fr.lip6.move.pnml.framework.utils.exception,
  fr.lip6.move.pnml.framework.utils.logging;uses:="org.slf4j,org.apache.commons.logging",
  fr.lip6.move.pnml.framework.utils.validation;uses:="org.xml.sax"
-Require-Bundle: org.eclipse.ocl.ecore;visibility:=reexport,
- fr.lip6.pnml.framework.3rdpartimports;bundle-version="2.2.12"
+Require-Bundle: fr.lip6.pnml.framework.3rdpartimports;bundle-version="2.2.12",
+ org.eclipse.emf.ecore
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-BuddyPolicy: registered


### PR DESCRIPTION
This does:
GOOD :
a) allows travis to build and deploy on github-pages, my update site is here :  https://yanntm.github.io/pnmlframework/
b) cuts some unneeded deps (from PNMLFW-Util mostly), notably OCL that draws a lot of stuff in. 
pnmlFW no longer transitively draws JDT in.
c) go for neon aligned artifacts + java 1.8

MEDIUM :
d) removed deploy/download from broken miage server. I don't know effects on existing nexus deploy stuff, be careful merging parent/pom.xml.

BAD: 
e) I removed the coverity stuff I didn't register for, so be careful when merging .travis.yml

I didn't set any new version of any kind, the update site builds snapshots with a release number, that's not so great especially for p2 scenarios. Maybe doesn't matter so much, this commit only changes build related files, not functionality.