### PR TITLE
Change nsURI for fr.lip6.move.pnml.pthlpng.integers.IntegersPackage to http:///pthlpng.integers.ecore

### DIFF
--- a/pnmlFw-Low_Level_API_Generation/model/pthlpng/integers.ecore
+++ b/pnmlFw-Low_Level_API_Generation/model/pthlpng/integers.ecore
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="integers" nsURI="http:///hlpn.integers.ecore" nsPrefix="integers">
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="integers" nsURI="http:///pthlpng.integers.ecore" nsPrefix="integers">
   <eClassifiers xsi:type="ecore:EClass" name="HLPNNumber" abstract="true" eSuperTypes="terms.ecore#//BuiltInSort">
     <eAnnotations source="http://www.pnml.org/models/HLAPI"/>
     <eAnnotations source="http://www.pnml.org/models/methods/SORT">

--- a/pnmlFw-Low_Level_API_Generation/model/pthlpng/pthlpng.genmodel
+++ b/pnmlFw-Low_Level_API_Generation/model/pthlpng/pthlpng.genmodel
@@ -8,7 +8,7 @@
     editPluginClass="fr.lip6.move.pnml.framework.pthlpng.provider.PthlpngEditPlugin"
     editorPluginClass="fr.lip6.move.pnml.framework.pthlpng.presentation.PthlpngEditorPlugin"
     rootExtendsClass="org.eclipse.emf.ecore.impl.MinimalEObjectImpl" suppressEMFTypes="true"
-    codeFormatting="true" testSuiteClass="fr.lip6.move.pnml.framework.pthlpng.tests.PthlpngAllTests"
+    codeFormatting="true" commentFormatting="true" testSuiteClass="fr.lip6.move.pnml.framework.pthlpng.tests.PthlpngAllTests"
     importerID="org.eclipse.emf.importer.ecore" complianceLevel="7.0" copyrightFields="false"
     cleanup="true">
   <foreignModel>booleans.ecore</foreignModel>

--- a/pnmlFw-PT-HLPNG/META-INF/MANIFEST.MF
+++ b/pnmlFw-PT-HLPNG/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 2.2.14
 Bundle-ClassPath: .
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-xport-Package: fr.lip6.move.pnml.pthlpng.booleans;
+Export-Package: fr.lip6.move.pnml.pthlpng.booleans;
   uses:="org.eclipse.emf.ecore,
    org.apache.axiom.om,
    org.eclipse.emf.common.util,
@@ -223,7 +223,7 @@ xport-Package: fr.lip6.move.pnml.pthlpng.booleans;
    org.eclipse.emf.common.notify,
    org.eclipse.emf.common.notify.impl,
    org.eclipse.emf.ecore.util"
-Require-Bundle: fr.lip6.pnml.framework.3rdpartimports;bundle-version="2.2.14",
+Require-Bundle: fr.lip6.pnml.framework.3rdpartimports;bundle-version="2.2.7",
  org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.ocl.ecore;visibility:=reexport,

--- a/pnmlFw-PT-HLPNG/plugin.xml
+++ b/pnmlFw-PT-HLPNG/plugin.xml
@@ -40,7 +40,7 @@
    <extension point="org.eclipse.emf.ecore.generated_package">
       <!-- @generated pthlpng -->
       <package
-            uri="http:///hlpn.integers.ecore"
+            uri="http:///pthlpng.integers.ecore"
             class="fr.lip6.move.pnml.pthlpng.integers.IntegersPackage"/>
    </extension>
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/And.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/And.java
@@ -42,15 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>And</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>And</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getAnd()
- * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input.size() = 2'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='InputSize'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='and' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        InputSize='self.input.size() = 2'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='and' kind='son'"
  * @generated
  */
 public interface And extends BooleanOperator {
@@ -65,8 +66,8 @@ public interface And extends BooleanOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/And.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/And.java
@@ -51,7 +51,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        InputSize='self.input.size() = 2'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
- *        tag='and' kind='son'"
+ *        tag='and' kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface And extends BooleanOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Bool.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Bool.java
@@ -43,14 +43,28 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Bool</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Bool</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBool()
  * @model annotation="http://www.pnml.org/models/ToPNML bool='not' kind='son'"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;' documentation='/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r \052/'"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
+ *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
+ *        {\n\t\t //by default they are the same sort, unless they have been
+ *        named.\n\t\t \tisEqual = true;\n\t\t \tif
+ *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
+ *        they have been explicitly named.\n\t\t\t\tisEqual =
+ *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}//
+ *        otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;'
+ *        documentation='/**\r * Returns true if this sort and argument sort are
+ *        actually \r * semantically the same sort, even in two different
+ *        objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return
+ *        true if so. \r * @param sort the sort to which we compare this one. \r
+ *        * @throws NullPointerException if according to the model, some\r *
+ *        required reference attributes have not been set.\r \052/'"
  * @generated
  */
 public interface Bool extends BuiltInSort {
@@ -65,8 +79,8 @@ public interface Bool extends BuiltInSort {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Bool.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Bool.java
@@ -48,13 +48,14 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBool()
- * @model annotation="http://www.pnml.org/models/ToPNML bool='not' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML bool='not' kind='son'"
  *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
  *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
  *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
  *        {\n\t\t //by default they are the same sort, unless they have been
  *        named.\n\t\t \tisEqual = true;\n\t\t \tif
- *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&amp;&amp;
  *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
  *        they have been explicitly named.\n\t\t\t\tisEqual =
  *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}//

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanConstant.java
@@ -43,43 +43,47 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Boolean Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Boolean
+ * Constant</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue <em>Value</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue
+ * <em>Value</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBooleanConstant()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='booleanconstantt' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='booleanconstantt'
+ *        kind='son'"
  * @generated
  */
 public interface BooleanConstant extends BuiltInConstant {
 	/**
-	 * Returns the value of the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Value</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Value</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Value</em>' attribute.
 	 * @see #setValue(Boolean)
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBooleanConstant_Value()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='value' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='value'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	Boolean getValue();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue
+	 * <em>Value</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Value</em>' attribute.
 	 * @see #getValue()
 	 * @generated
@@ -96,8 +100,8 @@ public interface BooleanConstant extends BuiltInConstant {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanConstant.java
@@ -56,7 +56,7 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBooleanConstant()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='booleanconstantt'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface BooleanConstant extends BuiltInConstant {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanOperator.java
@@ -43,15 +43,16 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Boolean Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Boolean
+ * Operator</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBooleanOperator()
- * @model abstract="true"
- *        annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsKindOf(Bool) and  self.input->forAll{c | c.oclIsKindOf(Bool)}'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
+ * @model abstract="true" annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsKindOf(Bool) and
+ *        self.input->forAll{c | c.oclIsKindOf(Bool)}'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
  * @generated
  */
 public interface BooleanOperator extends BuiltInOperator {
@@ -60,8 +61,8 @@ public interface BooleanOperator extends BuiltInOperator {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleanOperator.java
@@ -50,7 +50,7 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getBooleanOperator()
  * @model abstract="true" annotation="http://www.pnml.org/models/OCL
  *        inputOutputTypes='self.output.oclIsKindOf(Bool) and
- *        self.input->forAll{c | c.oclIsKindOf(Bool)}'"
+ *        self.input-&gt;forAll{c | c.oclIsKindOf(Bool)}'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  * @generated

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleansFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleansFactory.java
@@ -34,101 +34,100 @@ package fr.lip6.move.pnml.pthlpng.booleans;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage
  * @generated
  */
 public interface BooleansFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	BooleansFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Equality</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Equality</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Equality</em>'.
 	 * @generated
 	 */
 	Equality createEquality();
 
 	/**
-	 * Returns a new object of class '<em>Inequality</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Inequality</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Inequality</em>'.
 	 * @generated
 	 */
 	Inequality createInequality();
 
 	/**
-	 * Returns a new object of class '<em>Boolean Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Boolean Constant</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Boolean Constant</em>'.
 	 * @generated
 	 */
 	BooleanConstant createBooleanConstant();
 
 	/**
-	 * Returns a new object of class '<em>Or</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Or</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Or</em>'.
 	 * @generated
 	 */
 	Or createOr();
 
 	/**
-	 * Returns a new object of class '<em>And</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>And</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>And</em>'.
 	 * @generated
 	 */
 	And createAnd();
 
 	/**
-	 * Returns a new object of class '<em>Imply</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Imply</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Imply</em>'.
 	 * @generated
 	 */
 	Imply createImply();
 
 	/**
-	 * Returns a new object of class '<em>Not</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Not</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Not</em>'.
 	 * @generated
 	 */
 	Not createNot();
 
 	/**
-	 * Returns a new object of class '<em>Bool</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Bool</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Bool</em>'.
 	 * @generated
 	 */
 	Bool createBool();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	BooleansPackage getBooleansPackage();
 
-} //BooleansFactory
+} // BooleansFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleansPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/BooleansPackage.java
@@ -38,57 +38,55 @@ import org.eclipse.emf.ecore.EPackage;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansFactory
  * @model kind="package"
  * @generated
  */
 public interface BooleansPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "booleans";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///pthlpng.booleans.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "booleans";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	BooleansPackage eINSTANCE = fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl <em>Equality</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl
+	 * <em>Equality</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getEquality()
 	 * @generated
@@ -96,63 +94,63 @@ public interface BooleansPackage extends EPackage {
 	int EQUALITY = 0;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__SORT = TermsPackage.OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__CONTAINER_OPERATOR = TermsPackage.OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__CONTAINER_NAMED_OPERATOR = TermsPackage.OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__CONTAINER_HL_MARKING = TermsPackage.OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__CONTAINER_CONDITION = TermsPackage.OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__CONTAINER_HL_ANNOTATION = TermsPackage.OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -160,44 +158,45 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__SUBTERM = TermsPackage.OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__OUTPUT = TermsPackage.OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY__INPUT = TermsPackage.OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Equality</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Equality</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EQUALITY_FEATURE_COUNT = TermsPackage.OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl <em>Inequality</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl
+	 * <em>Inequality</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getInequality()
 	 * @generated
@@ -205,63 +204,63 @@ public interface BooleansPackage extends EPackage {
 	int INEQUALITY = 1;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__SORT = TermsPackage.OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__CONTAINER_OPERATOR = TermsPackage.OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__CONTAINER_NAMED_OPERATOR = TermsPackage.OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__CONTAINER_HL_MARKING = TermsPackage.OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__CONTAINER_CONDITION = TermsPackage.OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__CONTAINER_HL_ANNOTATION = TermsPackage.OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -269,44 +268,46 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__SUBTERM = TermsPackage.OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__OUTPUT = TermsPackage.OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY__INPUT = TermsPackage.OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Inequality</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Inequality</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INEQUALITY_FEATURE_COUNT = TermsPackage.OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl <em>Boolean Constant</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl
+	 * <em>Boolean Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getBooleanConstant()
 	 * @generated
@@ -314,63 +315,63 @@ public interface BooleansPackage extends EPackage {
 	int BOOLEAN_CONSTANT = 2;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__SORT = TermsPackage.BUILT_IN_CONSTANT__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__CONTAINER_CONDITION = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -378,35 +379,35 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__SUBTERM = TermsPackage.BUILT_IN_CONSTANT__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__OUTPUT = TermsPackage.BUILT_IN_CONSTANT__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT__INPUT = TermsPackage.BUILT_IN_CONSTANT__INPUT;
 
 	/**
-	 * The feature id for the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -414,17 +415,19 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Boolean Constant</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_CONSTANT_FEATURE_COUNT = TermsPackage.BUILT_IN_CONSTANT_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanOperatorImpl <em>Boolean Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanOperatorImpl
+	 * <em>Boolean Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getBooleanOperator()
 	 * @generated
@@ -432,63 +435,63 @@ public interface BooleansPackage extends EPackage {
 	int BOOLEAN_OPERATOR = 4;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__SORT = TermsPackage.BUILT_IN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__CONTAINER_CONDITION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -496,26 +499,26 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__SUBTERM = TermsPackage.BUILT_IN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR__OUTPUT = TermsPackage.BUILT_IN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -523,17 +526,18 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Boolean Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOLEAN_OPERATOR_FEATURE_COUNT = TermsPackage.BUILT_IN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl <em>Or</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl <em>Or</em>}' class.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getOr()
 	 * @generated
@@ -541,63 +545,63 @@ public interface BooleansPackage extends EPackage {
 	int OR = 3;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__SORT = BOOLEAN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__CONTAINER_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__CONTAINER_NAMED_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__CONTAINER_HL_MARKING = BOOLEAN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__CONTAINER_CONDITION = BOOLEAN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__CONTAINER_HL_ANNOTATION = BOOLEAN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -605,44 +609,45 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__SUBTERM = BOOLEAN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__OUTPUT = BOOLEAN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR__INPUT = BOOLEAN_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Or</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Or</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OR_FEATURE_COUNT = BOOLEAN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl <em>And</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl <em>And</em>}' class.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getAnd()
 	 * @generated
@@ -650,63 +655,63 @@ public interface BooleansPackage extends EPackage {
 	int AND = 5;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__SORT = BOOLEAN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__CONTAINER_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__CONTAINER_NAMED_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__CONTAINER_HL_MARKING = BOOLEAN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__CONTAINER_CONDITION = BOOLEAN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__CONTAINER_HL_ANNOTATION = BOOLEAN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -714,44 +719,45 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__SUBTERM = BOOLEAN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__OUTPUT = BOOLEAN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND__INPUT = BOOLEAN_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>And</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>And</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int AND_FEATURE_COUNT = BOOLEAN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl <em>Imply</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl <em>Imply</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getImply()
 	 * @generated
@@ -759,63 +765,63 @@ public interface BooleansPackage extends EPackage {
 	int IMPLY = 6;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__SORT = BOOLEAN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__CONTAINER_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__CONTAINER_NAMED_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__CONTAINER_HL_MARKING = BOOLEAN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__CONTAINER_CONDITION = BOOLEAN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__CONTAINER_HL_ANNOTATION = BOOLEAN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -823,44 +829,45 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__SUBTERM = BOOLEAN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__OUTPUT = BOOLEAN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY__INPUT = BOOLEAN_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Imply</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Imply</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int IMPLY_FEATURE_COUNT = BOOLEAN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl <em>Not</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl <em>Not</em>}' class.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getNot()
 	 * @generated
@@ -868,63 +875,63 @@ public interface BooleansPackage extends EPackage {
 	int NOT = 7;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__SORT = BOOLEAN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__CONTAINER_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__CONTAINER_NAMED_OPERATOR = BOOLEAN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__CONTAINER_HL_MARKING = BOOLEAN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__CONTAINER_CONDITION = BOOLEAN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__CONTAINER_HL_ANNOTATION = BOOLEAN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -932,44 +939,45 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__SUBTERM = BOOLEAN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__OUTPUT = BOOLEAN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT__INPUT = BOOLEAN_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Not</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Not</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NOT_FEATURE_COUNT = BOOLEAN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl <em>Bool</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl <em>Bool</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getBool()
 	 * @generated
@@ -977,36 +985,36 @@ public interface BooleansPackage extends EPackage {
 	int BOOL = 8;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOL__MULTI = TermsPackage.BUILT_IN_SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOL__CONTAINER_NAMED_SORT = TermsPackage.BUILT_IN_SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOL__CONTAINER_VARIABLE_DECL = TermsPackage.BUILT_IN_SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1014,8 +1022,8 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1023,8 +1031,8 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1032,35 +1040,36 @@ public interface BooleansPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOL__CONTAINER_EMPTY = TermsPackage.BUILT_IN_SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOL__CONTAINER_PARTITION = TermsPackage.BUILT_IN_SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The number of structural features of the '<em>Bool</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Bool</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BOOL_FEATURE_COUNT = TermsPackage.BUILT_IN_SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.Equality <em>Equality</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Equality <em>Equality</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Equality</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Equality
 	 * @generated
@@ -1068,9 +1077,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getEquality();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.Inequality <em>Inequality</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Inequality <em>Inequality</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Inequality</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Inequality
 	 * @generated
@@ -1078,9 +1088,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getInequality();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant <em>Boolean Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant <em>Boolean
+	 * Constant</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Boolean Constant</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant
 	 * @generated
@@ -1088,9 +1099,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getBooleanConstant();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue <em>Value</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue
+	 * <em>Value</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Value</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant#getValue()
 	 * @see #getBooleanConstant()
@@ -1099,9 +1111,10 @@ public interface BooleansPackage extends EPackage {
 	EAttribute getBooleanConstant_Value();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.Or <em>Or</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Or <em>Or</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Or</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Or
 	 * @generated
@@ -1109,9 +1122,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getOr();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanOperator <em>Boolean Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanOperator <em>Boolean
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Boolean Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleanOperator
 	 * @generated
@@ -1119,9 +1133,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getBooleanOperator();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.And <em>And</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.And <em>And</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>And</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.And
 	 * @generated
@@ -1129,9 +1144,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getAnd();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.Imply <em>Imply</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Imply <em>Imply</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Imply</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Imply
 	 * @generated
@@ -1139,9 +1155,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getImply();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.Not <em>Not</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Not <em>Not</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Not</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Not
 	 * @generated
@@ -1149,9 +1166,10 @@ public interface BooleansPackage extends EPackage {
 	EClass getNot();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.booleans.Bool <em>Bool</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Bool <em>Bool</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Bool</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Bool
 	 * @generated
@@ -1159,31 +1177,32 @@ public interface BooleansPackage extends EPackage {
 	EClass getBool();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	BooleansFactory getBooleansFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl <em>Equality</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl
+		 * <em>Equality</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getEquality()
 		 * @generated
@@ -1191,9 +1210,10 @@ public interface BooleansPackage extends EPackage {
 		EClass EQUALITY = eINSTANCE.getEquality();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl <em>Inequality</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl
+		 * <em>Inequality</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getInequality()
 		 * @generated
@@ -1201,9 +1221,11 @@ public interface BooleansPackage extends EPackage {
 		EClass INEQUALITY = eINSTANCE.getInequality();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl <em>Boolean Constant</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl
+		 * <em>Boolean Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getBooleanConstant()
 		 * @generated
@@ -1212,16 +1234,17 @@ public interface BooleansPackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute BOOLEAN_CONSTANT__VALUE = eINSTANCE.getBooleanConstant_Value();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl <em>Or</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl <em>Or</em>}' class.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getOr()
 		 * @generated
@@ -1229,9 +1252,11 @@ public interface BooleansPackage extends EPackage {
 		EClass OR = eINSTANCE.getOr();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanOperatorImpl <em>Boolean Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanOperatorImpl
+		 * <em>Boolean Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getBooleanOperator()
 		 * @generated
@@ -1239,9 +1264,10 @@ public interface BooleansPackage extends EPackage {
 		EClass BOOLEAN_OPERATOR = eINSTANCE.getBooleanOperator();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl <em>And</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl <em>And</em>}' class.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getAnd()
 		 * @generated
@@ -1249,9 +1275,10 @@ public interface BooleansPackage extends EPackage {
 		EClass AND = eINSTANCE.getAnd();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl <em>Imply</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl <em>Imply</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getImply()
 		 * @generated
@@ -1259,9 +1286,10 @@ public interface BooleansPackage extends EPackage {
 		EClass IMPLY = eINSTANCE.getImply();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl <em>Not</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl <em>Not</em>}' class.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getNot()
 		 * @generated
@@ -1269,9 +1297,10 @@ public interface BooleansPackage extends EPackage {
 		EClass NOT = eINSTANCE.getNot();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl <em>Bool</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl <em>Bool</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl
 		 * @see fr.lip6.move.pnml.pthlpng.booleans.impl.BooleansPackageImpl#getBool()
 		 * @generated
@@ -1280,4 +1309,4 @@ public interface BooleansPackage extends EPackage {
 
 	}
 
-} //BooleansPackage
+} // BooleansPackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Equality.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Equality.java
@@ -43,15 +43,19 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Operator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Equality</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Equality</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getEquality()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.input.size() >= 2 and self.input->forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and self.output.oclIsKindOf(Bool)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='equality' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.input.size() >= 2 and self.input->forAll{c, d |
+ *        c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and
+ *        self.output.oclIsKindOf(Bool)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='equality'
+ *        kind='son'"
  * @generated
  */
 public interface Equality extends Operator {
@@ -66,8 +70,8 @@ public interface Equality extends Operator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Equality.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Equality.java
@@ -49,13 +49,13 @@ import fr.lip6.move.pnml.pthlpng.terms.Operator;
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getEquality()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputOutputTypes='self.input.size() >= 2 and self.input->forAll{c, d |
- *        c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and
+ *        inputOutputTypes='self.input.size() &gt;= 2 and
+ *        self.input-&gt;forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and
  *        self.output.oclIsKindOf(Bool)'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='equality'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Equality extends Operator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Imply.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Imply.java
@@ -42,15 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Imply</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Imply</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getImply()
- * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input.size() = 2'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='InputSize'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='imply' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        InputSize='self.input.size() = 2'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='imply' kind='son'"
  * @generated
  */
 public interface Imply extends BooleanOperator {
@@ -65,8 +66,8 @@ public interface Imply extends BooleanOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Imply.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Imply.java
@@ -51,7 +51,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        InputSize='self.input.size() = 2'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
- *        tag='imply' kind='son'"
+ *        tag='imply' kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Imply extends BooleanOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Inequality.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Inequality.java
@@ -49,13 +49,13 @@ import fr.lip6.move.pnml.pthlpng.terms.Operator;
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getInequality()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputOutputTypes='self.input.size() = 2 and self.input->forAll{c, d |
- *        c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and
+ *        inputOutputTypes='self.input.size() = 2 and self.input-&gt;forAll{c, d
+ *        | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and
  *        self.output.oclIsKindOf(Bool)'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='inequality'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Inequality extends Operator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Inequality.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Inequality.java
@@ -43,15 +43,19 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Operator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Inequality</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Inequality</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getInequality()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.input.size() = 2 and self.input->forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and self.output.oclIsKindOf(Bool)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='inequality' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.input.size() = 2 and self.input->forAll{c, d |
+ *        c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and
+ *        self.output.oclIsKindOf(Bool)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='inequality'
+ *        kind='son'"
  * @generated
  */
 public interface Inequality extends Operator {
@@ -66,8 +70,8 @@ public interface Inequality extends Operator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Not.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Not.java
@@ -42,15 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Not</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Not</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getNot()
- * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input.size() = 1'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='InputSize'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='not' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        InputSize='self.input.size() = 1'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='not' kind='son'"
  * @generated
  */
 public interface Not extends BooleanOperator {
@@ -65,8 +66,8 @@ public interface Not extends BooleanOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Not.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Not.java
@@ -51,7 +51,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        InputSize='self.input.size() = 1'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
- *        tag='not' kind='son'"
+ *        tag='not' kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Not extends BooleanOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Or.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Or.java
@@ -42,15 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Or</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Or</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#getOr()
- * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input.size() = 2'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='InputSize'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='or' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        InputSize='self.input.size() = 2'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='or' kind='son'"
  * @generated
  */
 public interface Or extends BooleanOperator {
@@ -65,8 +66,8 @@ public interface Or extends BooleanOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Or.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/Or.java
@@ -51,7 +51,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        InputSize='self.input.size() = 2'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
- *        tag='or' kind='son'"
+ *        tag='or' kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Or extends BooleanOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/AndHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/AndHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class AndHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class AndHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class AndHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private And item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AndHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AndHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AndHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AndHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AndHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AndHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AndHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AndHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AndHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AndHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AndHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AndHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AndHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AndHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnd();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnd();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public AndHLAPI(And lowLevelAPI){
+	public AndHLAPI(And lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class AndHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public And getContainedItem(){
+	public And getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(AndHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(AndHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/BoolHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/BoolHLAPI.java
@@ -64,8 +64,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI;
 
-
-public class BoolHLAPI implements HLAPIClass,SortHLAPI{
+public class BoolHLAPI implements HLAPIClass, SortHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -73,167 +72,149 @@ public class BoolHLAPI implements HLAPIClass,SortHLAPI{
 	private Bool item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public BoolHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI() {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BoolHLAPI(
-		 PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BoolHLAPI(PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBool();}
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBool();
+		}
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public BoolHLAPI(Bool lowLevelAPI){
+	public BoolHLAPI(Bool lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -241,344 +222,306 @@ public class BoolHLAPI implements HLAPIClass,SortHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Bool getContainedItem(){
+	public Bool getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
+			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(BoolHLAPI item){
+	// equals method
+	public boolean equals(BoolHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/BooleanConstantHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/BooleanConstantHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class BooleanConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class BooleanConstantHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,460 +73,376 @@ public class BooleanConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private BooleanConstant item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public BooleanConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, java.lang.Boolean value
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public BooleanConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, java.lang.Boolean value
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public BooleanConstantHLAPI(java.lang.Boolean value
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createBooleanConstant();
+		}
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public BooleanConstantHLAPI(
-		 java.lang.Boolean value
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createBooleanConstant();}
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public BooleanConstantHLAPI(BooleanConstant lowLevelAPI){
+	public BooleanConstantHLAPI(BooleanConstant lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -535,1618 +450,1497 @@ public class BooleanConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public BooleanConstant getContainedItem(){
+	public BooleanConstant getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Boolean getValue(){
+	public Boolean getValue() {
 		return item.getValue();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Value
 	 */
 	public void setValueHLAPI(
-	
-	java.lang.Boolean elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Boolean elem) {
+
+		if (elem != null) {
+
 			item.setValue(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(BooleanConstantHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(BooleanConstantHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/EqualityHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/EqualityHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class EqualityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class EqualityHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class EqualityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Equality item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EqualityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EqualityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EqualityHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EqualityHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EqualityHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EqualityHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EqualityHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EqualityHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EqualityHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EqualityHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EqualityHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EqualityHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EqualityHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EqualityHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEquality();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEquality();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public EqualityHLAPI(Equality lowLevelAPI){
+	public EqualityHLAPI(Equality lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class EqualityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Equality getContainedItem(){
+	public Equality getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(EqualityHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(EqualityHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/ImplyHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/ImplyHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class ImplyHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class ImplyHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class ImplyHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Imply item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ImplyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ImplyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ImplyHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createImply();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ImplyHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ImplyHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ImplyHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ImplyHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ImplyHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ImplyHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ImplyHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ImplyHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ImplyHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ImplyHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ImplyHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createImply();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createImply();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ImplyHLAPI(Imply lowLevelAPI){
+	public ImplyHLAPI(Imply lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class ImplyHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Imply getContainedItem(){
+	public Imply getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ImplyHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ImplyHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/InequalityHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/InequalityHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class InequalityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class InequalityHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class InequalityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Inequality item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public InequalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public InequalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public InequalityHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public InequalityHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public InequalityHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public InequalityHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public InequalityHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public InequalityHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public InequalityHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public InequalityHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public InequalityHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public InequalityHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public InequalityHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public InequalityHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createInequality();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createInequality();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public InequalityHLAPI(Inequality lowLevelAPI){
+	public InequalityHLAPI(Inequality lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class InequalityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Inequality getContainedItem(){
+	public Inequality getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(InequalityHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(InequalityHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/NotHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/NotHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class NotHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class NotHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class NotHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Not item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NotHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NotHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NotHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createNot();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NotHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NotHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NotHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NotHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NotHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NotHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NotHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NotHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NotHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NotHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NotHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNot();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNot();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NotHLAPI(Not lowLevelAPI){
+	public NotHLAPI(Not lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class NotHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Not getContainedItem(){
+	public Not getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NotHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(NotHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/OrHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/hlapi/OrHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class OrHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class OrHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class OrHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Or item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OrHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OrHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public OrHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createOr();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public OrHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public OrHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public OrHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public OrHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public OrHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public OrHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public OrHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public OrHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public OrHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public OrHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public OrHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		BooleansFactory fact = BooleansFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOr();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOr();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public OrHLAPI(Or lowLevelAPI){
+	public OrHLAPI(Or lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class OrHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Or getContainedItem(){
+	public Or getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(OrHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(OrHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/AndImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/AndImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>And</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>And</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class AndImpl extends BooleanOperatorImpl implements And {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AndImpl() {
@@ -80,8 +79,8 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 		return BooleansPackage.Literals.AND;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class AndImpl extends BooleanOperatorImpl implements And {
 		return retour;
 
 	}
-} //AndImpl
+} // AndImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BoolImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BoolImpl.java
@@ -57,9 +57,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Bool</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Bool</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -67,8 +66,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class BoolImpl extends BuiltInSortImpl implements Bool {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BoolImpl() {
@@ -76,8 +75,8 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,10 +89,10 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -111,12 +110,12 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -129,22 +128,22 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -153,10 +152,10 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -179,12 +178,12 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -242,16 +241,16 @@ public class BoolImpl extends BuiltInSortImpl implements Bool {
 	public boolean equalSorts(Sort sort) {
 		boolean isEqual = false;
 		if (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {
-			//by default they are the same sort, unless they have been named.
+			// by default they are the same sort, unless they have been named.
 			isEqual = true;
 			if (this.getContainerNamedSort() != null && sort.getContainerNamedSort() != null) {
 				// we test them if they have been explicitly named.
 				isEqual = this.getContainerNamedSort().getName()
 						.equalsIgnoreCase(sort.getContainerNamedSort().getName());
-			}// otherwise, keep the default.
+			} // otherwise, keep the default.
 		}
 		return isEqual;
 
 	}
 
-} //BoolImpl
+} // BoolImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleanConstantImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleanConstantImpl.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.DiagnosticChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleanConstantImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleanConstantImpl.java
@@ -66,13 +66,13 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Boolean Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Boolean
+ * Constant</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl#getValue <em>Value</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl#getValue
+ * <em>Value</em>}</li>
  * </ul>
  * </p>
  *
@@ -80,9 +80,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanConstant {
 	/**
-	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -90,9 +90,9 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	protected static final Boolean VALUE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -100,8 +100,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	protected Boolean value = VALUE_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BooleanConstantImpl() {
@@ -109,8 +109,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,8 +119,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +129,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -143,8 +143,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -157,8 +157,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -172,8 +172,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -187,8 +187,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -201,8 +201,8 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -217,24 +217,24 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 		return result.toString();
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -252,7 +252,7 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getValue() != null) {
 			sb.append(" value");
@@ -265,7 +265,7 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -308,20 +308,20 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//1
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 1
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("value")) != null) {
 			try {
@@ -331,7 +331,7 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -554,30 +554,30 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -600,7 +600,7 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getValue() != null) {
 			sb.append(" value");
@@ -613,7 +613,7 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -715,4 +715,4 @@ public class BooleanConstantImpl extends BuiltInConstantImpl implements BooleanC
 		return retour;
 
 	}
-} //BooleanConstantImpl
+} // BooleanConstantImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleanOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleanOperatorImpl.java
@@ -39,9 +39,8 @@ import fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Boolean Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Boolean
+ * Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -49,8 +48,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl;
  */
 public abstract class BooleanOperatorImpl extends BuiltInOperatorImpl implements BooleanOperator {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BooleanOperatorImpl() {
@@ -58,8 +57,8 @@ public abstract class BooleanOperatorImpl extends BuiltInOperatorImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -69,4 +68,4 @@ public abstract class BooleanOperatorImpl extends BuiltInOperatorImpl implements
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //BooleanOperatorImpl
+} // BooleanOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleansFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleansFactoryImpl.java
@@ -49,16 +49,16 @@ import fr.lip6.move.pnml.pthlpng.booleans.Not;
 import fr.lip6.move.pnml.pthlpng.booleans.Or;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static BooleansFactory init() {
@@ -75,9 +75,9 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public BooleansFactoryImpl() {
@@ -85,8 +85,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -114,8 +114,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,8 +125,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -136,8 +136,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -147,8 +147,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -158,8 +158,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -169,8 +169,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -180,8 +180,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -191,8 +191,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -202,8 +202,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -212,8 +212,8 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -222,4 +222,4 @@ public class BooleansFactoryImpl extends EFactoryImpl implements BooleansFactory
 		return BooleansPackage.eINSTANCE;
 	}
 
-} //BooleansFactoryImpl
+} // BooleansFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleansPackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/BooleansPackageImpl.java
@@ -63,85 +63,85 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass equalityEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass inequalityEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass booleanConstantEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass orEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass booleanOperatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass andEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass implyEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass notEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass boolEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage#eNS_URI
 	 * @see #init()
@@ -152,19 +152,22 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link BooleansPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link BooleansPackage#eINSTANCE} when that
+	 * field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -175,29 +178,37 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 			return (BooleansPackage) EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI);
 
 		// Obtain or create and register package
-		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.get(eNS_URI) : new BooleansPackageImpl());
+		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
+				.get(eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
+						: new BooleansPackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(DotsPackage.eNS_URI) : DotsPackage.eINSTANCE);
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI)
+						: DotsPackage.eINSTANCE);
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) : HlcorestructurePackage.eINSTANCE);
+				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(HlcorestructurePackage.eNS_URI)
+						: HlcorestructurePackage.eINSTANCE);
 		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) : IntegersPackage.eINSTANCE);
+				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI)
+						: IntegersPackage.eINSTANCE);
 		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) : MultisetsPackage.eINSTANCE);
+				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI)
+						: MultisetsPackage.eINSTANCE);
 		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) : PartitionsPackage.eINSTANCE);
+				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI)
+						: PartitionsPackage.eINSTANCE);
 		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) : TermsPackage.eINSTANCE);
+				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI)
+						: TermsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theBooleansPackage.createPackageContents();
@@ -234,8 +245,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -244,8 +255,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -254,8 +265,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -264,8 +275,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -274,8 +285,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -284,8 +295,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -294,8 +305,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -304,8 +315,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -314,8 +325,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -324,8 +335,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -334,8 +345,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -344,17 +355,17 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -384,17 +395,17 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -426,7 +437,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 		boolEClass.getESuperTypes().add(theTermsPackage.getBuiltInSort());
 
 		// Initialize classes and features; add operations and parameters
-		initEClass(equalityEClass, Equality.class, "Equality", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(equalityEClass, Equality.class, "Equality", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(inequalityEClass, Inequality.class, "Inequality", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -467,25 +479,17 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createOCLAnnotations() {
 		String source = "http://www.pnml.org/models/OCL";
-		addAnnotation(
-				equalityEClass,
-				source,
-				new String[] {
-						"inputOutputTypes",
-						"self.input.size() >= 2 and self.input->forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and self.output.oclIsKindOf(Bool)" });
-		addAnnotation(
-				inequalityEClass,
-				source,
-				new String[] {
-						"inputOutputTypes",
-						"self.input.size() = 2 and self.input->forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and self.output.oclIsKindOf(Bool)" });
+		addAnnotation(equalityEClass, source, new String[] { "inputOutputTypes",
+				"self.input.size() >= 2 and self.input->forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and self.output.oclIsKindOf(Bool)" });
+		addAnnotation(inequalityEClass, source, new String[] { "inputOutputTypes",
+				"self.input.size() = 2 and self.input->forAll{c, d | c.oclIsTypeOf(d) or d.oclIsTypeOf(c)} and self.output.oclIsKindOf(Bool)" });
 		addAnnotation(orEClass, source, new String[] { "InputSize", "self.input.size() = 2" });
 		addAnnotation(booleanOperatorEClass, source, new String[] { "inputOutputTypes",
 				"self.output.oclIsKindOf(Bool) and  self.input->forAll{c | c.oclIsKindOf(Bool)}" });
@@ -496,8 +500,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 
 	/**
 	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createEcoreAnnotations() {
@@ -513,8 +517,8 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -531,9 +535,9 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -549,23 +553,18 @@ public class BooleansPackageImpl extends EPackageImpl implements BooleansPackage
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/methods/SORT</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for
+	 * <b>http://www.pnml.org/models/methods/SORT</b>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createSORTAnnotations() {
 		String source = "http://www.pnml.org/models/methods/SORT";
-		addAnnotation(
-				boolEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;",
-						"documentation",
-						"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r */" });
+		addAnnotation(boolEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body",
+				"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;",
+				"documentation",
+				"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r */" });
 	}
 
-} //BooleansPackageImpl
+} // BooleansPackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/EqualityImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/EqualityImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Equality</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Equality</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class EqualityImpl extends OperatorImpl implements Equality {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected EqualityImpl() {
@@ -81,8 +80,8 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 		return BooleansPackage.Literals.EQUALITY;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class EqualityImpl extends OperatorImpl implements Equality {
 		return retour;
 
 	}
-} //EqualityImpl
+} // EqualityImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/ImplyImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/ImplyImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Imply</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Imply</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ImplyImpl() {
@@ -80,8 +79,8 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 		return BooleansPackage.Literals.IMPLY;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class ImplyImpl extends BooleanOperatorImpl implements Imply {
 		return retour;
 
 	}
-} //ImplyImpl
+} // ImplyImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/InequalityImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/InequalityImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Inequality</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Inequality</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class InequalityImpl extends OperatorImpl implements Inequality {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected InequalityImpl() {
@@ -81,8 +80,8 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 		return BooleansPackage.Literals.INEQUALITY;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class InequalityImpl extends OperatorImpl implements Inequality {
 		return retour;
 
 	}
-} //InequalityImpl
+} // InequalityImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/NotImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/NotImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Not</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Not</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class NotImpl extends BooleanOperatorImpl implements Not {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NotImpl() {
@@ -80,8 +79,8 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 		return BooleansPackage.Literals.NOT;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class NotImpl extends BooleanOperatorImpl implements Not {
 		return retour;
 
 	}
-} //NotImpl
+} // NotImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/OrImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/impl/OrImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Or</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Or</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class OrImpl extends BooleanOperatorImpl implements Or {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected OrImpl() {
@@ -80,8 +79,8 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 		return BooleansPackage.Literals.OR;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		BooleansFactory fact = BooleansFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class OrImpl extends BooleanOperatorImpl implements Or {
 		return retour;
 
 	}
-} //OrImpl
+} // OrImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/util/BooleansAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/util/BooleansAdapterFactory.java
@@ -54,26 +54,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage
  * @generated
  */
 public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static BooleansPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public BooleansAdapterFactory() {
@@ -83,10 +82,11 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -102,9 +102,9 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BooleansSwitch<Adapter> modelSwitch = new BooleansSwitch<Adapter>() {
@@ -190,9 +190,9 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -203,11 +203,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.Equality <em>Equality</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Equality <em>Equality</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Equality
 	 * @generated
@@ -217,11 +218,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.Inequality <em>Inequality</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Inequality <em>Inequality</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Inequality
 	 * @generated
@@ -231,11 +233,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant <em>Boolean Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant <em>Boolean
+	 * Constant</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant
 	 * @generated
@@ -245,11 +248,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.Or <em>Or</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Or <em>Or</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Or
 	 * @generated
@@ -259,11 +263,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanOperator <em>Boolean Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.BooleanOperator <em>Boolean
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.BooleanOperator
 	 * @generated
@@ -273,11 +278,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.And <em>And</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.And <em>And</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.And
 	 * @generated
@@ -287,11 +293,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.Imply <em>Imply</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Imply <em>Imply</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Imply
 	 * @generated
@@ -301,11 +308,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.Not <em>Not</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Not <em>Not</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Not
 	 * @generated
@@ -315,11 +323,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.booleans.Bool <em>Bool</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.booleans.Bool <em>Bool</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.booleans.Bool
 	 * @generated
@@ -329,11 +338,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -343,11 +353,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -357,11 +368,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In
+	 * Constant</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant
 	 * @generated
@@ -371,11 +383,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator
 	 * @generated
@@ -385,11 +398,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort
 	 * @generated
@@ -399,11 +413,12 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInSort
 	 * @generated
@@ -413,10 +428,9 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -424,4 +438,4 @@ public class BooleansAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //BooleansAdapterFactory
+} // BooleansAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/util/BooleansSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/util/BooleansSwitch.java
@@ -53,31 +53,28 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage
  * @generated
  */
 public class BooleansSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static BooleansPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public BooleansSwitch() {
@@ -87,9 +84,9 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -100,9 +97,10 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -234,13 +232,14 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Equality</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Equality</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Equality</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Equality</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -249,13 +248,14 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Inequality</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Inequality</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Inequality</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Inequality</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -264,13 +264,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Boolean Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Boolean
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Boolean Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Boolean
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -279,13 +279,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Or</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Or</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Or</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Or</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -294,13 +294,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Boolean Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Boolean
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Boolean Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Boolean
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -309,13 +309,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>And</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>And</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>And</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>And</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -324,13 +324,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Imply</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Imply</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Imply</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Imply</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -339,13 +339,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Not</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Not</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Not</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Not</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -354,13 +354,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Bool</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Bool</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Bool</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Bool</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -369,13 +369,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Term</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Term</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Term</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Term</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -384,13 +384,14 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Operator</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -399,13 +400,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -414,13 +415,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -429,13 +430,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Sort</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -444,13 +445,13 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -459,13 +460,14 @@ public class BooleansSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -474,4 +476,4 @@ public class BooleansSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //BooleansSwitch
+} // BooleansSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/util/BooleansValidator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/booleans/util/BooleansValidator.java
@@ -52,25 +52,25 @@ import fr.lip6.move.pnml.pthlpng.booleans.Or;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Validator</b> for the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Validator</b> for the model. <!-- end-user-doc
+ * -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.booleans.BooleansPackage
  * @generated
  */
 public class BooleansValidator extends EObjectValidator {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final BooleansValidator INSTANCE = new BooleansValidator();
 
 	/**
-	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource() source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode() codes} from this package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource()
+	 * source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode()
+	 * codes} from this package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.common.util.Diagnostic#getSource()
 	 * @see org.eclipse.emf.common.util.Diagnostic#getCode()
 	 * @generated
@@ -78,33 +78,35 @@ public class BooleansValidator extends EObjectValidator {
 	public static final String DIAGNOSTIC_SOURCE = "fr.lip6.move.pnml.pthlpng.booleans";
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 0;
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
-	 * <!-- begin-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants in a derived class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static final int DIAGNOSTIC_CODE_COUNT = GENERATED_DIAGNOSTIC_CODE_COUNT;
 
 	/**
-	 * The cached base package validator.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached base package validator. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	protected TermsValidator termsValidator;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public BooleansValidator() {
@@ -113,9 +115,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the package of this validator switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package of this validator switch. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,12 +127,13 @@ public class BooleansValidator extends EObjectValidator {
 
 	/**
 	 * Calls <code>validateXXX</code> for the corresponding classifier of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		switch (classifierID) {
 		case BooleansPackage.EQUALITY:
 			return validateEquality((Equality) value, diagnostics, context);
@@ -156,8 +159,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateEquality(Equality equality, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -186,9 +189,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Equality</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Equality</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateEquality_inputOutputTypes(Equality equality, DiagnosticChain diagnostics,
@@ -199,10 +202,10 @@ public class BooleansValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(equality, context) },
-						new Object[] { equality }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(equality, context) },
+								new Object[] { equality }, context));
 			}
 			return false;
 		}
@@ -210,8 +213,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateInequality(Inequality inequality, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -240,9 +243,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Inequality</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Inequality</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateInequality_inputOutputTypes(Inequality inequality, DiagnosticChain diagnostics,
@@ -253,10 +256,10 @@ public class BooleansValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(inequality, context) },
-						new Object[] { inequality }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(inequality, context) },
+								new Object[] { inequality }, context));
 			}
 			return false;
 		}
@@ -264,8 +267,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateBooleanConstant(BooleanConstant booleanConstant, DiagnosticChain diagnostics,
@@ -293,8 +296,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateOr(Or or, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -325,9 +328,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the InputSize constraint of '<em>Or</em>'.
-	 * <!-- begin-user-doc -->
+	 * Validates the InputSize constraint of '<em>Or</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateOr_InputSize(Or or, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -347,8 +350,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateBooleanOperator(BooleanOperator booleanOperator, DiagnosticChain diagnostics,
@@ -379,8 +382,8 @@ public class BooleansValidator extends EObjectValidator {
 
 	/**
 	 * Validates the inputOutputTypes constraint of '<em>Boolean Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateBooleanOperator_inputOutputTypes(BooleanOperator booleanOperator,
@@ -391,10 +394,10 @@ public class BooleansValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(booleanOperator, context) },
-						new Object[] { booleanOperator }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(booleanOperator, context) },
+								new Object[] { booleanOperator }, context));
 			}
 			return false;
 		}
@@ -402,8 +405,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAnd(And and, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -434,9 +437,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the InputSize constraint of '<em>And</em>'.
-	 * <!-- begin-user-doc -->
+	 * Validates the InputSize constraint of '<em>And</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAnd_InputSize(And and, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -456,8 +459,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateImply(Imply imply, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -488,9 +491,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the InputSize constraint of '<em>Imply</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the InputSize constraint of '<em>Imply</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateImply_InputSize(Imply imply, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -510,8 +513,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNot(Not not, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -542,9 +545,9 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the InputSize constraint of '<em>Not</em>'.
-	 * <!-- begin-user-doc -->
+	 * Validates the InputSize constraint of '<em>Not</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNot_InputSize(Not not, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -564,8 +567,8 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateBool(Bool bool, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -573,17 +576,18 @@ public class BooleansValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the resource locator that will be used to fetch messages for this validator's diagnostics.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the resource locator that will be used to fetch messages for this
+	 * validator's diagnostics. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public ResourceLocator getResourceLocator() {
 		// TODO
-		// Specialize this to return a resource locator for messages specific to this validator.
+		// Specialize this to return a resource locator for messages specific to this
+		// validator.
 		// Ensure that you remove @generated or mark it @generated NOT
 		return super.getResourceLocator();
 	}
 
-} //BooleansValidator
+} // BooleansValidator

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/Dot.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/Dot.java
@@ -49,12 +49,13 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
  *
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage#getDot()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='dot' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
  *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
  *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
  *        {\n\t\t //by default they are the same sort, unless they have been
  *        named.\n\t\t \tisEqual = true;\n\t\t \tif
- *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&amp;&amp;
  *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
  *        they have been explicitly named.\n\t\t\t\tisEqual =
  *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}//

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/Dot.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/Dot.java
@@ -43,14 +43,28 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Dot</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Dot</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage#getDot()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='dot' kind='son'"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;' documentation='/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r \052/'"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
+ *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
+ *        {\n\t\t //by default they are the same sort, unless they have been
+ *        named.\n\t\t \tisEqual = true;\n\t\t \tif
+ *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
+ *        they have been explicitly named.\n\t\t\t\tisEqual =
+ *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}//
+ *        otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;'
+ *        documentation='/**\r * Returns true if this sort and argument sort are
+ *        actually \r * semantically the same sort, even in two different
+ *        objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return
+ *        true if so. \r * @param sort the sort to which we compare this one. \r
+ *        * @throws NullPointerException if according to the model, some\r *
+ *        required reference attributes have not been set.\r \052/'"
  * @generated
  */
 public interface Dot extends BuiltInSort {
@@ -65,8 +79,8 @@ public interface Dot extends BuiltInSort {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotConstant.java
@@ -49,7 +49,7 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
  *
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage#getDotConstant()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='dotconstant'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface DotConstant extends BuiltInConstant {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotConstant.java
@@ -43,13 +43,13 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Dot Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Dot
+ * Constant</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage#getDotConstant()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='dotconstant' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='dotconstant'
+ *        kind='son'"
  * @generated
  */
 public interface DotConstant extends BuiltInConstant {
@@ -64,8 +64,8 @@ public interface DotConstant extends BuiltInConstant {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotsFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotsFactory.java
@@ -34,47 +34,46 @@ package fr.lip6.move.pnml.pthlpng.dots;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage
  * @generated
  */
 public interface DotsFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	DotsFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.dots.impl.DotsFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Dot</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Dot</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Dot</em>'.
 	 * @generated
 	 */
 	Dot createDot();
 
 	/**
-	 * Returns a new object of class '<em>Dot Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Dot Constant</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Dot Constant</em>'.
 	 * @generated
 	 */
 	DotConstant createDotConstant();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	DotsPackage getDotsPackage();
 
-} //DotsFactory
+} // DotsFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotsPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/DotsPackage.java
@@ -37,57 +37,55 @@ import org.eclipse.emf.ecore.EPackage;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsFactory
  * @model kind="package"
  * @generated
  */
 public interface DotsPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "dots";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///pthlpng.dots.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "dots";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	DotsPackage eINSTANCE = fr.lip6.move.pnml.pthlpng.dots.impl.DotsPackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl <em>Dot</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl <em>Dot</em>}' class.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl
 	 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotsPackageImpl#getDot()
 	 * @generated
@@ -95,36 +93,36 @@ public interface DotsPackage extends EPackage {
 	int DOT = 0;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT__MULTI = TermsPackage.BUILT_IN_SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT__CONTAINER_NAMED_SORT = TermsPackage.BUILT_IN_SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT__CONTAINER_VARIABLE_DECL = TermsPackage.BUILT_IN_SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -132,8 +130,8 @@ public interface DotsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -141,8 +139,8 @@ public interface DotsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -150,35 +148,36 @@ public interface DotsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT__CONTAINER_EMPTY = TermsPackage.BUILT_IN_SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT__CONTAINER_PARTITION = TermsPackage.BUILT_IN_SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The number of structural features of the '<em>Dot</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Dot</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_FEATURE_COUNT = TermsPackage.BUILT_IN_SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl <em>Dot Constant</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl <em>Dot
+	 * Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl
 	 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotsPackageImpl#getDotConstant()
 	 * @generated
@@ -186,63 +185,63 @@ public interface DotsPackage extends EPackage {
 	int DOT_CONSTANT = 1;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__SORT = TermsPackage.BUILT_IN_CONSTANT__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__CONTAINER_CONDITION = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -250,44 +249,44 @@ public interface DotsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__SUBTERM = TermsPackage.BUILT_IN_CONSTANT__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__OUTPUT = TermsPackage.BUILT_IN_CONSTANT__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT__INPUT = TermsPackage.BUILT_IN_CONSTANT__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Dot Constant</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Dot Constant</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DOT_CONSTANT_FEATURE_COUNT = TermsPackage.BUILT_IN_CONSTANT_FEATURE_COUNT + 0;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.dots.Dot <em>Dot</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.dots.Dot
+	 * <em>Dot</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Dot</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.dots.Dot
 	 * @generated
@@ -295,9 +294,10 @@ public interface DotsPackage extends EPackage {
 	EClass getDot();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.dots.DotConstant <em>Dot Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.dots.DotConstant <em>Dot Constant</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Dot Constant</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.dots.DotConstant
 	 * @generated
@@ -305,31 +305,32 @@ public interface DotsPackage extends EPackage {
 	EClass getDotConstant();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	DotsFactory getDotsFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl <em>Dot</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl <em>Dot</em>}' class.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl
 		 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotsPackageImpl#getDot()
 		 * @generated
@@ -337,9 +338,10 @@ public interface DotsPackage extends EPackage {
 		EClass DOT = eINSTANCE.getDot();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl <em>Dot Constant</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl <em>Dot
+		 * Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl
 		 * @see fr.lip6.move.pnml.pthlpng.dots.impl.DotsPackageImpl#getDotConstant()
 		 * @generated
@@ -348,4 +350,4 @@ public interface DotsPackage extends EPackage {
 
 	}
 
-} //DotsPackage
+} // DotsPackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/hlapi/DotConstantHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/hlapi/DotConstantHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class DotConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class DotConstantHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class DotConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private DotConstant item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DotConstantHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DotConstantHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DotConstantHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DotConstantHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DotConstantHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DotConstantHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DotConstantHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DotConstantHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DotConstantHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DotConstantHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DotConstantHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DotConstantHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDotConstant();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDotConstant();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public DotConstantHLAPI(DotConstant lowLevelAPI){
+	public DotConstantHLAPI(DotConstant lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class DotConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public DotConstant getContainedItem(){
+	public DotConstant getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(DotConstantHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(DotConstantHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/hlapi/DotHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/hlapi/DotHLAPI.java
@@ -64,8 +64,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI;
 
-
-public class DotHLAPI implements HLAPIClass,SortHLAPI{
+public class DotHLAPI implements HLAPIClass, SortHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -73,167 +72,149 @@ public class DotHLAPI implements HLAPIClass,SortHLAPI{
 	private Dot item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public DotHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI() {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DotHLAPI(
-		 PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DotHLAPI(PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		DotsFactory fact = DotsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDot();}
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDot();
+		}
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public DotHLAPI(Dot lowLevelAPI){
+	public DotHLAPI(Dot lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -241,344 +222,306 @@ public class DotHLAPI implements HLAPIClass,SortHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Dot getContainedItem(){
+	public Dot getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
+			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(DotHLAPI item){
+	// equals method
+	public boolean equals(DotHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotConstantImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotConstantImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Dot Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Dot
+ * Constant</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
  */
 public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DotConstantImpl() {
@@ -80,8 +79,8 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 		return DotsPackage.Literals.DOT_CONSTANT;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		DotsFactory fact = DotsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -550,8 +549,8 @@ public class DotConstantImpl extends BuiltInConstantImpl implements DotConstant 
 	@Override
 	public boolean validateOCL(DiagnosticChain diagnostics) {
 
-		//this package has no validator class
+		// this package has no validator class
 		return true;
 
 	}
-} //DotConstantImpl
+} // DotConstantImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotImpl.java
@@ -56,9 +56,8 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Dot</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Dot</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -66,8 +65,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl;
  */
 public class DotImpl extends BuiltInSortImpl implements Dot {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DotImpl() {
@@ -75,8 +74,8 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,10 +88,10 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -110,12 +109,12 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -128,22 +127,22 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		DotsFactory fact = DotsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -152,10 +151,10 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -178,12 +177,12 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -229,7 +228,7 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 	@Override
 	public boolean validateOCL(DiagnosticChain diagnostics) {
 
-		//this package has no validator class
+		// this package has no validator class
 		return true;
 
 	}
@@ -238,16 +237,16 @@ public class DotImpl extends BuiltInSortImpl implements Dot {
 	public boolean equalSorts(Sort sort) {
 		boolean isEqual = false;
 		if (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {
-			//by default they are the same sort, unless they have been named.
+			// by default they are the same sort, unless they have been named.
 			isEqual = true;
 			if (this.getContainerNamedSort() != null && sort.getContainerNamedSort() != null) {
 				// we test them if they have been explicitly named.
 				isEqual = this.getContainerNamedSort().getName()
 						.equalsIgnoreCase(sort.getContainerNamedSort().getName());
-			}// otherwise, keep the default.
+			} // otherwise, keep the default.
 		}
 		return isEqual;
 
 	}
 
-} //DotImpl
+} // DotImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotsFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotsFactoryImpl.java
@@ -43,16 +43,16 @@ import fr.lip6.move.pnml.pthlpng.dots.DotsFactory;
 import fr.lip6.move.pnml.pthlpng.dots.DotsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static DotsFactory init() {
@@ -68,9 +68,9 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public DotsFactoryImpl() {
@@ -78,8 +78,8 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -95,8 +95,8 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -106,8 +106,8 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -117,8 +117,8 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -127,8 +127,8 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -137,4 +137,4 @@ public class DotsFactoryImpl extends EFactoryImpl implements DotsFactory {
 		return DotsPackage.eINSTANCE;
 	}
 
-} //DotsFactoryImpl
+} // DotsFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotsPackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/impl/DotsPackageImpl.java
@@ -53,36 +53,36 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass dotEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass dotConstantEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage#eNS_URI
 	 * @see #init()
@@ -93,19 +93,22 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link DotsPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link DotsPackage#eINSTANCE} when that
+	 * field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -116,30 +119,37 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 			return (DotsPackage) EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI);
 
 		// Obtain or create and register package
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.get(eNS_URI) : new DotsPackageImpl());
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.get(eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
+						: new DotsPackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
 		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) : BooleansPackage.eINSTANCE);
+				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI)
+						: BooleansPackage.eINSTANCE);
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) : HlcorestructurePackage.eINSTANCE);
+				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(HlcorestructurePackage.eNS_URI)
+						: HlcorestructurePackage.eINSTANCE);
 		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) : IntegersPackage.eINSTANCE);
+				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI)
+						: IntegersPackage.eINSTANCE);
 		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) : MultisetsPackage.eINSTANCE);
+				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI)
+						: MultisetsPackage.eINSTANCE);
 		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) : PartitionsPackage.eINSTANCE);
+				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI)
+						: PartitionsPackage.eINSTANCE);
 		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) : TermsPackage.eINSTANCE);
+				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI)
+						: TermsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theDotsPackage.createPackageContents();
@@ -168,8 +178,8 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -178,8 +188,8 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -188,8 +198,8 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -198,17 +208,17 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -223,17 +233,17 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -277,8 +287,8 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -288,9 +298,9 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -300,23 +310,18 @@ public class DotsPackageImpl extends EPackageImpl implements DotsPackage {
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/methods/SORT</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for
+	 * <b>http://www.pnml.org/models/methods/SORT</b>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createSORTAnnotations() {
 		String source = "http://www.pnml.org/models/methods/SORT";
-		addAnnotation(
-				dotEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;",
-						"documentation",
-						"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r */" });
+		addAnnotation(dotEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body",
+				"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;",
+				"documentation",
+				"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r */" });
 	}
 
-} //DotsPackageImpl
+} // DotsPackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/util/DotsAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/util/DotsAdapterFactory.java
@@ -46,26 +46,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage
  * @generated
  */
 public class DotsAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static DotsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public DotsAdapterFactory() {
@@ -75,10 +74,11 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -94,9 +94,9 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DotsSwitch<Adapter> modelSwitch = new DotsSwitch<Adapter>() {
@@ -142,9 +142,9 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -155,11 +155,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.dots.Dot <em>Dot</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.dots.Dot <em>Dot</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.dots.Dot
 	 * @generated
@@ -169,11 +170,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.dots.DotConstant <em>Dot Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.dots.DotConstant <em>Dot Constant</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.dots.DotConstant
 	 * @generated
@@ -183,11 +185,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort
 	 * @generated
@@ -197,11 +200,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInSort
 	 * @generated
@@ -211,11 +215,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -225,11 +230,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -239,11 +245,12 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In
+	 * Constant</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant
 	 * @generated
@@ -253,10 +260,9 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -264,4 +270,4 @@ public class DotsAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //DotsAdapterFactory
+} // DotsAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/util/DotsSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/dots/util/DotsSwitch.java
@@ -45,31 +45,28 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.dots.DotsPackage
  * @generated
  */
 public class DotsSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static DotsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public DotsSwitch() {
@@ -79,9 +76,9 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -92,9 +89,10 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -131,13 +129,13 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Dot</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Dot</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Dot</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Dot</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -146,13 +144,13 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Dot Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Dot
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Dot Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Dot
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -161,13 +159,13 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Sort</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -176,13 +174,13 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -191,13 +189,13 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Term</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Term</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Term</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Term</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -206,13 +204,14 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Operator</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -221,13 +220,13 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -236,13 +235,14 @@ public class DotsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -251,4 +251,4 @@ public class DotsSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //DotsSwitch
+} // DotsSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Annotation.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Annotation.java
@@ -54,7 +54,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotation()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Annotation extends Label {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Annotation.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Annotation.java
@@ -42,14 +42,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Annotation</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Annotation</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics <em>Annotationgraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics
+ * <em>Annotationgraphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -59,14 +59,16 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Annotation extends Label {
 	/**
-	 * Returns the value of the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation <em>Container Annotation</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation
+	 * <em>Container Annotation</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Annotationgraphics</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Annotationgraphics</em>' containment reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Annotationgraphics</em>' containment reference.
 	 * @see #setAnnotationgraphics(AnnotationGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotation_Annotationgraphics()
@@ -78,10 +80,13 @@ public interface Annotation extends Label {
 	AnnotationGraphics getAnnotationgraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics <em>Annotationgraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics
+	 * <em>Annotationgraphics</em>}' containment reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Annotationgraphics</em>' containment reference.
+	 * 
+	 * @param value the new value of the '<em>Annotationgraphics</em>' containment
+	 *              reference.
 	 * @see #getAnnotationgraphics()
 	 * @generated
 	 */
@@ -91,8 +96,8 @@ public interface Annotation extends Label {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnnotationGraphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnnotationGraphics.java
@@ -62,7 +62,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics'
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='graphics'
  *        kind='son'"
  * @generated
  */

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnnotationGraphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnnotationGraphics.java
@@ -42,49 +42,59 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Annotation Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Annotation Graphics</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset <em>Offset</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill <em>Fill</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine <em>Line</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont <em>Font</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation <em>Container Annotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset
+ * <em>Offset</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill
+ * <em>Fill</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine
+ * <em>Line</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont
+ * <em>Font</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation
+ * <em>Container Annotation</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics'
+ *        kind='son'"
  * @generated
  */
 public interface AnnotationGraphics extends Graphics {
 	/**
-	 * Returns the value of the '<em><b>Offset</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Offset</b></em>' containment reference. It
+	 * is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Offset</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Offset</em>' containment reference.
 	 * @see #setOffset(Offset)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics_Offset()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics
-	 * @model opposite="containerAnnotationGraphics" containment="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerAnnotationGraphics" containment="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Offset getOffset();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset <em>Offset</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset
+	 * <em>Offset</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Offset</em>' containment reference.
 	 * @see #getOffset()
 	 * @generated
@@ -92,28 +102,33 @@ public interface AnnotationGraphics extends Graphics {
 	void setOffset(Offset value);
 
 	/**
-	 * Returns the value of the '<em><b>Fill</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Fill</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Fill</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Fill</em>' containment reference.
 	 * @see #setFill(Fill)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics_Fill()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics
-	 * @model opposite="containerAnnotationGraphics" containment="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerAnnotationGraphics" containment="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Fill getFill();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill <em>Fill</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill
+	 * <em>Fill</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Fill</em>' containment reference.
 	 * @see #getFill()
 	 * @generated
@@ -121,28 +136,33 @@ public interface AnnotationGraphics extends Graphics {
 	void setFill(Fill value);
 
 	/**
-	 * Returns the value of the '<em><b>Line</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Line</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Line</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Line</em>' containment reference.
 	 * @see #setLine(Line)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics_Line()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics
-	 * @model opposite="containerAnnotationGraphics" containment="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerAnnotationGraphics" containment="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Line getLine();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine <em>Line</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine
+	 * <em>Line</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Line</em>' containment reference.
 	 * @see #getLine()
 	 * @generated
@@ -150,28 +170,33 @@ public interface AnnotationGraphics extends Graphics {
 	void setLine(Line value);
 
 	/**
-	 * Returns the value of the '<em><b>Font</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Font</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Font</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Font</em>' containment reference.
 	 * @see #setFont(Font)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics_Font()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics
-	 * @model opposite="containerAnnotationGraphics" containment="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerAnnotationGraphics" containment="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Font getFont();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont <em>Font</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont
+	 * <em>Font</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Font</em>' containment reference.
 	 * @see #getFont()
 	 * @generated
@@ -179,14 +204,16 @@ public interface AnnotationGraphics extends Graphics {
 	void setFont(Font value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Annotation</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics <em>Annotationgraphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Annotation</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics
+	 * <em>Annotationgraphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Annotation</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Annotation</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Annotation</em>' container reference.
 	 * @see #setContainerAnnotation(Annotation)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnnotationGraphics_ContainerAnnotation()
@@ -197,10 +224,13 @@ public interface AnnotationGraphics extends Graphics {
 	Annotation getContainerAnnotation();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation <em>Container Annotation</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation
+	 * <em>Container Annotation</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Annotation</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Annotation</em>' container
+	 *              reference.
 	 * @see #getContainerAnnotation()
 	 * @generated
 	 */
@@ -216,8 +246,8 @@ public interface AnnotationGraphics extends Graphics {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnyObject.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnyObject.java
@@ -43,14 +43,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Any Object</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Any
+ * Object</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo <em>Container Tool Info</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo
+ * <em>Container Tool Info</em>}</li>
  * </ul>
  * </p>
  *
@@ -60,14 +60,16 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface AnyObject extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Container Tool Info</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel <em>Tool Info Model</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Tool Info</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel
+	 * <em>Tool Info Model</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Tool Info</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Tool Info</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Tool Info</em>' container reference.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnyObject_ContainerToolInfo()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel
@@ -78,8 +80,8 @@ public interface AnyObject extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnyObject.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/AnyObject.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAnyObject()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface AnyObject extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Arc.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Arc.java
@@ -42,50 +42,64 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Arc</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Arc</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource <em>Source</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget <em>Target</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics <em>Arcgraphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription <em>Hlinscription</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource
+ * <em>Source</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget
+ * <em>Target</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics
+ * <em>Arcgraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription
+ * <em>Hlinscription</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArc()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='arc' kind='son'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='samePageSourceTarget differentSourceTarget'"
- *        annotation="http://www.pnml.org/models/OCL samePageSourceTarget='self.source.containerPage = self.target.containerPage' differentSourceTarget='(self.source.oclIsKindOf(PlaceNode) and self.target.oclIsKindOf(TransitionNode)) or (self.source.oclIsKindOf(TransitionNode) and self.target.oclIsKindOf(PlaceNode))'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='samePageSourceTarget differentSourceTarget'"
+ *        annotation="http://www.pnml.org/models/OCL
+ *        samePageSourceTarget='self.source.containerPage =
+ *        self.target.containerPage'
+ *        differentSourceTarget='(self.source.oclIsKindOf(PlaceNode) and
+ *        self.target.oclIsKindOf(TransitionNode)) or
+ *        (self.source.oclIsKindOf(TransitionNode) and
+ *        self.target.oclIsKindOf(PlaceNode))'"
  * @generated
  */
 public interface Arc extends PnObject {
 	/**
-	 * Returns the value of the '<em><b>Source</b></em>' reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs <em>Out Arcs</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Source</b></em>' reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs <em>Out
+	 * Arcs</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Source</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Source</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Source</em>' reference.
 	 * @see #setSource(Node)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArc_Source()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs
 	 * @model opposite="OutArcs" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='idref' tag='source'"
+	 *        annotation="http://www.pnml.org/models/ToPNML kind='idref'
+	 *        tag='source'"
 	 * @generated
 	 */
 	Node getSource();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource <em>Source</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource
+	 * <em>Source</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Source</em>' reference.
 	 * @see #getSource()
 	 * @generated
@@ -93,28 +107,32 @@ public interface Arc extends PnObject {
 	void setSource(Node value);
 
 	/**
-	 * Returns the value of the '<em><b>Target</b></em>' reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs <em>In Arcs</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Target</b></em>' reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs <em>In
+	 * Arcs</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Target</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Target</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Target</em>' reference.
 	 * @see #setTarget(Node)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArc_Target()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs
 	 * @model opposite="InArcs" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='idref' tag='target'"
+	 *        annotation="http://www.pnml.org/models/ToPNML kind='idref'
+	 *        tag='target'"
 	 * @generated
 	 */
 	Node getTarget();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget <em>Target</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget
+	 * <em>Target</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Target</em>' reference.
 	 * @see #getTarget()
 	 * @generated
@@ -123,13 +141,15 @@ public interface Arc extends PnObject {
 
 	/**
 	 * Returns the value of the '<em><b>Arcgraphics</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc <em>Container Arc</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc
+	 * <em>Container Arc</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Arcgraphics</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Arcgraphics</em>' containment reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Arcgraphics</em>' containment reference.
 	 * @see #setArcgraphics(ArcGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArc_Arcgraphics()
@@ -141,24 +161,29 @@ public interface Arc extends PnObject {
 	ArcGraphics getArcgraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics <em>Arcgraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Arcgraphics</em>' containment reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics
+	 * <em>Arcgraphics</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Arcgraphics</em>' containment
+	 *              reference.
 	 * @see #getArcgraphics()
 	 * @generated
 	 */
 	void setArcgraphics(ArcGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Hlinscription</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc <em>Container Arc</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Hlinscription</b></em>' containment
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc
+	 * <em>Container Arc</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Hlinscription</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Hlinscription</em>' containment reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Hlinscription</em>' containment reference.
 	 * @see #setHlinscription(HLAnnotation)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArc_Hlinscription()
@@ -170,10 +195,13 @@ public interface Arc extends PnObject {
 	HLAnnotation getHlinscription();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription <em>Hlinscription</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Hlinscription</em>' containment reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription
+	 * <em>Hlinscription</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Hlinscription</em>' containment
+	 *              reference.
 	 * @see #getHlinscription()
 	 * @generated
 	 */
@@ -189,8 +217,8 @@ public interface Arc extends PnObject {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Arc.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Arc.java
@@ -60,7 +60,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArc()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='arc' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='arc' kind='son'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='samePageSourceTarget differentSourceTarget'"
  *        annotation="http://www.pnml.org/models/OCL

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ArcGraphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ArcGraphics.java
@@ -59,7 +59,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArcGraphics()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics'
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='graphics'
  *        kind='son'"
  * @generated
  */

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ArcGraphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ArcGraphics.java
@@ -43,34 +43,40 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Arc Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Arc
+ * Graphics</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions <em>Positions</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine <em>Line</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc <em>Container Arc</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions
+ * <em>Positions</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine
+ * <em>Line</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc
+ * <em>Container Arc</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArcGraphics()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics'
+ *        kind='son'"
  * @generated
  */
 public interface ArcGraphics extends Graphics {
 	/**
-	 * Returns the value of the '<em><b>Positions</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics <em>Container Arc Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Positions</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics
+	 * <em>Container Arc Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Positions</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Positions</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Positions</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArcGraphics_Positions()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics
@@ -81,14 +87,16 @@ public interface ArcGraphics extends Graphics {
 	List<Position> getPositions();
 
 	/**
-	 * Returns the value of the '<em><b>Line</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics <em>Container Arc Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Line</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics
+	 * <em>Container Arc Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Line</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Line</em>' containment reference.
 	 * @see #setLine(Line)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArcGraphics_Line()
@@ -100,9 +108,11 @@ public interface ArcGraphics extends Graphics {
 	Line getLine();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine <em>Line</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine
+	 * <em>Line</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Line</em>' containment reference.
 	 * @see #getLine()
 	 * @generated
@@ -111,13 +121,15 @@ public interface ArcGraphics extends Graphics {
 
 	/**
 	 * Returns the value of the '<em><b>Container Arc</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics <em>Arcgraphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics
+	 * <em>Arcgraphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Arc</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Arc</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Arc</em>' container reference.
 	 * @see #setContainerArc(Arc)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getArcGraphics_ContainerArc()
@@ -128,10 +140,13 @@ public interface ArcGraphics extends Graphics {
 	Arc getContainerArc();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc <em>Container Arc</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Arc</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc
+	 * <em>Container Arc</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Arc</em>' container
+	 *              reference.
 	 * @see #getContainerArc()
 	 * @generated
 	 */
@@ -147,8 +162,8 @@ public interface ArcGraphics extends Graphics {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Attribute.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Attribute.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Attribute</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Attribute</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getAttribute()
@@ -57,8 +56,8 @@ public interface Attribute extends Label {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2Color.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2Color.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2Color()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum CSS2Color implements Enumerator {
@@ -605,6 +605,7 @@ public enum CSS2Color implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -614,6 +615,7 @@ public enum CSS2Color implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -623,6 +625,7 @@ public enum CSS2Color implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2Color.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2Color.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>CSS2 Color</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>CSS2 Color</b></em>', and utility methods for working with them. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2Color()
  * @model
  * @generated
  */
 public enum CSS2Color implements Enumerator {
 	/**
-	 * The '<em><b>AQUA</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>AQUA</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #AQUA_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum CSS2Color implements Enumerator {
 	AQUA(0, "AQUA", "AQUA"),
 
 	/**
-	 * The '<em><b>BLACK</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>BLACK</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #BLACK_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum CSS2Color implements Enumerator {
 	BLACK(1, "BLACK", "BLACK"),
 
 	/**
-	 * The '<em><b>BLUE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>BLUE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #BLUE_VALUE
 	 * @generated
 	 * @ordered
@@ -78,9 +78,9 @@ public enum CSS2Color implements Enumerator {
 	BLUE(2, "BLUE", "BLUE"),
 
 	/**
-	 * The '<em><b>FUCHSIA</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>FUCHSIA</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #FUCHSIA_VALUE
 	 * @generated
 	 * @ordered
@@ -88,9 +88,9 @@ public enum CSS2Color implements Enumerator {
 	FUCHSIA(3, "FUCHSIA", "FUCHSIA"),
 
 	/**
-	 * The '<em><b>GRAY</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>GRAY</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #GRAY_VALUE
 	 * @generated
 	 * @ordered
@@ -98,9 +98,9 @@ public enum CSS2Color implements Enumerator {
 	GRAY(4, "GRAY", "GRAY"),
 
 	/**
-	 * The '<em><b>GREEN</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>GREEN</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #GREEN_VALUE
 	 * @generated
 	 * @ordered
@@ -108,9 +108,9 @@ public enum CSS2Color implements Enumerator {
 	GREEN(5, "GREEN", "GREEN"),
 
 	/**
-	 * The '<em><b>LIME</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>LIME</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #LIME_VALUE
 	 * @generated
 	 * @ordered
@@ -118,9 +118,9 @@ public enum CSS2Color implements Enumerator {
 	LIME(6, "LIME", "LIME"),
 
 	/**
-	 * The '<em><b>MAROON</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>MAROON</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #MAROON_VALUE
 	 * @generated
 	 * @ordered
@@ -128,9 +128,9 @@ public enum CSS2Color implements Enumerator {
 	MAROON(7, "MAROON", "MAROON"),
 
 	/**
-	 * The '<em><b>NAVY</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>NAVY</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #NAVY_VALUE
 	 * @generated
 	 * @ordered
@@ -138,9 +138,9 @@ public enum CSS2Color implements Enumerator {
 	NAVY(8, "NAVY", "NAVY"),
 
 	/**
-	 * The '<em><b>OLIVE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>OLIVE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #OLIVE_VALUE
 	 * @generated
 	 * @ordered
@@ -148,9 +148,9 @@ public enum CSS2Color implements Enumerator {
 	OLIVE(9, "OLIVE", "OLIVE"),
 
 	/**
-	 * The '<em><b>ORANGE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>ORANGE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #ORANGE_VALUE
 	 * @generated
 	 * @ordered
@@ -158,9 +158,9 @@ public enum CSS2Color implements Enumerator {
 	ORANGE(10, "ORANGE", "ORANGE"),
 
 	/**
-	 * The '<em><b>PURPLE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>PURPLE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #PURPLE_VALUE
 	 * @generated
 	 * @ordered
@@ -168,9 +168,9 @@ public enum CSS2Color implements Enumerator {
 	PURPLE(11, "PURPLE", "PURPLE"),
 
 	/**
-	 * The '<em><b>RED</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>RED</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #RED_VALUE
 	 * @generated
 	 * @ordered
@@ -178,9 +178,9 @@ public enum CSS2Color implements Enumerator {
 	RED(12, "RED", "RED"),
 
 	/**
-	 * The '<em><b>SILVER</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>SILVER</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #SILVER_VALUE
 	 * @generated
 	 * @ordered
@@ -188,9 +188,9 @@ public enum CSS2Color implements Enumerator {
 	SILVER(13, "SILVER", "SILVER"),
 
 	/**
-	 * The '<em><b>TEAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>TEAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #TEAL_VALUE
 	 * @generated
 	 * @ordered
@@ -198,9 +198,9 @@ public enum CSS2Color implements Enumerator {
 	TEAL(14, "TEAL", "TEAL"),
 
 	/**
-	 * The '<em><b>WHITE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>WHITE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #WHITE_VALUE
 	 * @generated
 	 * @ordered
@@ -208,9 +208,9 @@ public enum CSS2Color implements Enumerator {
 	WHITE(15, "WHITE", "WHITE"),
 
 	/**
-	 * The '<em><b>YELLOW</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>YELLOW</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #YELLOW_VALUE
 	 * @generated
 	 * @ordered
@@ -218,13 +218,13 @@ public enum CSS2Color implements Enumerator {
 	YELLOW(16, "YELLOW", "YELLOW");
 
 	/**
-	 * The '<em><b>AQUA</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>AQUA</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>AQUA</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>AQUA</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #AQUA
 	 * @model
 	 * @generated
@@ -233,13 +233,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int AQUA_VALUE = 0;
 
 	/**
-	 * The '<em><b>BLACK</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>BLACK</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>BLACK</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>BLACK</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #BLACK
 	 * @model
 	 * @generated
@@ -248,13 +248,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int BLACK_VALUE = 1;
 
 	/**
-	 * The '<em><b>BLUE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>BLUE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>BLUE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>BLUE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #BLUE
 	 * @model
 	 * @generated
@@ -263,13 +263,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int BLUE_VALUE = 2;
 
 	/**
-	 * The '<em><b>FUCHSIA</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>FUCHSIA</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>FUCHSIA</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>FUCHSIA</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #FUCHSIA
 	 * @model
 	 * @generated
@@ -278,13 +278,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int FUCHSIA_VALUE = 3;
 
 	/**
-	 * The '<em><b>GRAY</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>GRAY</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>GRAY</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>GRAY</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #GRAY
 	 * @model
 	 * @generated
@@ -293,13 +293,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int GRAY_VALUE = 4;
 
 	/**
-	 * The '<em><b>GREEN</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>GREEN</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>GREEN</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>GREEN</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #GREEN
 	 * @model
 	 * @generated
@@ -308,13 +308,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int GREEN_VALUE = 5;
 
 	/**
-	 * The '<em><b>LIME</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LIME</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>LIME</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>LIME</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LIME
 	 * @model
 	 * @generated
@@ -323,13 +323,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int LIME_VALUE = 6;
 
 	/**
-	 * The '<em><b>MAROON</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>MAROON</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>MAROON</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>MAROON</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #MAROON
 	 * @model
 	 * @generated
@@ -338,13 +338,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int MAROON_VALUE = 7;
 
 	/**
-	 * The '<em><b>NAVY</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>NAVY</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>NAVY</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>NAVY</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #NAVY
 	 * @model
 	 * @generated
@@ -353,13 +353,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int NAVY_VALUE = 8;
 
 	/**
-	 * The '<em><b>OLIVE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>OLIVE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>OLIVE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>OLIVE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #OLIVE
 	 * @model
 	 * @generated
@@ -368,13 +368,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int OLIVE_VALUE = 9;
 
 	/**
-	 * The '<em><b>ORANGE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>ORANGE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>ORANGE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>ORANGE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #ORANGE
 	 * @model
 	 * @generated
@@ -383,13 +383,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int ORANGE_VALUE = 10;
 
 	/**
-	 * The '<em><b>PURPLE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>PURPLE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>PURPLE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>PURPLE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #PURPLE
 	 * @model
 	 * @generated
@@ -398,13 +398,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int PURPLE_VALUE = 11;
 
 	/**
-	 * The '<em><b>RED</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>RED</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>RED</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>RED</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #RED
 	 * @model
 	 * @generated
@@ -413,13 +413,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int RED_VALUE = 12;
 
 	/**
-	 * The '<em><b>SILVER</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>SILVER</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>SILVER</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>SILVER</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #SILVER
 	 * @model
 	 * @generated
@@ -428,13 +428,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int SILVER_VALUE = 13;
 
 	/**
-	 * The '<em><b>TEAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>TEAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>TEAL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>TEAL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #TEAL
 	 * @model
 	 * @generated
@@ -443,13 +443,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int TEAL_VALUE = 14;
 
 	/**
-	 * The '<em><b>WHITE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>WHITE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>WHITE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>WHITE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #WHITE
 	 * @model
 	 * @generated
@@ -458,13 +458,13 @@ public enum CSS2Color implements Enumerator {
 	public static final int WHITE_VALUE = 15;
 
 	/**
-	 * The '<em><b>YELLOW</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>YELLOW</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>YELLOW</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>YELLOW</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #YELLOW
 	 * @model
 	 * @generated
@@ -473,9 +473,9 @@ public enum CSS2Color implements Enumerator {
 	public static final int YELLOW_VALUE = 16;
 
 	/**
-	 * An array of all the '<em><b>CSS2 Color</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>CSS2 Color</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final CSS2Color[] VALUES_ARRAY = new CSS2Color[] { AQUA, BLACK, BLUE, FUCHSIA, GRAY, GREEN, LIME,
@@ -483,16 +483,16 @@ public enum CSS2Color implements Enumerator {
 
 	/**
 	 * A public read-only list of all the '<em><b>CSS2 Color</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<CSS2Color> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>CSS2 Color</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Color</b></em>' literal with the specified literal
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2Color get(String literal) {
@@ -507,8 +507,8 @@ public enum CSS2Color implements Enumerator {
 
 	/**
 	 * Returns the '<em><b>CSS2 Color</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2Color getByName(String name) {
@@ -522,9 +522,9 @@ public enum CSS2Color implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Color</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Color</b></em>' literal with the specified integer
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2Color get(int value) {
@@ -568,30 +568,30 @@ public enum CSS2Color implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private CSS2Color(int value, String name, String literal) {
@@ -601,8 +601,8 @@ public enum CSS2Color implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -610,8 +610,8 @@ public enum CSS2Color implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -619,8 +619,8 @@ public enum CSS2Color implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -628,9 +628,9 @@ public enum CSS2Color implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -638,4 +638,4 @@ public enum CSS2Color implements Enumerator {
 		return literal;
 	}
 
-} //CSS2Color
+} // CSS2Color

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontFamily.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontFamily.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>CSS2 Font Family</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>CSS2 Font Family</b></em>', and utility methods for working with
+ * them. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontFamily()
  * @model
  * @generated
  */
 public enum CSS2FontFamily implements Enumerator {
 	/**
-	 * The '<em><b>VERDANA</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>VERDANA</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #VERDANA_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum CSS2FontFamily implements Enumerator {
 	VERDANA(0, "VERDANA", "VERDANA"),
 
 	/**
-	 * The '<em><b>ARIAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>ARIAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #ARIAL_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum CSS2FontFamily implements Enumerator {
 	ARIAL(1, "ARIAL", "ARIAL"),
 
 	/**
-	 * The '<em><b>TIMES</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>TIMES</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #TIMES_VALUE
 	 * @generated
 	 * @ordered
@@ -78,9 +78,9 @@ public enum CSS2FontFamily implements Enumerator {
 	TIMES(2, "TIMES", "TIMES"),
 
 	/**
-	 * The '<em><b>GEORGIA</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>GEORGIA</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #GEORGIA_VALUE
 	 * @generated
 	 * @ordered
@@ -88,9 +88,9 @@ public enum CSS2FontFamily implements Enumerator {
 	GEORGIA(3, "GEORGIA", "GEORGIA"),
 
 	/**
-	 * The '<em><b>TREBUCHET</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>TREBUCHET</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #TREBUCHET_VALUE
 	 * @generated
 	 * @ordered
@@ -98,13 +98,13 @@ public enum CSS2FontFamily implements Enumerator {
 	TREBUCHET(4, "TREBUCHET", "TREBUCHET");
 
 	/**
-	 * The '<em><b>VERDANA</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>VERDANA</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>VERDANA</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>VERDANA</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #VERDANA
 	 * @model
 	 * @generated
@@ -113,13 +113,13 @@ public enum CSS2FontFamily implements Enumerator {
 	public static final int VERDANA_VALUE = 0;
 
 	/**
-	 * The '<em><b>ARIAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>ARIAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>ARIAL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>ARIAL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #ARIAL
 	 * @model
 	 * @generated
@@ -128,13 +128,13 @@ public enum CSS2FontFamily implements Enumerator {
 	public static final int ARIAL_VALUE = 1;
 
 	/**
-	 * The '<em><b>TIMES</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>TIMES</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>TIMES</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>TIMES</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #TIMES
 	 * @model
 	 * @generated
@@ -143,13 +143,13 @@ public enum CSS2FontFamily implements Enumerator {
 	public static final int TIMES_VALUE = 2;
 
 	/**
-	 * The '<em><b>GEORGIA</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>GEORGIA</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>GEORGIA</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>GEORGIA</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #GEORGIA
 	 * @model
 	 * @generated
@@ -158,13 +158,13 @@ public enum CSS2FontFamily implements Enumerator {
 	public static final int GEORGIA_VALUE = 3;
 
 	/**
-	 * The '<em><b>TREBUCHET</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>TREBUCHET</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>TREBUCHET</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #TREBUCHET
 	 * @model
 	 * @generated
@@ -173,26 +173,26 @@ public enum CSS2FontFamily implements Enumerator {
 	public static final int TREBUCHET_VALUE = 4;
 
 	/**
-	 * An array of all the '<em><b>CSS2 Font Family</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>CSS2 Font Family</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final CSS2FontFamily[] VALUES_ARRAY = new CSS2FontFamily[] { VERDANA, ARIAL, TIMES, GEORGIA,
 			TREBUCHET, };
 
 	/**
-	 * A public read-only list of all the '<em><b>CSS2 Font Family</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A public read-only list of all the '<em><b>CSS2 Font Family</b></em>'
+	 * enumerators. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<CSS2FontFamily> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Family</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Family</b></em>' literal with the specified
+	 * literal value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontFamily get(String literal) {
@@ -206,9 +206,9 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Family</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Family</b></em>' literal with the specified
+	 * name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontFamily getByName(String name) {
@@ -222,9 +222,9 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Family</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Family</b></em>' literal with the specified
+	 * integer value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontFamily get(int value) {
@@ -244,30 +244,30 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private CSS2FontFamily(int value, String name, String literal) {
@@ -277,8 +277,8 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -286,8 +286,8 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -295,8 +295,8 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -304,9 +304,9 @@ public enum CSS2FontFamily implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -314,4 +314,4 @@ public enum CSS2FontFamily implements Enumerator {
 		return literal;
 	}
 
-} //CSS2FontFamily
+} // CSS2FontFamily

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontFamily.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontFamily.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * them. <!-- end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontFamily()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum CSS2FontFamily implements Enumerator {
@@ -281,6 +281,7 @@ public enum CSS2FontFamily implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -290,6 +291,7 @@ public enum CSS2FontFamily implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -299,6 +301,7 @@ public enum CSS2FontFamily implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontSize.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontSize.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>CSS2 Font Size</b></em>',
- * and utility methods for working with them.
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>CSS2 Font Size</b></em>', and utility methods for working with them.
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontSize()
  * @model
  * @generated
  */
 public enum CSS2FontSize implements Enumerator {
 	/**
-	 * The '<em><b>XXSMALL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>XXSMALL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #XXSMALL_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum CSS2FontSize implements Enumerator {
 	XXSMALL(0, "XXSMALL", "XXSMALL"),
 
 	/**
-	 * The '<em><b>XSMALL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>XSMALL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #XSMALL_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum CSS2FontSize implements Enumerator {
 	XSMALL(1, "XSMALL", "XSMALL"),
 
 	/**
-	 * The '<em><b>SMALL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>SMALL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #SMALL_VALUE
 	 * @generated
 	 * @ordered
@@ -78,9 +78,9 @@ public enum CSS2FontSize implements Enumerator {
 	SMALL(2, "SMALL", "SMALL"),
 
 	/**
-	 * The '<em><b>MEDIUM</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>MEDIUM</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #MEDIUM_VALUE
 	 * @generated
 	 * @ordered
@@ -88,9 +88,9 @@ public enum CSS2FontSize implements Enumerator {
 	MEDIUM(3, "MEDIUM", "MEDIUM"),
 
 	/**
-	 * The '<em><b>LARGE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>LARGE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #LARGE_VALUE
 	 * @generated
 	 * @ordered
@@ -98,9 +98,9 @@ public enum CSS2FontSize implements Enumerator {
 	LARGE(4, "LARGE", "LARGE"),
 
 	/**
-	 * The '<em><b>XLARGE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>XLARGE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #XLARGE_VALUE
 	 * @generated
 	 * @ordered
@@ -108,9 +108,9 @@ public enum CSS2FontSize implements Enumerator {
 	XLARGE(5, "XLARGE", "XLARGE"),
 
 	/**
-	 * The '<em><b>XXLARGE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>XXLARGE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #XXLARGE_VALUE
 	 * @generated
 	 * @ordered
@@ -118,13 +118,13 @@ public enum CSS2FontSize implements Enumerator {
 	XXLARGE(6, "XXLARGE", "XXLARGE");
 
 	/**
-	 * The '<em><b>XXSMALL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>XXSMALL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>XXSMALL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>XXSMALL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #XXSMALL
 	 * @model
 	 * @generated
@@ -133,13 +133,13 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int XXSMALL_VALUE = 0;
 
 	/**
-	 * The '<em><b>XSMALL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>XSMALL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>XSMALL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>XSMALL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #XSMALL
 	 * @model
 	 * @generated
@@ -148,13 +148,13 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int XSMALL_VALUE = 1;
 
 	/**
-	 * The '<em><b>SMALL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>SMALL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>SMALL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>SMALL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #SMALL
 	 * @model
 	 * @generated
@@ -163,13 +163,13 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int SMALL_VALUE = 2;
 
 	/**
-	 * The '<em><b>MEDIUM</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>MEDIUM</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>MEDIUM</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>MEDIUM</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #MEDIUM
 	 * @model
 	 * @generated
@@ -178,13 +178,13 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int MEDIUM_VALUE = 3;
 
 	/**
-	 * The '<em><b>LARGE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LARGE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>LARGE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>LARGE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LARGE
 	 * @model
 	 * @generated
@@ -193,13 +193,13 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int LARGE_VALUE = 4;
 
 	/**
-	 * The '<em><b>XLARGE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>XLARGE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>XLARGE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>XLARGE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #XLARGE
 	 * @model
 	 * @generated
@@ -208,13 +208,13 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int XLARGE_VALUE = 5;
 
 	/**
-	 * The '<em><b>XXLARGE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>XXLARGE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>XXLARGE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>XXLARGE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #XXLARGE
 	 * @model
 	 * @generated
@@ -223,26 +223,26 @@ public enum CSS2FontSize implements Enumerator {
 	public static final int XXLARGE_VALUE = 6;
 
 	/**
-	 * An array of all the '<em><b>CSS2 Font Size</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>CSS2 Font Size</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final CSS2FontSize[] VALUES_ARRAY = new CSS2FontSize[] { XXSMALL, XSMALL, SMALL, MEDIUM, LARGE,
 			XLARGE, XXLARGE, };
 
 	/**
-	 * A public read-only list of all the '<em><b>CSS2 Font Size</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A public read-only list of all the '<em><b>CSS2 Font Size</b></em>'
+	 * enumerators. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<CSS2FontSize> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Size</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Size</b></em>' literal with the specified
+	 * literal value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontSize get(String literal) {
@@ -257,8 +257,8 @@ public enum CSS2FontSize implements Enumerator {
 
 	/**
 	 * Returns the '<em><b>CSS2 Font Size</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontSize getByName(String name) {
@@ -272,9 +272,9 @@ public enum CSS2FontSize implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Size</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Size</b></em>' literal with the specified
+	 * integer value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontSize get(int value) {
@@ -298,30 +298,30 @@ public enum CSS2FontSize implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private CSS2FontSize(int value, String name, String literal) {
@@ -331,8 +331,8 @@ public enum CSS2FontSize implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -340,8 +340,8 @@ public enum CSS2FontSize implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -349,8 +349,8 @@ public enum CSS2FontSize implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -358,9 +358,9 @@ public enum CSS2FontSize implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -368,4 +368,4 @@ public enum CSS2FontSize implements Enumerator {
 		return literal;
 	}
 
-} //CSS2FontSize
+} // CSS2FontSize

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontSize.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontSize.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * <!-- end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontSize()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum CSS2FontSize implements Enumerator {
@@ -335,6 +335,7 @@ public enum CSS2FontSize implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -344,6 +345,7 @@ public enum CSS2FontSize implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -353,6 +355,7 @@ public enum CSS2FontSize implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontStyle.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontStyle.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * <!-- end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontStyle()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum CSS2FontStyle implements Enumerator {
@@ -226,6 +226,7 @@ public enum CSS2FontStyle implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -235,6 +236,7 @@ public enum CSS2FontStyle implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -244,6 +246,7 @@ public enum CSS2FontStyle implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontStyle.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontStyle.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>CSS2 Font Style</b></em>',
- * and utility methods for working with them.
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>CSS2 Font Style</b></em>', and utility methods for working with them.
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontStyle()
  * @model
  * @generated
  */
 public enum CSS2FontStyle implements Enumerator {
 	/**
-	 * The '<em><b>NORMAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>NORMAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #NORMAL_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum CSS2FontStyle implements Enumerator {
 	NORMAL(0, "NORMAL", "NORMAL"),
 
 	/**
-	 * The '<em><b>ITALIC</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>ITALIC</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #ITALIC_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum CSS2FontStyle implements Enumerator {
 	ITALIC(1, "ITALIC", "ITALIC"),
 
 	/**
-	 * The '<em><b>OBLIQUE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>OBLIQUE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #OBLIQUE_VALUE
 	 * @generated
 	 * @ordered
@@ -78,13 +78,13 @@ public enum CSS2FontStyle implements Enumerator {
 	OBLIQUE(2, "OBLIQUE", "OBLIQUE");
 
 	/**
-	 * The '<em><b>NORMAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>NORMAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>NORMAL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>NORMAL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #NORMAL
 	 * @model
 	 * @generated
@@ -93,13 +93,13 @@ public enum CSS2FontStyle implements Enumerator {
 	public static final int NORMAL_VALUE = 0;
 
 	/**
-	 * The '<em><b>ITALIC</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>ITALIC</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>ITALIC</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>ITALIC</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #ITALIC
 	 * @model
 	 * @generated
@@ -108,13 +108,13 @@ public enum CSS2FontStyle implements Enumerator {
 	public static final int ITALIC_VALUE = 1;
 
 	/**
-	 * The '<em><b>OBLIQUE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>OBLIQUE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>OBLIQUE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>OBLIQUE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #OBLIQUE
 	 * @model
 	 * @generated
@@ -123,25 +123,25 @@ public enum CSS2FontStyle implements Enumerator {
 	public static final int OBLIQUE_VALUE = 2;
 
 	/**
-	 * An array of all the '<em><b>CSS2 Font Style</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>CSS2 Font Style</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final CSS2FontStyle[] VALUES_ARRAY = new CSS2FontStyle[] { NORMAL, ITALIC, OBLIQUE, };
 
 	/**
-	 * A public read-only list of all the '<em><b>CSS2 Font Style</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A public read-only list of all the '<em><b>CSS2 Font Style</b></em>'
+	 * enumerators. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<CSS2FontStyle> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Style</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Style</b></em>' literal with the specified
+	 * literal value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontStyle get(String literal) {
@@ -155,9 +155,9 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Style</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Style</b></em>' literal with the specified
+	 * name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontStyle getByName(String name) {
@@ -171,9 +171,9 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Style</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Style</b></em>' literal with the specified
+	 * integer value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontStyle get(int value) {
@@ -189,30 +189,30 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private CSS2FontStyle(int value, String name, String literal) {
@@ -222,8 +222,8 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -231,8 +231,8 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -240,8 +240,8 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -249,9 +249,9 @@ public enum CSS2FontStyle implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,4 +259,4 @@ public enum CSS2FontStyle implements Enumerator {
 		return literal;
 	}
 
-} //CSS2FontStyle
+} // CSS2FontStyle

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontWeight.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontWeight.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>CSS2 Font Weight</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>CSS2 Font Weight</b></em>', and utility methods for working with
+ * them. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontWeight()
  * @model
  * @generated
  */
 public enum CSS2FontWeight implements Enumerator {
 	/**
-	 * The '<em><b>NORMAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>NORMAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #NORMAL_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum CSS2FontWeight implements Enumerator {
 	NORMAL(0, "NORMAL", "NORMAL"),
 
 	/**
-	 * The '<em><b>BOLD</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>BOLD</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #BOLD_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum CSS2FontWeight implements Enumerator {
 	BOLD(1, "BOLD", "BOLD"),
 
 	/**
-	 * The '<em><b>BOLDER</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>BOLDER</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #BOLDER_VALUE
 	 * @generated
 	 * @ordered
@@ -78,9 +78,9 @@ public enum CSS2FontWeight implements Enumerator {
 	BOLDER(2, "BOLDER", "BOLDER"),
 
 	/**
-	 * The '<em><b>LIGHTER</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>LIGHTER</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #LIGHTER_VALUE
 	 * @generated
 	 * @ordered
@@ -88,13 +88,13 @@ public enum CSS2FontWeight implements Enumerator {
 	LIGHTER(3, "LIGHTER", "LIGHTER");
 
 	/**
-	 * The '<em><b>NORMAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>NORMAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>NORMAL</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>NORMAL</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #NORMAL
 	 * @model
 	 * @generated
@@ -103,13 +103,13 @@ public enum CSS2FontWeight implements Enumerator {
 	public static final int NORMAL_VALUE = 0;
 
 	/**
-	 * The '<em><b>BOLD</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>BOLD</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>BOLD</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>BOLD</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #BOLD
 	 * @model
 	 * @generated
@@ -118,13 +118,13 @@ public enum CSS2FontWeight implements Enumerator {
 	public static final int BOLD_VALUE = 1;
 
 	/**
-	 * The '<em><b>BOLDER</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>BOLDER</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>BOLDER</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>BOLDER</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #BOLDER
 	 * @model
 	 * @generated
@@ -133,13 +133,13 @@ public enum CSS2FontWeight implements Enumerator {
 	public static final int BOLDER_VALUE = 2;
 
 	/**
-	 * The '<em><b>LIGHTER</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LIGHTER</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>LIGHTER</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>LIGHTER</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LIGHTER
 	 * @model
 	 * @generated
@@ -148,25 +148,25 @@ public enum CSS2FontWeight implements Enumerator {
 	public static final int LIGHTER_VALUE = 3;
 
 	/**
-	 * An array of all the '<em><b>CSS2 Font Weight</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>CSS2 Font Weight</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final CSS2FontWeight[] VALUES_ARRAY = new CSS2FontWeight[] { NORMAL, BOLD, BOLDER, LIGHTER, };
 
 	/**
-	 * A public read-only list of all the '<em><b>CSS2 Font Weight</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A public read-only list of all the '<em><b>CSS2 Font Weight</b></em>'
+	 * enumerators. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<CSS2FontWeight> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Weight</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Weight</b></em>' literal with the specified
+	 * literal value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontWeight get(String literal) {
@@ -180,9 +180,9 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Weight</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Weight</b></em>' literal with the specified
+	 * name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontWeight getByName(String name) {
@@ -196,9 +196,9 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>CSS2 Font Weight</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>CSS2 Font Weight</b></em>' literal with the specified
+	 * integer value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static CSS2FontWeight get(int value) {
@@ -216,30 +216,30 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private CSS2FontWeight(int value, String name, String literal) {
@@ -249,8 +249,8 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -258,8 +258,8 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -267,8 +267,8 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -276,9 +276,9 @@ public enum CSS2FontWeight implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -286,4 +286,4 @@ public enum CSS2FontWeight implements Enumerator {
 		return literal;
 	}
 
-} //CSS2FontWeight
+} // CSS2FontWeight

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontWeight.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/CSS2FontWeight.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * them. <!-- end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCSS2FontWeight()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum CSS2FontWeight implements Enumerator {
@@ -253,6 +253,7 @@ public enum CSS2FontWeight implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -262,6 +263,7 @@ public enum CSS2FontWeight implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -271,6 +273,7 @@ public enum CSS2FontWeight implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Condition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Condition.java
@@ -43,46 +43,53 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Condition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Condition</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition <em>Container Transition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition
+ * <em>Container Transition</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCondition()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='condition' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='condition'
+ *        kind='son'"
  * @generated
  */
 public interface Condition extends HLCoreAnnotation {
 	/**
 	 * Returns the value of the '<em><b>Structure</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition <em>Container Condition</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition
+	 * <em>Container Condition</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Structure</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Structure</em>' containment reference.
 	 * @see #setStructure(Term)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCondition_Structure()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition
 	 * @model opposite="containerCondition" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	Term getStructure();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure
+	 * <em>Structure</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Structure</em>' containment reference.
 	 * @see #getStructure()
 	 * @generated
@@ -90,14 +97,16 @@ public interface Condition extends HLCoreAnnotation {
 	void setStructure(Term value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Transition</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition <em>Condition</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Transition</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition
+	 * <em>Condition</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Transition</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Transition</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Transition</em>' container reference.
 	 * @see #setContainerTransition(Transition)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCondition_ContainerTransition()
@@ -108,10 +117,13 @@ public interface Condition extends HLCoreAnnotation {
 	Transition getContainerTransition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition <em>Container Transition</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition
+	 * <em>Container Transition</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Transition</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Transition</em>' container
+	 *              reference.
 	 * @see #getContainerTransition()
 	 * @generated
 	 */
@@ -127,8 +139,8 @@ public interface Condition extends HLCoreAnnotation {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Condition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Condition.java
@@ -58,7 +58,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCondition()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='condition'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Condition extends HLCoreAnnotation {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Coordinate.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Coordinate.java
@@ -43,15 +43,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Coordinate</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Coordinate</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX <em>X</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY <em>Y</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX
+ * <em>X</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY
+ * <em>Y</em>}</li>
  * </ul>
  * </p>
  *
@@ -61,26 +62,29 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Coordinate extends EObject {
 	/**
-	 * Returns the value of the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>X</b></em>' attribute. <!-- begin-user-doc
+	 * -->
 	 * <p>
-	 * If the meaning of the '<em>X</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>X</em>' attribute isn't clear, there really should
+	 * be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>X</em>' attribute.
 	 * @see #setX(Integer)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCoordinate_X()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='x' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='x'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	Integer getX();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX <em>X</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX
+	 * <em>X</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>X</em>' attribute.
 	 * @see #getX()
 	 * @generated
@@ -88,26 +92,29 @@ public interface Coordinate extends EObject {
 	void setX(Integer value);
 
 	/**
-	 * Returns the value of the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc
+	 * -->
 	 * <p>
-	 * If the meaning of the '<em>Y</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Y</em>' attribute isn't clear, there really should
+	 * be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Y</em>' attribute.
 	 * @see #setY(Integer)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCoordinate_Y()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='y' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='y'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	Integer getY();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY <em>Y</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY
+	 * <em>Y</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Y</em>' attribute.
 	 * @see #getY()
 	 * @generated
@@ -116,8 +123,8 @@ public interface Coordinate extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Coordinate.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Coordinate.java
@@ -57,7 +57,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getCoordinate()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Coordinate extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Declaration.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Declaration.java
@@ -43,47 +43,55 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Declarations;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Declaration</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Declaration</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet <em>Container Declaration Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage <em>Container Declaration Page</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet
+ * <em>Container Declaration Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage
+ * <em>Container Declaration Page</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDeclaration()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='declaration' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='declaration'
+ *        kind='son'"
  * @generated
  */
 public interface Declaration extends HLCoreAnnotation {
 	/**
 	 * Returns the value of the '<em><b>Structure</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration <em>Container Declaration</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration
+	 * <em>Container Declaration</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Structure</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Structure</em>' containment reference.
 	 * @see #setStructure(Declarations)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDeclaration_Structure()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration
 	 * @model opposite="containerDeclaration" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	Declarations getStructure();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure
+	 * <em>Structure</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Structure</em>' containment reference.
 	 * @see #getStructure()
 	 * @generated
@@ -91,15 +99,18 @@ public interface Declaration extends HLCoreAnnotation {
 	void setStructure(Declarations value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Declaration Petri Net</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Declaration Petri Net</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Declaration Petri Net</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Declaration Petri Net</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Declaration Petri Net</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Declaration Petri Net</em>' container
+	 *         reference.
 	 * @see #setContainerDeclarationPetriNet(PetriNet)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDeclaration_ContainerDeclarationPetriNet()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration
@@ -109,25 +120,31 @@ public interface Declaration extends HLCoreAnnotation {
 	PetriNet getContainerDeclarationPetriNet();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet <em>Container Declaration Petri Net</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Declaration Petri Net</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet
+	 * <em>Container Declaration Petri Net</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Declaration Petri Net</em>'
+	 *              container reference.
 	 * @see #getContainerDeclarationPetriNet()
 	 * @generated
 	 */
 	void setContainerDeclarationPetriNet(PetriNet value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Declaration Page</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Declaration Page</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Declaration Page</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Declaration Page</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Declaration Page</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Declaration Page</em>' container
+	 *         reference.
 	 * @see #setContainerDeclarationPage(Page)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDeclaration_ContainerDeclarationPage()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration
@@ -137,10 +154,13 @@ public interface Declaration extends HLCoreAnnotation {
 	Page getContainerDeclarationPage();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage <em>Container Declaration Page</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Declaration Page</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage
+	 * <em>Container Declaration Page</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Declaration Page</em>'
+	 *              container reference.
 	 * @see #getContainerDeclarationPage()
 	 * @generated
 	 */
@@ -156,8 +176,8 @@ public interface Declaration extends HLCoreAnnotation {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Declaration.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Declaration.java
@@ -60,7 +60,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Declarations;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDeclaration()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='declaration'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Declaration extends HLCoreAnnotation {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Dimension.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Dimension.java
@@ -42,32 +42,36 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Dimension</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Dimension</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics <em>Container DNode Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics
+ * <em>Container DNode Graphics</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDimension()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='dimension' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='dimension'
+ *        kind='son'"
  * @generated
  */
 public interface Dimension extends Coordinate {
 	/**
-	 * Returns the value of the '<em><b>Container DNode Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension <em>Dimension</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container DNode Graphics</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension
+	 * <em>Dimension</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container DNode Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container DNode Graphics</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container DNode Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container DNode Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerDNodeGraphics(NodeGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDimension_ContainerDNodeGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension
@@ -77,10 +81,13 @@ public interface Dimension extends Coordinate {
 	NodeGraphics getContainerDNodeGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics <em>Container DNode Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container DNode Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics
+	 * <em>Container DNode Graphics</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container DNode Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerDNodeGraphics()
 	 * @generated
 	 */
@@ -96,8 +103,8 @@ public interface Dimension extends Coordinate {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Dimension.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Dimension.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getDimension()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='dimension'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Dimension extends Coordinate {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Fill.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Fill.java
@@ -66,7 +66,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='fill' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='fill' kind='son'"
  * @generated
  */
 public interface Fill extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Fill.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Fill.java
@@ -44,19 +44,24 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Fill</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Fill</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor <em>Color</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor <em>Gradientcolor</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation <em>Gradientrotation</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage <em>Image</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics <em>Container Node Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor
+ * <em>Color</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor
+ * <em>Gradientcolor</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation
+ * <em>Gradientrotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage
+ * <em>Image</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics
+ * <em>Container Node Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -66,29 +71,32 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Fill extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Color</b></em>' attribute.
-	 * The default value is <code>"BLACK"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Color</b></em>' attribute. The default value
+	 * is <code>"BLACK"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Color</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Color</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Color</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see #setColor(CSS2Color)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill_Color()
 	 * @model default="BLACK" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='color' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='color'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	CSS2Color getColor();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor <em>Color</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor
+	 * <em>Color</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Color</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see #getColor()
@@ -97,29 +105,33 @@ public interface Fill extends EObject {
 	void setColor(CSS2Color value);
 
 	/**
-	 * Returns the value of the '<em><b>Gradientcolor</b></em>' attribute.
-	 * The default value is <code>"BLACK"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Gradientcolor</b></em>' attribute. The
+	 * default value is <code>"BLACK"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Gradientcolor</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Gradientcolor</em>' attribute isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Gradientcolor</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see #setGradientcolor(CSS2Color)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill_Gradientcolor()
 	 * @model default="BLACK" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='gradient-color' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='gradient-color'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	CSS2Color getGradientcolor();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor <em>Gradientcolor</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor
+	 * <em>Gradientcolor</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @param value the new value of the '<em>Gradientcolor</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see #getGradientcolor()
@@ -128,28 +140,32 @@ public interface Fill extends EObject {
 	void setGradientcolor(CSS2Color value);
 
 	/**
-	 * Returns the value of the '<em><b>Gradientrotation</b></em>' attribute.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Gradientrotation</b></em>' attribute. The
+	 * literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient}. <!--
+	 * begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Gradientrotation</em>' attribute isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Gradientrotation</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
 	 * @see #setGradientrotation(Gradient)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill_Gradientrotation()
-	 * @model ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='gradient-rotation' kind='attribute'"
+	 * @model ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='gradient-rotation' kind='attribute'"
 	 * @generated
 	 */
 	Gradient getGradientrotation();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation <em>Gradientrotation</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation
+	 * <em>Gradientrotation</em>}' attribute. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Gradientrotation</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
 	 * @see #getGradientrotation()
@@ -158,26 +174,29 @@ public interface Fill extends EObject {
 	void setGradientrotation(Gradient value);
 
 	/**
-	 * Returns the value of the '<em><b>Image</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Image</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Image</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Image</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Image</em>' attribute.
 	 * @see #setImage(URI)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill_Image()
-	 * @model dataType="fr.lip6.move.pnml.pthlpng.hlcorestructure.URI" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='image' kind='attribute'"
+	 * @model dataType="fr.lip6.move.pnml.pthlpng.hlcorestructure.URI"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='image' kind='attribute'"
 	 * @generated
 	 */
 	URI getImage();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage <em>Image</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage
+	 * <em>Image</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Image</em>' attribute.
 	 * @see #getImage()
 	 * @generated
@@ -185,15 +204,18 @@ public interface Fill extends EObject {
 	void setImage(URI value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Node Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill <em>Fill</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Node Graphics</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill
+	 * <em>Fill</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Node Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Node Graphics</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Node Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Node Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerNodeGraphics(NodeGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill_ContainerNodeGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill
@@ -203,25 +225,31 @@ public interface Fill extends EObject {
 	NodeGraphics getContainerNodeGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics <em>Container Node Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Node Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics
+	 * <em>Container Node Graphics</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Node Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerNodeGraphics()
 	 * @generated
 	 */
 	void setContainerNodeGraphics(NodeGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill <em>Fill</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill
+	 * <em>Fill</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Annotation Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Annotation Graphics</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Annotation Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerAnnotationGraphics(AnnotationGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFill_ContainerAnnotationGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill
@@ -231,10 +259,13 @@ public interface Fill extends EObject {
 	AnnotationGraphics getContainerAnnotationGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Annotation Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerAnnotationGraphics()
 	 * @generated
 	 */
@@ -248,8 +279,8 @@ public interface Fill extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Font.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Font.java
@@ -44,21 +44,28 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Font</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Font</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign <em>Align</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration <em>Decoration</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily <em>Family</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation <em>Rotation</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize <em>Size</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle <em>Style</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight <em>Weight</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign
+ * <em>Align</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration
+ * <em>Decoration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily
+ * <em>Family</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation
+ * <em>Rotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize
+ * <em>Size</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle
+ * <em>Style</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight
+ * <em>Weight</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -68,29 +75,32 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Font extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Align</b></em>' attribute.
-	 * The default value is <code>"LEFT"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Align</b></em>' attribute. The default value
+	 * is <code>"LEFT"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Align</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Align</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Align</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign
 	 * @see #setAlign(FontAlign)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Align()
 	 * @model default="LEFT" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='align' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='align'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	FontAlign getAlign();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign <em>Align</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign
+	 * <em>Align</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Align</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign
 	 * @see #getAlign()
@@ -99,29 +109,33 @@ public interface Font extends EObject {
 	void setAlign(FontAlign value);
 
 	/**
-	 * Returns the value of the '<em><b>Decoration</b></em>' attribute.
-	 * The default value is <code>"UNDERLINE"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Decoration</b></em>' attribute. The default
+	 * value is <code>"UNDERLINE"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Decoration</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Decoration</em>' attribute isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Decoration</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration
 	 * @see #setDecoration(FontDecoration)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Decoration()
 	 * @model default="UNDERLINE" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='decoration' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='decoration'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	FontDecoration getDecoration();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration <em>Decoration</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration
+	 * <em>Decoration</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @param value the new value of the '<em>Decoration</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration
 	 * @see #getDecoration()
@@ -130,29 +144,32 @@ public interface Font extends EObject {
 	void setDecoration(FontDecoration value);
 
 	/**
-	 * Returns the value of the '<em><b>Family</b></em>' attribute.
-	 * The default value is <code>"VERDANA"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Family</b></em>' attribute. The default
+	 * value is <code>"VERDANA"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Family</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Family</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Family</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily
 	 * @see #setFamily(CSS2FontFamily)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Family()
 	 * @model default="VERDANA" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='family' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='family'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	CSS2FontFamily getFamily();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily <em>Family</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily
+	 * <em>Family</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Family</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily
 	 * @see #getFamily()
@@ -161,26 +178,28 @@ public interface Font extends EObject {
 	void setFamily(CSS2FontFamily value);
 
 	/**
-	 * Returns the value of the '<em><b>Rotation</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Rotation</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Rotation</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Rotation</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Rotation</em>' attribute.
 	 * @see #setRotation(BigDecimal)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Rotation()
-	 * @model ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='rotation' kind='attribute'"
+	 * @model ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='rotation' kind='attribute'"
 	 * @generated
 	 */
 	BigDecimal getRotation();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation <em>Rotation</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation
+	 * <em>Rotation</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Rotation</em>' attribute.
 	 * @see #getRotation()
 	 * @generated
@@ -188,29 +207,32 @@ public interface Font extends EObject {
 	void setRotation(BigDecimal value);
 
 	/**
-	 * Returns the value of the '<em><b>Size</b></em>' attribute.
-	 * The default value is <code>"SMALL"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Size</b></em>' attribute. The default value
+	 * is <code>"SMALL"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Size</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Size</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Size</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize
 	 * @see #setSize(CSS2FontSize)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Size()
 	 * @model default="SMALL" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='size' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='size'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	CSS2FontSize getSize();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize <em>Size</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize
+	 * <em>Size</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Size</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize
 	 * @see #getSize()
@@ -219,29 +241,32 @@ public interface Font extends EObject {
 	void setSize(CSS2FontSize value);
 
 	/**
-	 * Returns the value of the '<em><b>Style</b></em>' attribute.
-	 * The default value is <code>"NORMAL"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Style</b></em>' attribute. The default value
+	 * is <code>"NORMAL"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Style</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Style</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Style</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle
 	 * @see #setStyle(CSS2FontStyle)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Style()
 	 * @model default="NORMAL" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='style' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='style'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	CSS2FontStyle getStyle();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle <em>Style</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle
+	 * <em>Style</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Style</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle
 	 * @see #getStyle()
@@ -250,28 +275,31 @@ public interface Font extends EObject {
 	void setStyle(CSS2FontStyle value);
 
 	/**
-	 * Returns the value of the '<em><b>Weight</b></em>' attribute.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Weight</b></em>' attribute. The literals are
+	 * from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Weight</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Weight</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Weight</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight
 	 * @see #setWeight(CSS2FontWeight)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_Weight()
-	 * @model ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='weight' kind='attribute'"
+	 * @model ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='weight' kind='attribute'"
 	 * @generated
 	 */
 	CSS2FontWeight getWeight();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight <em>Weight</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight
+	 * <em>Weight</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Weight</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight
 	 * @see #getWeight()
@@ -280,15 +308,18 @@ public interface Font extends EObject {
 	void setWeight(CSS2FontWeight value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont <em>Font</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont
+	 * <em>Font</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Annotation Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Annotation Graphics</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Annotation Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerAnnotationGraphics(AnnotationGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont_ContainerAnnotationGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont
@@ -298,10 +329,13 @@ public interface Font extends EObject {
 	AnnotationGraphics getContainerAnnotationGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Annotation Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerAnnotationGraphics()
 	 * @generated
 	 */
@@ -315,8 +349,8 @@ public interface Font extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Font.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Font.java
@@ -70,7 +70,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFont()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='font' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='font' kind='son'"
  * @generated
  */
 public interface Font extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontAlign.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontAlign.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFontAlign()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum FontAlign implements Enumerator {
@@ -226,6 +226,7 @@ public enum FontAlign implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -235,6 +236,7 @@ public enum FontAlign implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -244,6 +246,7 @@ public enum FontAlign implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontAlign.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontAlign.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>Font Align</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>Font Align</b></em>', and utility methods for working with them. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFontAlign()
  * @model
  * @generated
  */
 public enum FontAlign implements Enumerator {
 	/**
-	 * The '<em><b>LEFT</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>LEFT</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #LEFT_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum FontAlign implements Enumerator {
 	LEFT(0, "LEFT", "LEFT"),
 
 	/**
-	 * The '<em><b>CENTER</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>CENTER</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #CENTER_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum FontAlign implements Enumerator {
 	CENTER(1, "CENTER", "CENTER"),
 
 	/**
-	 * The '<em><b>RIGHT</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>RIGHT</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #RIGHT_VALUE
 	 * @generated
 	 * @ordered
@@ -78,13 +78,13 @@ public enum FontAlign implements Enumerator {
 	RIGHT(2, "RIGHT", "RIGHT");
 
 	/**
-	 * The '<em><b>LEFT</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LEFT</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>LEFT</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>LEFT</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LEFT
 	 * @model
 	 * @generated
@@ -93,13 +93,13 @@ public enum FontAlign implements Enumerator {
 	public static final int LEFT_VALUE = 0;
 
 	/**
-	 * The '<em><b>CENTER</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>CENTER</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>CENTER</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>CENTER</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #CENTER
 	 * @model
 	 * @generated
@@ -108,13 +108,13 @@ public enum FontAlign implements Enumerator {
 	public static final int CENTER_VALUE = 1;
 
 	/**
-	 * The '<em><b>RIGHT</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>RIGHT</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>RIGHT</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>RIGHT</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #RIGHT
 	 * @model
 	 * @generated
@@ -123,25 +123,25 @@ public enum FontAlign implements Enumerator {
 	public static final int RIGHT_VALUE = 2;
 
 	/**
-	 * An array of all the '<em><b>Font Align</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>Font Align</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final FontAlign[] VALUES_ARRAY = new FontAlign[] { LEFT, CENTER, RIGHT, };
 
 	/**
 	 * A public read-only list of all the '<em><b>Font Align</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<FontAlign> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>Font Align</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Font Align</b></em>' literal with the specified literal
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static FontAlign get(String literal) {
@@ -156,8 +156,8 @@ public enum FontAlign implements Enumerator {
 
 	/**
 	 * Returns the '<em><b>Font Align</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static FontAlign getByName(String name) {
@@ -171,9 +171,9 @@ public enum FontAlign implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Font Align</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Font Align</b></em>' literal with the specified integer
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static FontAlign get(int value) {
@@ -189,30 +189,30 @@ public enum FontAlign implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private FontAlign(int value, String name, String literal) {
@@ -222,8 +222,8 @@ public enum FontAlign implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -231,8 +231,8 @@ public enum FontAlign implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -240,8 +240,8 @@ public enum FontAlign implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -249,9 +249,9 @@ public enum FontAlign implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,4 +259,4 @@ public enum FontAlign implements Enumerator {
 		return literal;
 	}
 
-} //FontAlign
+} // FontAlign

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontDecoration.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontDecoration.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>Font Decoration</b></em>',
- * and utility methods for working with them.
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>Font Decoration</b></em>', and utility methods for working with them.
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFontDecoration()
  * @model
  * @generated
  */
 public enum FontDecoration implements Enumerator {
 	/**
-	 * The '<em><b>UNDERLINE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>UNDERLINE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #UNDERLINE_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum FontDecoration implements Enumerator {
 	UNDERLINE(0, "UNDERLINE", "UNDERLINE"),
 
 	/**
-	 * The '<em><b>OVERLINE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>OVERLINE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #OVERLINE_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum FontDecoration implements Enumerator {
 	OVERLINE(1, "OVERLINE", "OVERLINE"),
 
 	/**
-	 * The '<em><b>LINETHROUGH</b></em>' literal object.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LINETHROUGH</b></em>' literal object. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LINETHROUGH_VALUE
 	 * @generated
 	 * @ordered
@@ -78,13 +78,13 @@ public enum FontDecoration implements Enumerator {
 	LINETHROUGH(2, "LINETHROUGH", "LINETHROUGH");
 
 	/**
-	 * The '<em><b>UNDERLINE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>UNDERLINE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>UNDERLINE</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #UNDERLINE
 	 * @model
 	 * @generated
@@ -93,13 +93,13 @@ public enum FontDecoration implements Enumerator {
 	public static final int UNDERLINE_VALUE = 0;
 
 	/**
-	 * The '<em><b>OVERLINE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>OVERLINE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>OVERLINE</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #OVERLINE
 	 * @model
 	 * @generated
@@ -108,13 +108,13 @@ public enum FontDecoration implements Enumerator {
 	public static final int OVERLINE_VALUE = 1;
 
 	/**
-	 * The '<em><b>LINETHROUGH</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LINETHROUGH</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>LINETHROUGH</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LINETHROUGH
 	 * @model
 	 * @generated
@@ -123,25 +123,25 @@ public enum FontDecoration implements Enumerator {
 	public static final int LINETHROUGH_VALUE = 2;
 
 	/**
-	 * An array of all the '<em><b>Font Decoration</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>Font Decoration</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final FontDecoration[] VALUES_ARRAY = new FontDecoration[] { UNDERLINE, OVERLINE, LINETHROUGH, };
 
 	/**
-	 * A public read-only list of all the '<em><b>Font Decoration</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A public read-only list of all the '<em><b>Font Decoration</b></em>'
+	 * enumerators. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<FontDecoration> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>Font Decoration</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Font Decoration</b></em>' literal with the specified
+	 * literal value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static FontDecoration get(String literal) {
@@ -155,9 +155,9 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Font Decoration</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Font Decoration</b></em>' literal with the specified
+	 * name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static FontDecoration getByName(String name) {
@@ -171,9 +171,9 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Font Decoration</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Font Decoration</b></em>' literal with the specified
+	 * integer value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static FontDecoration get(int value) {
@@ -189,30 +189,30 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private FontDecoration(int value, String name, String literal) {
@@ -222,8 +222,8 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -231,8 +231,8 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -240,8 +240,8 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -249,9 +249,9 @@ public enum FontDecoration implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,4 +259,4 @@ public enum FontDecoration implements Enumerator {
 		return literal;
 	}
 
-} //FontDecoration
+} // FontDecoration

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontDecoration.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/FontDecoration.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * <!-- end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getFontDecoration()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum FontDecoration implements Enumerator {
@@ -226,6 +226,7 @@ public enum FontDecoration implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -235,6 +236,7 @@ public enum FontDecoration implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -244,6 +246,7 @@ public enum FontDecoration implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Gradient.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Gradient.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getGradient()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum Gradient implements Enumerator {
@@ -226,6 +226,7 @@ public enum Gradient implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -235,6 +236,7 @@ public enum Gradient implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -244,6 +246,7 @@ public enum Gradient implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Gradient.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Gradient.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>Gradient</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>Gradient</b></em>', and utility methods for working with them. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getGradient()
  * @model
  * @generated
  */
 public enum Gradient implements Enumerator {
 	/**
-	 * The '<em><b>HORIZONTAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>HORIZONTAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #HORIZONTAL_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum Gradient implements Enumerator {
 	HORIZONTAL(0, "HORIZONTAL", "HORIZONTAL"),
 
 	/**
-	 * The '<em><b>VERTICAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>VERTICAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #VERTICAL_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum Gradient implements Enumerator {
 	VERTICAL(1, "VERTICAL", "VERTICAL"),
 
 	/**
-	 * The '<em><b>DIAGONAL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>DIAGONAL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #DIAGONAL_VALUE
 	 * @generated
 	 * @ordered
@@ -78,13 +78,13 @@ public enum Gradient implements Enumerator {
 	DIAGONAL(2, "DIAGONAL", "DIAGONAL");
 
 	/**
-	 * The '<em><b>HORIZONTAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>HORIZONTAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>HORIZONTAL</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #HORIZONTAL
 	 * @model
 	 * @generated
@@ -93,13 +93,13 @@ public enum Gradient implements Enumerator {
 	public static final int HORIZONTAL_VALUE = 0;
 
 	/**
-	 * The '<em><b>VERTICAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>VERTICAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>VERTICAL</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #VERTICAL
 	 * @model
 	 * @generated
@@ -108,13 +108,13 @@ public enum Gradient implements Enumerator {
 	public static final int VERTICAL_VALUE = 1;
 
 	/**
-	 * The '<em><b>DIAGONAL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>DIAGONAL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>DIAGONAL</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #DIAGONAL
 	 * @model
 	 * @generated
@@ -123,25 +123,25 @@ public enum Gradient implements Enumerator {
 	public static final int DIAGONAL_VALUE = 2;
 
 	/**
-	 * An array of all the '<em><b>Gradient</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>Gradient</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final Gradient[] VALUES_ARRAY = new Gradient[] { HORIZONTAL, VERTICAL, DIAGONAL, };
 
 	/**
 	 * A public read-only list of all the '<em><b>Gradient</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<Gradient> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>Gradient</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Gradient</b></em>' literal with the specified literal
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static Gradient get(String literal) {
@@ -155,9 +155,9 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Gradient</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Gradient</b></em>' literal with the specified name. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static Gradient getByName(String name) {
@@ -171,9 +171,9 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Gradient</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Gradient</b></em>' literal with the specified integer
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static Gradient get(int value) {
@@ -189,30 +189,30 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private Gradient(int value, String name, String literal) {
@@ -222,8 +222,8 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -231,8 +231,8 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -240,8 +240,8 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -249,9 +249,9 @@ public enum Gradient implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,4 +259,4 @@ public enum Gradient implements Enumerator {
 		return literal;
 	}
 
-} //Gradient
+} // Gradient

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Graphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Graphics.java
@@ -43,9 +43,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Graphics</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getGraphics()
@@ -56,8 +55,8 @@ public interface Graphics extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Graphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Graphics.java
@@ -48,7 +48,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getGraphics()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Graphics extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLAnnotation.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLAnnotation.java
@@ -43,46 +43,53 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>HL Annotation</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>HL
+ * Annotation</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc <em>Container Arc</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc
+ * <em>Container Arc</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLAnnotation()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='hlinscription' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='hlinscription'
+ *        kind='son'"
  * @generated
  */
 public interface HLAnnotation extends HLCoreAnnotation {
 	/**
 	 * Returns the value of the '<em><b>Structure</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation <em>Container HL Annotation</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation
+	 * <em>Container HL Annotation</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Structure</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Structure</em>' containment reference.
 	 * @see #setStructure(Term)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLAnnotation_Structure()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation
 	 * @model opposite="containerHLAnnotation" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	Term getStructure();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure
+	 * <em>Structure</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Structure</em>' containment reference.
 	 * @see #getStructure()
 	 * @generated
@@ -91,13 +98,15 @@ public interface HLAnnotation extends HLCoreAnnotation {
 
 	/**
 	 * Returns the value of the '<em><b>Container Arc</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription <em>Hlinscription</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription
+	 * <em>Hlinscription</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Arc</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Arc</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Arc</em>' container reference.
 	 * @see #setContainerArc(Arc)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLAnnotation_ContainerArc()
@@ -108,10 +117,13 @@ public interface HLAnnotation extends HLCoreAnnotation {
 	Arc getContainerArc();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc <em>Container Arc</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Arc</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc
+	 * <em>Container Arc</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Arc</em>' container
+	 *              reference.
 	 * @see #getContainerArc()
 	 * @generated
 	 */
@@ -127,8 +139,8 @@ public interface HLAnnotation extends HLCoreAnnotation {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLAnnotation.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLAnnotation.java
@@ -58,7 +58,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLAnnotation()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='hlinscription'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface HLAnnotation extends HLCoreAnnotation {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLCoreAnnotation.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLCoreAnnotation.java
@@ -42,14 +42,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>HL Core Annotation</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>HL Core
+ * Annotation</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText <em>Text</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText
+ * <em>Text</em>}</li>
  * </ul>
  * </p>
  *
@@ -59,13 +59,14 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface HLCoreAnnotation extends Annotation {
 	/**
-	 * Returns the value of the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Text</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Text</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Text</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Text</em>' attribute.
 	 * @see #setText(String)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLCoreAnnotation_Text()
@@ -75,9 +76,10 @@ public interface HLCoreAnnotation extends Annotation {
 	String getText();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText <em>Text</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText
+	 * <em>Text</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Text</em>' attribute.
 	 * @see #getText()
 	 * @generated
@@ -88,8 +90,8 @@ public interface HLCoreAnnotation extends Annotation {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLMarking.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLMarking.java
@@ -58,7 +58,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLMarking()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='hlinitialMarking'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface HLMarking extends HLCoreAnnotation {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLMarking.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HLMarking.java
@@ -43,46 +43,53 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>HL Marking</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>HL
+ * Marking</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace <em>Container Place</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace
+ * <em>Container Place</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLMarking()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='hlinitialMarking' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='hlinitialMarking'
+ *        kind='son'"
  * @generated
  */
 public interface HLMarking extends HLCoreAnnotation {
 	/**
 	 * Returns the value of the '<em><b>Structure</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking <em>Container HL Marking</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking
+	 * <em>Container HL Marking</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Structure</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Structure</em>' containment reference.
 	 * @see #setStructure(Term)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLMarking_Structure()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking
 	 * @model opposite="containerHLMarking" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	Term getStructure();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure
+	 * <em>Structure</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Structure</em>' containment reference.
 	 * @see #getStructure()
 	 * @generated
@@ -90,14 +97,16 @@ public interface HLMarking extends HLCoreAnnotation {
 	void setStructure(Term value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Place</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking <em>Hlinitial Marking</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Place</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking
+	 * <em>Hlinitial Marking</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Place</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Place</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Place</em>' container reference.
 	 * @see #setContainerPlace(Place)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getHLMarking_ContainerPlace()
@@ -108,10 +117,13 @@ public interface HLMarking extends HLCoreAnnotation {
 	Place getContainerPlace();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace <em>Container Place</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Place</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace
+	 * <em>Container Place</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Place</em>' container
+	 *              reference.
 	 * @see #getContainerPlace()
 	 * @generated
 	 */
@@ -127,8 +139,8 @@ public interface HLMarking extends HLCoreAnnotation {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HlcorestructureFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HlcorestructureFactory.java
@@ -34,245 +34,244 @@ package fr.lip6.move.pnml.pthlpng.hlcorestructure;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage
  * @generated
  */
 public interface HlcorestructureFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	HlcorestructureFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Petri Net Doc</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Petri Net Doc</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Petri Net Doc</em>'.
 	 * @generated
 	 */
 	PetriNetDoc createPetriNetDoc();
 
 	/**
-	 * Returns a new object of class '<em>Petri Net</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Petri Net</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Petri Net</em>'.
 	 * @generated
 	 */
 	PetriNet createPetriNet();
 
 	/**
-	 * Returns a new object of class '<em>Page</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Page</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Page</em>'.
 	 * @generated
 	 */
 	Page createPage();
 
 	/**
-	 * Returns a new object of class '<em>Name</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Name</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Name</em>'.
 	 * @generated
 	 */
 	Name createName();
 
 	/**
-	 * Returns a new object of class '<em>Tool Info</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Tool Info</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Tool Info</em>'.
 	 * @generated
 	 */
 	ToolInfo createToolInfo();
 
 	/**
-	 * Returns a new object of class '<em>Node Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Node Graphics</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Node Graphics</em>'.
 	 * @generated
 	 */
 	NodeGraphics createNodeGraphics();
 
 	/**
-	 * Returns a new object of class '<em>Position</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Position</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Position</em>'.
 	 * @generated
 	 */
 	Position createPosition();
 
 	/**
-	 * Returns a new object of class '<em>Offset</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Offset</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Offset</em>'.
 	 * @generated
 	 */
 	Offset createOffset();
 
 	/**
-	 * Returns a new object of class '<em>Dimension</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Dimension</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Dimension</em>'.
 	 * @generated
 	 */
 	Dimension createDimension();
 
 	/**
-	 * Returns a new object of class '<em>Annotation Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Annotation Graphics</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Annotation Graphics</em>'.
 	 * @generated
 	 */
 	AnnotationGraphics createAnnotationGraphics();
 
 	/**
-	 * Returns a new object of class '<em>Fill</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Fill</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Fill</em>'.
 	 * @generated
 	 */
 	Fill createFill();
 
 	/**
-	 * Returns a new object of class '<em>Line</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Line</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Line</em>'.
 	 * @generated
 	 */
 	Line createLine();
 
 	/**
-	 * Returns a new object of class '<em>Arc Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Arc Graphics</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Arc Graphics</em>'.
 	 * @generated
 	 */
 	ArcGraphics createArcGraphics();
 
 	/**
-	 * Returns a new object of class '<em>Arc</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Arc</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Arc</em>'.
 	 * @generated
 	 */
 	Arc createArc();
 
 	/**
-	 * Returns a new object of class '<em>Font</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Font</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Font</em>'.
 	 * @generated
 	 */
 	Font createFont();
 
 	/**
-	 * Returns a new object of class '<em>Place</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Place</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Place</em>'.
 	 * @generated
 	 */
 	Place createPlace();
 
 	/**
-	 * Returns a new object of class '<em>Ref Transition</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Ref Transition</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Ref Transition</em>'.
 	 * @generated
 	 */
 	RefTransition createRefTransition();
 
 	/**
-	 * Returns a new object of class '<em>Transition</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Transition</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Transition</em>'.
 	 * @generated
 	 */
 	Transition createTransition();
 
 	/**
-	 * Returns a new object of class '<em>Ref Place</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Ref Place</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Ref Place</em>'.
 	 * @generated
 	 */
 	RefPlace createRefPlace();
 
 	/**
-	 * Returns a new object of class '<em>Type</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Type</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Type</em>'.
 	 * @generated
 	 */
 	Type createType();
 
 	/**
-	 * Returns a new object of class '<em>HL Marking</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>HL Marking</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>HL Marking</em>'.
 	 * @generated
 	 */
 	HLMarking createHLMarking();
 
 	/**
-	 * Returns a new object of class '<em>Condition</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Condition</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Condition</em>'.
 	 * @generated
 	 */
 	Condition createCondition();
 
 	/**
-	 * Returns a new object of class '<em>HL Annotation</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>HL Annotation</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>HL Annotation</em>'.
 	 * @generated
 	 */
 	HLAnnotation createHLAnnotation();
 
 	/**
-	 * Returns a new object of class '<em>Declaration</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Declaration</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Declaration</em>'.
 	 * @generated
 	 */
 	Declaration createDeclaration();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	HlcorestructurePackage getHlcorestructurePackage();
 
-} //HlcorestructureFactory
+} // HlcorestructureFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HlcorestructurePackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/HlcorestructurePackage.java
@@ -39,57 +39,55 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructureFactory
  * @model kind="package"
  * @generated
  */
 public interface HlcorestructurePackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "hlcorestructure";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///pthlpng.hlcorestructure.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "hlcorestructure";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	HlcorestructurePackage eINSTANCE = fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl <em>Petri Net Doc</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl
+	 * <em>Petri Net Doc</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPetriNetDoc()
 	 * @generated
@@ -98,35 +96,36 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nets</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET_DOC__NETS = 0;
 
 	/**
-	 * The feature id for the '<em><b>Xmlns</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Xmlns</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET_DOC__XMLNS = 1;
 
 	/**
-	 * The number of structural features of the '<em>Petri Net Doc</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Petri Net Doc</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET_DOC_FEATURE_COUNT = 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl <em>Petri Net</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl <em>Petri
+	 * Net</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPetriNet()
 	 * @generated
@@ -134,18 +133,18 @@ public interface HlcorestructurePackage extends EPackage {
 	int PETRI_NET = 1;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET__ID = 0;
 
 	/**
-	 * The feature id for the '<em><b>Type</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Type</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -153,62 +152,63 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Pages</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET__PAGES = 2;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET__NAME = 3;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET__TOOLSPECIFICS = 4;
 
 	/**
-	 * The feature id for the '<em><b>Container Petri Net Doc</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Petri Net Doc</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET__CONTAINER_PETRI_NET_DOC = 5;
 
 	/**
-	 * The feature id for the '<em><b>Declaration</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Declaration</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET__DECLARATION = 6;
 
 	/**
-	 * The number of structural features of the '<em>Petri Net</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Petri Net</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PETRI_NET_FEATURE_COUNT = 7;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl <em>Pn Object</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl <em>Pn
+	 * Object</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPnObject()
 	 * @generated
@@ -216,27 +216,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int PN_OBJECT = 3;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PN_OBJECT__ID = 0;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PN_OBJECT__NAME = 1;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -244,26 +244,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PN_OBJECT__CONTAINER_PAGE = 3;
 
 	/**
-	 * The number of structural features of the '<em>Pn Object</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Pn Object</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PN_OBJECT_FEATURE_COUNT = 4;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl <em>Page</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl
+	 * <em>Page</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPage()
 	 * @generated
@@ -271,27 +272,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int PAGE = 2;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PAGE__ID = PN_OBJECT__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PAGE__NAME = PN_OBJECT__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -299,8 +300,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -308,17 +309,17 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Objects</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PAGE__OBJECTS = PN_OBJECT_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Petri Net</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Petri Net</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -326,35 +327,36 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PAGE__NODEGRAPHICS = PN_OBJECT_FEATURE_COUNT + 2;
 
 	/**
-	 * The feature id for the '<em><b>Declaration</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Declaration</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PAGE__DECLARATION = PN_OBJECT_FEATURE_COUNT + 3;
 
 	/**
-	 * The number of structural features of the '<em>Page</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Page</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PAGE_FEATURE_COUNT = PN_OBJECT_FEATURE_COUNT + 4;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl <em>Label</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl
+	 * <em>Label</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLabel()
 	 * @generated
@@ -362,27 +364,28 @@ public interface HlcorestructurePackage extends EPackage {
 	int LABEL = 6;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LABEL__TOOLSPECIFICS = 0;
 
 	/**
-	 * The number of structural features of the '<em>Label</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Label</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LABEL_FEATURE_COUNT = 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl <em>Annotation</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl
+	 * <em>Annotation</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAnnotation()
 	 * @generated
@@ -390,36 +393,37 @@ public interface HlcorestructurePackage extends EPackage {
 	int ANNOTATION = 27;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION__TOOLSPECIFICS = LABEL__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION__ANNOTATIONGRAPHICS = LABEL_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Annotation</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Annotation</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_FEATURE_COUNT = LABEL_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl <em>Name</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl
+	 * <em>Name</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getName_()
 	 * @generated
@@ -427,63 +431,64 @@ public interface HlcorestructurePackage extends EPackage {
 	int NAME = 4;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAME__TOOLSPECIFICS = ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAME__ANNOTATIONGRAPHICS = ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAME__TEXT = ANNOTATION_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Name Petri Net</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Name Petri Net</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAME__CONTAINER_NAME_PETRI_NET = ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The feature id for the '<em><b>Container Name Pn Object</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Name Pn Object</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAME__CONTAINER_NAME_PN_OBJECT = ANNOTATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The number of structural features of the '<em>Name</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Name</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAME_FEATURE_COUNT = ANNOTATION_FEATURE_COUNT + 3;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl <em>Tool Info</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl <em>Tool
+	 * Info</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getToolInfo()
 	 * @generated
@@ -491,27 +496,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int TOOL_INFO = 5;
 
 	/**
-	 * The feature id for the '<em><b>Tool</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Tool</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO__TOOL = 0;
 
 	/**
-	 * The feature id for the '<em><b>Version</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Version</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO__VERSION = 1;
 
 	/**
-	 * The feature id for the '<em><b>Formatted XML Buffer</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Formatted XML Buffer</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -519,26 +524,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Tool Info Grammar URI</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO__TOOL_INFO_GRAMMAR_URI = 3;
 
 	/**
-	 * The feature id for the '<em><b>Container Petri Net</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Petri Net</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO__CONTAINER_PETRI_NET = 4;
 
 	/**
-	 * The feature id for the '<em><b>Container Pn Object</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Pn Object</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -546,35 +551,36 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Label</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO__CONTAINER_LABEL = 6;
 
 	/**
-	 * The feature id for the '<em><b>Tool Info Model</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Tool Info Model</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO__TOOL_INFO_MODEL = 7;
 
 	/**
-	 * The number of structural features of the '<em>Tool Info</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Tool Info</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TOOL_INFO_FEATURE_COUNT = 8;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.GraphicsImpl <em>Graphics</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.GraphicsImpl
+	 * <em>Graphics</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.GraphicsImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getGraphics()
 	 * @generated
@@ -582,18 +588,19 @@ public interface HlcorestructurePackage extends EPackage {
 	int GRAPHICS = 8;
 
 	/**
-	 * The number of structural features of the '<em>Graphics</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Graphics</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GRAPHICS_FEATURE_COUNT = 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl <em>Node Graphics</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl
+	 * <em>Node Graphics</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getNodeGraphics()
 	 * @generated
@@ -601,9 +608,9 @@ public interface HlcorestructurePackage extends EPackage {
 	int NODE_GRAPHICS = 7;
 
 	/**
-	 * The feature id for the '<em><b>Position</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Position</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -611,26 +618,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Dimension</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE_GRAPHICS__DIMENSION = GRAPHICS_FEATURE_COUNT + 1;
 
 	/**
-	 * The feature id for the '<em><b>Fill</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Fill</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE_GRAPHICS__FILL = GRAPHICS_FEATURE_COUNT + 2;
 
 	/**
-	 * The feature id for the '<em><b>Line</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Line</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -638,8 +645,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Node</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -647,26 +654,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE_GRAPHICS__CONTAINER_PAGE = GRAPHICS_FEATURE_COUNT + 5;
 
 	/**
-	 * The number of structural features of the '<em>Node Graphics</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Node Graphics</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE_GRAPHICS_FEATURE_COUNT = GRAPHICS_FEATURE_COUNT + 6;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl <em>Coordinate</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl
+	 * <em>Coordinate</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCoordinate()
 	 * @generated
@@ -674,36 +682,37 @@ public interface HlcorestructurePackage extends EPackage {
 	int COORDINATE = 9;
 
 	/**
-	 * The feature id for the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>X</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int COORDINATE__X = 0;
 
 	/**
-	 * The feature id for the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int COORDINATE__Y = 1;
 
 	/**
-	 * The number of structural features of the '<em>Coordinate</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Coordinate</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int COORDINATE_FEATURE_COUNT = 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl <em>Position</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl
+	 * <em>Position</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPosition()
 	 * @generated
@@ -711,54 +720,55 @@ public interface HlcorestructurePackage extends EPackage {
 	int POSITION = 10;
 
 	/**
-	 * The feature id for the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>X</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITION__X = COORDINATE__X;
 
 	/**
-	 * The feature id for the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITION__Y = COORDINATE__Y;
 
 	/**
-	 * The feature id for the '<em><b>Container Arc Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Arc Graphics</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITION__CONTAINER_ARC_GRAPHICS = COORDINATE_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Container PNode Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container PNode Graphics</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITION__CONTAINER_PNODE_GRAPHICS = COORDINATE_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Position</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Position</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITION_FEATURE_COUNT = COORDINATE_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl <em>Offset</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl
+	 * <em>Offset</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getOffset()
 	 * @generated
@@ -766,45 +776,46 @@ public interface HlcorestructurePackage extends EPackage {
 	int OFFSET = 11;
 
 	/**
-	 * The feature id for the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>X</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OFFSET__X = COORDINATE__X;
 
 	/**
-	 * The feature id for the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OFFSET__Y = COORDINATE__Y;
 
 	/**
-	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OFFSET__CONTAINER_ANNOTATION_GRAPHICS = COORDINATE_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Offset</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Offset</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OFFSET_FEATURE_COUNT = COORDINATE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl <em>Dimension</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl
+	 * <em>Dimension</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getDimension()
 	 * @generated
@@ -812,45 +823,47 @@ public interface HlcorestructurePackage extends EPackage {
 	int DIMENSION = 12;
 
 	/**
-	 * The feature id for the '<em><b>X</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>X</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION__X = COORDINATE__X;
 
 	/**
-	 * The feature id for the '<em><b>Y</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * The feature id for the '<em><b>Y</b></em>' attribute. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION__Y = COORDINATE__Y;
 
 	/**
-	 * The feature id for the '<em><b>Container DNode Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container DNode Graphics</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION__CONTAINER_DNODE_GRAPHICS = COORDINATE_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Dimension</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Dimension</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIMENSION_FEATURE_COUNT = COORDINATE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl <em>Annotation Graphics</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl
+	 * <em>Annotation Graphics</em>}' class. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAnnotationGraphics()
 	 * @generated
@@ -858,63 +871,64 @@ public interface HlcorestructurePackage extends EPackage {
 	int ANNOTATION_GRAPHICS = 13;
 
 	/**
-	 * The feature id for the '<em><b>Offset</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Offset</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_GRAPHICS__OFFSET = GRAPHICS_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Fill</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Fill</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_GRAPHICS__FILL = GRAPHICS_FEATURE_COUNT + 1;
 
 	/**
-	 * The feature id for the '<em><b>Line</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Line</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_GRAPHICS__LINE = GRAPHICS_FEATURE_COUNT + 2;
 
 	/**
-	 * The feature id for the '<em><b>Font</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Font</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_GRAPHICS__FONT = GRAPHICS_FEATURE_COUNT + 3;
 
 	/**
-	 * The feature id for the '<em><b>Container Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_GRAPHICS__CONTAINER_ANNOTATION = GRAPHICS_FEATURE_COUNT + 4;
 
 	/**
-	 * The number of structural features of the '<em>Annotation Graphics</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Annotation Graphics</em>'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANNOTATION_GRAPHICS_FEATURE_COUNT = GRAPHICS_FEATURE_COUNT + 5;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl <em>Fill</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl
+	 * <em>Fill</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFill()
 	 * @generated
@@ -922,72 +936,73 @@ public interface HlcorestructurePackage extends EPackage {
 	int FILL = 14;
 
 	/**
-	 * The feature id for the '<em><b>Color</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Color</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL__COLOR = 0;
 
 	/**
-	 * The feature id for the '<em><b>Gradientcolor</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Gradientcolor</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL__GRADIENTCOLOR = 1;
 
 	/**
-	 * The feature id for the '<em><b>Gradientrotation</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Gradientrotation</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL__GRADIENTROTATION = 2;
 
 	/**
-	 * The feature id for the '<em><b>Image</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Image</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL__IMAGE = 3;
 
 	/**
-	 * The feature id for the '<em><b>Container Node Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Node Graphics</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL__CONTAINER_NODE_GRAPHICS = 4;
 
 	/**
-	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL__CONTAINER_ANNOTATION_GRAPHICS = 5;
 
 	/**
-	 * The number of structural features of the '<em>Fill</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Fill</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FILL_FEATURE_COUNT = 6;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl <em>Line</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl
+	 * <em>Line</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLine()
 	 * @generated
@@ -995,81 +1010,82 @@ public interface HlcorestructurePackage extends EPackage {
 	int LINE = 15;
 
 	/**
-	 * The feature id for the '<em><b>Color</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Color</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__COLOR = 0;
 
 	/**
-	 * The feature id for the '<em><b>Shape</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Shape</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__SHAPE = 1;
 
 	/**
-	 * The feature id for the '<em><b>Width</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Width</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__WIDTH = 2;
 
 	/**
-	 * The feature id for the '<em><b>Container Node Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Node Graphics</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__CONTAINER_NODE_GRAPHICS = 3;
 
 	/**
-	 * The feature id for the '<em><b>Container Arc Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Arc Graphics</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__CONTAINER_ARC_GRAPHICS = 4;
 
 	/**
-	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__CONTAINER_ANNOTATION_GRAPHICS = 5;
 
 	/**
-	 * The feature id for the '<em><b>Style</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Style</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE__STYLE = 6;
 
 	/**
-	 * The number of structural features of the '<em>Line</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Line</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LINE_FEATURE_COUNT = 7;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl <em>Arc Graphics</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl
+	 * <em>Arc Graphics</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getArcGraphics()
 	 * @generated
@@ -1077,18 +1093,18 @@ public interface HlcorestructurePackage extends EPackage {
 	int ARC_GRAPHICS = 16;
 
 	/**
-	 * The feature id for the '<em><b>Positions</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Positions</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC_GRAPHICS__POSITIONS = GRAPHICS_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Line</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Line</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1096,26 +1112,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Arc</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC_GRAPHICS__CONTAINER_ARC = GRAPHICS_FEATURE_COUNT + 2;
 
 	/**
-	 * The number of structural features of the '<em>Arc Graphics</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Arc Graphics</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC_GRAPHICS_FEATURE_COUNT = GRAPHICS_FEATURE_COUNT + 3;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl <em>Arc</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl <em>Arc</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getArc()
 	 * @generated
@@ -1123,27 +1140,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int ARC = 17;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC__ID = PN_OBJECT__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC__NAME = PN_OBJECT__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1151,26 +1168,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC__CONTAINER_PAGE = PN_OBJECT__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>Source</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Source</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC__SOURCE = PN_OBJECT_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Target</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Target</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1178,8 +1195,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Arcgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1187,26 +1204,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Hlinscription</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC__HLINSCRIPTION = PN_OBJECT_FEATURE_COUNT + 3;
 
 	/**
-	 * The number of structural features of the '<em>Arc</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Arc</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ARC_FEATURE_COUNT = PN_OBJECT_FEATURE_COUNT + 4;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl <em>Node</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl
+	 * <em>Node</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getNode()
 	 * @generated
@@ -1214,27 +1232,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int NODE = 18;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE__ID = PN_OBJECT__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE__NAME = PN_OBJECT__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1242,26 +1260,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE__CONTAINER_PAGE = PN_OBJECT__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE__IN_ARCS = PN_OBJECT_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1269,26 +1287,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE__NODEGRAPHICS = PN_OBJECT_FEATURE_COUNT + 2;
 
 	/**
-	 * The number of structural features of the '<em>Node</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Node</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NODE_FEATURE_COUNT = PN_OBJECT_FEATURE_COUNT + 3;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl <em>Font</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl
+	 * <em>Font</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFont()
 	 * @generated
@@ -1296,90 +1315,91 @@ public interface HlcorestructurePackage extends EPackage {
 	int FONT = 19;
 
 	/**
-	 * The feature id for the '<em><b>Align</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Align</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__ALIGN = 0;
 
 	/**
-	 * The feature id for the '<em><b>Decoration</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Decoration</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__DECORATION = 1;
 
 	/**
-	 * The feature id for the '<em><b>Family</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Family</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__FAMILY = 2;
 
 	/**
-	 * The feature id for the '<em><b>Rotation</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Rotation</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__ROTATION = 3;
 
 	/**
-	 * The feature id for the '<em><b>Size</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Size</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__SIZE = 4;
 
 	/**
-	 * The feature id for the '<em><b>Style</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Style</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__STYLE = 5;
 
 	/**
-	 * The feature id for the '<em><b>Weight</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Weight</b></em>' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__WEIGHT = 6;
 
 	/**
-	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT__CONTAINER_ANNOTATION_GRAPHICS = 7;
 
 	/**
-	 * The number of structural features of the '<em>Font</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Font</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int FONT_FEATURE_COUNT = 8;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl <em>Place Node</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl
+	 * <em>Place Node</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPlaceNode()
 	 * @generated
@@ -1387,27 +1407,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int PLACE_NODE = 20;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_NODE__ID = NODE__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_NODE__NAME = NODE__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1415,26 +1435,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_NODE__CONTAINER_PAGE = NODE__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_NODE__IN_ARCS = NODE__IN_ARCS;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1442,8 +1462,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1451,26 +1471,28 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Referencing Places</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_NODE__REFERENCING_PLACES = NODE_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Place Node</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Place Node</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_NODE_FEATURE_COUNT = NODE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl <em>Transition Node</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl
+	 * <em>Transition Node</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getTransitionNode()
 	 * @generated
@@ -1478,27 +1500,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int TRANSITION_NODE = 21;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_NODE__ID = NODE__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_NODE__NAME = NODE__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1506,26 +1528,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_NODE__CONTAINER_PAGE = NODE__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_NODE__IN_ARCS = NODE__IN_ARCS;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1533,17 +1555,17 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_NODE__NODEGRAPHICS = NODE__NODEGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Referencing Transitions</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Referencing Transitions</b></em>' reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1551,17 +1573,18 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Transition Node</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_NODE_FEATURE_COUNT = NODE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl <em>Place</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl
+	 * <em>Place</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPlace()
 	 * @generated
@@ -1569,27 +1592,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int PLACE = 22;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__ID = PLACE_NODE__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__NAME = PLACE_NODE__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1597,26 +1620,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__CONTAINER_PAGE = PLACE_NODE__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__IN_ARCS = PLACE_NODE__IN_ARCS;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1624,8 +1647,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1633,44 +1656,46 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Referencing Places</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__REFERENCING_PLACES = PLACE_NODE__REFERENCING_PLACES;
 
 	/**
-	 * The feature id for the '<em><b>Type</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Type</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__TYPE = PLACE_NODE_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Hlinitial Marking</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Hlinitial Marking</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE__HLINITIAL_MARKING = PLACE_NODE_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Place</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Place</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PLACE_FEATURE_COUNT = PLACE_NODE_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl <em>Ref Transition</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl
+	 * <em>Ref Transition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getRefTransition()
 	 * @generated
@@ -1678,27 +1703,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int REF_TRANSITION = 23;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION__ID = TRANSITION_NODE__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION__NAME = TRANSITION_NODE__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1706,26 +1731,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION__CONTAINER_PAGE = TRANSITION_NODE__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION__IN_ARCS = TRANSITION_NODE__IN_ARCS;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1733,26 +1758,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION__NODEGRAPHICS = TRANSITION_NODE__NODEGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Referencing Transitions</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Referencing Transitions</b></em>' reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION__REFERENCING_TRANSITIONS = TRANSITION_NODE__REFERENCING_TRANSITIONS;
 
 	/**
-	 * The feature id for the '<em><b>Ref</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Ref</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1760,17 +1785,18 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Ref Transition</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_TRANSITION_FEATURE_COUNT = TRANSITION_NODE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl <em>Transition</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl
+	 * <em>Transition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getTransition()
 	 * @generated
@@ -1778,27 +1804,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int TRANSITION = 24;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION__ID = TRANSITION_NODE__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION__NAME = TRANSITION_NODE__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1806,26 +1832,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION__CONTAINER_PAGE = TRANSITION_NODE__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION__IN_ARCS = TRANSITION_NODE__IN_ARCS;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1833,17 +1859,17 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION__NODEGRAPHICS = TRANSITION_NODE__NODEGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Referencing Transitions</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Referencing Transitions</b></em>' reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1851,26 +1877,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Condition</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION__CONDITION = TRANSITION_NODE_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Transition</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Transition</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TRANSITION_FEATURE_COUNT = TRANSITION_NODE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl <em>Ref Place</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl <em>Ref
+	 * Place</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getRefPlace()
 	 * @generated
@@ -1878,27 +1905,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int REF_PLACE = 25;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE__ID = PLACE_NODE__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE__NAME = PLACE_NODE__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1906,26 +1933,26 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE__CONTAINER_PAGE = PLACE_NODE__CONTAINER_PAGE;
 
 	/**
-	 * The feature id for the '<em><b>In Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>In Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE__IN_ARCS = PLACE_NODE__IN_ARCS;
 
 	/**
-	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Out Arcs</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1933,8 +1960,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1942,35 +1969,36 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Referencing Places</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE__REFERENCING_PLACES = PLACE_NODE__REFERENCING_PLACES;
 
 	/**
-	 * The feature id for the '<em><b>Ref</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Ref</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE__REF = PLACE_NODE_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Ref Place</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Ref Place</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int REF_PLACE_FEATURE_COUNT = PLACE_NODE_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AttributeImpl <em>Attribute</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AttributeImpl
+	 * <em>Attribute</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AttributeImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAttribute()
 	 * @generated
@@ -1978,27 +2006,28 @@ public interface HlcorestructurePackage extends EPackage {
 	int ATTRIBUTE = 26;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ATTRIBUTE__TOOLSPECIFICS = LABEL__TOOLSPECIFICS;
 
 	/**
-	 * The number of structural features of the '<em>Attribute</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Attribute</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ATTRIBUTE_FEATURE_COUNT = LABEL_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl <em>Any Object</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl <em>Any
+	 * Object</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAnyObject()
 	 * @generated
@@ -2006,27 +2035,29 @@ public interface HlcorestructurePackage extends EPackage {
 	int ANY_OBJECT = 28;
 
 	/**
-	 * The feature id for the '<em><b>Container Tool Info</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Tool Info</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANY_OBJECT__CONTAINER_TOOL_INFO = 0;
 
 	/**
-	 * The number of structural features of the '<em>Any Object</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Any Object</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ANY_OBJECT_FEATURE_COUNT = 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl <em>HL Core Annotation</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl
+	 * <em>HL Core Annotation</em>}' class. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getHLCoreAnnotation()
 	 * @generated
@@ -2034,27 +2065,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int HL_CORE_ANNOTATION = 29;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_CORE_ANNOTATION__TOOLSPECIFICS = ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_CORE_ANNOTATION__ANNOTATIONGRAPHICS = ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2062,17 +2093,18 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>HL Core Annotation</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_CORE_ANNOTATION_FEATURE_COUNT = ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl <em>Type</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl
+	 * <em>Type</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getType()
 	 * @generated
@@ -2080,27 +2112,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int TYPE = 30;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TYPE__TOOLSPECIFICS = HL_CORE_ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TYPE__ANNOTATIONGRAPHICS = HL_CORE_ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2108,8 +2140,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Structure</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2117,26 +2149,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Place</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TYPE__CONTAINER_PLACE = HL_CORE_ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Type</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Type</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TYPE_FEATURE_COUNT = HL_CORE_ANNOTATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl <em>HL Marking</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl <em>HL
+	 * Marking</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getHLMarking()
 	 * @generated
@@ -2144,27 +2177,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int HL_MARKING = 31;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_MARKING__TOOLSPECIFICS = HL_CORE_ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_MARKING__ANNOTATIONGRAPHICS = HL_CORE_ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2172,8 +2205,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Structure</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2181,26 +2214,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Place</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_MARKING__CONTAINER_PLACE = HL_CORE_ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>HL Marking</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>HL Marking</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_MARKING_FEATURE_COUNT = HL_CORE_ANNOTATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl <em>Condition</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl
+	 * <em>Condition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCondition()
 	 * @generated
@@ -2208,27 +2242,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int CONDITION = 32;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONDITION__TOOLSPECIFICS = HL_CORE_ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONDITION__ANNOTATIONGRAPHICS = HL_CORE_ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2236,35 +2270,36 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Structure</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONDITION__STRUCTURE = HL_CORE_ANNOTATION_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Transition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Transition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONDITION__CONTAINER_TRANSITION = HL_CORE_ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Condition</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Condition</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONDITION_FEATURE_COUNT = HL_CORE_ANNOTATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl <em>HL Annotation</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl
+	 * <em>HL Annotation</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getHLAnnotation()
 	 * @generated
@@ -2272,27 +2307,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int HL_ANNOTATION = 33;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_ANNOTATION__TOOLSPECIFICS = HL_CORE_ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_ANNOTATION__ANNOTATIONGRAPHICS = HL_CORE_ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2300,8 +2335,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Structure</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2309,26 +2344,27 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Arc</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_ANNOTATION__CONTAINER_ARC = HL_CORE_ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>HL Annotation</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>HL Annotation</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_ANNOTATION_FEATURE_COUNT = HL_CORE_ANNOTATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl <em>Declaration</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl
+	 * <em>Declaration</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getDeclaration()
 	 * @generated
@@ -2336,27 +2372,27 @@ public interface HlcorestructurePackage extends EPackage {
 	int DECLARATION = 34;
 
 	/**
-	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Toolspecifics</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATION__TOOLSPECIFICS = HL_CORE_ANNOTATION__TOOLSPECIFICS;
 
 	/**
-	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Annotationgraphics</b></em>' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATION__ANNOTATIONGRAPHICS = HL_CORE_ANNOTATION__ANNOTATIONGRAPHICS;
 
 	/**
-	 * The feature id for the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Text</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -2364,44 +2400,45 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Structure</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATION__STRUCTURE = HL_CORE_ANNOTATION_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Declaration Petri Net</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declaration Petri Net</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATION__CONTAINER_DECLARATION_PETRI_NET = HL_CORE_ANNOTATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The feature id for the '<em><b>Container Declaration Page</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declaration Page</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATION__CONTAINER_DECLARATION_PAGE = HL_CORE_ANNOTATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The number of structural features of the '<em>Declaration</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Declaration</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATION_FEATURE_COUNT = HL_CORE_ANNOTATION_FEATURE_COUNT + 3;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType <em>PN Type</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType <em>PN Type</em>}'
+	 * enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPNType()
 	 * @generated
@@ -2409,9 +2446,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int PN_TYPE = 35;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color <em>CSS2 Color</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color <em>CSS2
+	 * Color</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2Color()
 	 * @generated
@@ -2419,9 +2457,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int CSS2_COLOR = 36;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient <em>Gradient</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
+	 * <em>Gradient</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getGradient()
 	 * @generated
@@ -2429,9 +2468,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int GRADIENT = 37;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape <em>Line Shape</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape <em>Line
+	 * Shape</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLineShape()
 	 * @generated
@@ -2439,9 +2479,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int LINE_SHAPE = 38;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign <em>Font Align</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign <em>Font
+	 * Align</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFontAlign()
 	 * @generated
@@ -2449,9 +2490,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int FONT_ALIGN = 39;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration <em>Font Decoration</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration <em>Font
+	 * Decoration</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFontDecoration()
 	 * @generated
@@ -2459,9 +2501,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int FONT_DECORATION = 40;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily <em>CSS2 Font Family</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily <em>CSS2
+	 * Font Family</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontFamily()
 	 * @generated
@@ -2469,9 +2512,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int CSS2_FONT_FAMILY = 41;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize <em>CSS2 Font Size</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize <em>CSS2 Font
+	 * Size</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontSize()
 	 * @generated
@@ -2479,9 +2523,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int CSS2_FONT_SIZE = 42;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle <em>CSS2 Font Style</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle <em>CSS2 Font
+	 * Style</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontStyle()
 	 * @generated
@@ -2489,9 +2534,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int CSS2_FONT_STYLE = 43;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight <em>CSS2 Font Weight</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight <em>CSS2
+	 * Font Weight</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontWeight()
 	 * @generated
@@ -2499,9 +2545,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int CSS2_FONT_WEIGHT = 44;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle <em>Line Style</em>}' enum.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle <em>Line
+	 * Style</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLineStyle()
 	 * @generated
@@ -2509,9 +2556,9 @@ public interface HlcorestructurePackage extends EPackage {
 	int LINE_STYLE = 45;
 
 	/**
-	 * The meta object id for the '<em>URI</em>' data type.
-	 * <!-- begin-user-doc -->
+	 * The meta object id for the '<em>URI</em>' data type. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see java.net.URI
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getURI()
 	 * @generated
@@ -2519,9 +2566,9 @@ public interface HlcorestructurePackage extends EPackage {
 	int URI = 46;
 
 	/**
-	 * The meta object id for the '<em>Long String</em>' data type.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the '<em>Long String</em>' data type. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see java.lang.StringBuffer
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLongString()
 	 * @generated
@@ -2529,9 +2576,10 @@ public interface HlcorestructurePackage extends EPackage {
 	int LONG_STRING = 47;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc <em>Petri Net Doc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc <em>Petri Net
+	 * Doc</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Petri Net Doc</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc
 	 * @generated
@@ -2539,9 +2587,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPetriNetDoc();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets <em>Nets</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets
+	 * <em>Nets</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference list '<em>Nets</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets()
 	 * @see #getPetriNetDoc()
@@ -2550,9 +2599,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPetriNetDoc_Nets();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getXmlns <em>Xmlns</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getXmlns
+	 * <em>Xmlns</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Xmlns</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getXmlns()
 	 * @see #getPetriNetDoc()
@@ -2561,9 +2611,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getPetriNetDoc_Xmlns();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet <em>Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet <em>Petri
+	 * Net</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Petri Net</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet
 	 * @generated
@@ -2571,9 +2622,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPetriNet();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId <em>Id</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId
+	 * <em>Id</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Id</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId()
 	 * @see #getPetriNet()
@@ -2582,9 +2634,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getPetriNet_Id();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Type</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType()
 	 * @see #getPetriNet()
@@ -2593,9 +2646,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getPetriNet_Type();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages <em>Pages</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages
+	 * <em>Pages</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference list '<em>Pages</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages()
 	 * @see #getPetriNet()
@@ -2604,9 +2658,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPetriNet_Pages();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Name</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName()
 	 * @see #getPetriNet()
@@ -2615,10 +2670,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPetriNet_Name();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics <em>Toolspecifics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Toolspecifics</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics
+	 * <em>Toolspecifics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Toolspecifics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics()
 	 * @see #getPetriNet()
 	 * @generated
@@ -2626,10 +2683,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPetriNet_Toolspecifics();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc <em>Container Petri Net Doc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Petri Net Doc</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc
+	 * <em>Container Petri Net Doc</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Petri Net
+	 *         Doc</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc()
 	 * @see #getPetriNet()
 	 * @generated
@@ -2637,10 +2697,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPetriNet_ContainerPetriNetDoc();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Declaration</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration()
 	 * @see #getPetriNet()
 	 * @generated
@@ -2648,9 +2710,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPetriNet_Declaration();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page <em>Page</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page <em>Page</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Page</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page
 	 * @generated
@@ -2658,10 +2721,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPage();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects <em>Objects</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Objects</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects
+	 * <em>Objects</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Objects</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects()
 	 * @see #getPage()
 	 * @generated
@@ -2669,10 +2734,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPage_Objects();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet <em>Container Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Petri Net</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet
+	 * <em>Container Petri Net</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Petri
+	 *         Net</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet()
 	 * @see #getPage()
 	 * @generated
@@ -2680,10 +2747,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPage_ContainerPetriNet();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics <em>Nodegraphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Nodegraphics</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics
+	 * <em>Nodegraphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference
+	 *         '<em>Nodegraphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics()
 	 * @see #getPage()
 	 * @generated
@@ -2691,10 +2760,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPage_Nodegraphics();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Declaration</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration()
 	 * @see #getPage()
 	 * @generated
@@ -2702,9 +2773,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPage_Declaration();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject <em>Pn Object</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject <em>Pn
+	 * Object</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Pn Object</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject
 	 * @generated
@@ -2712,9 +2784,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPnObject();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId <em>Id</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId
+	 * <em>Id</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Id</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId()
 	 * @see #getPnObject()
@@ -2723,9 +2796,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getPnObject_Id();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Name</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName()
 	 * @see #getPnObject()
@@ -2734,10 +2808,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPnObject_Name();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics <em>Toolspecifics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Toolspecifics</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics
+	 * <em>Toolspecifics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Toolspecifics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics()
 	 * @see #getPnObject()
 	 * @generated
@@ -2745,10 +2821,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPnObject_Toolspecifics();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage <em>Container Page</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Page</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage
+	 * <em>Container Page</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Page</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage()
 	 * @see #getPnObject()
 	 * @generated
@@ -2756,9 +2834,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPnObject_ContainerPage();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name <em>Name</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Name</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name
 	 * @generated
@@ -2766,9 +2845,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getName_();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText <em>Text</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText
+	 * <em>Text</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Text</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText()
 	 * @see #getName_()
@@ -2777,10 +2857,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getName_Text();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet <em>Container Name Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Name Petri Net</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet
+	 * <em>Container Name Petri Net</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Name Petri
+	 *         Net</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet()
 	 * @see #getName_()
 	 * @generated
@@ -2788,10 +2871,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getName_ContainerNamePetriNet();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject <em>Container Name Pn Object</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Name Pn Object</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject
+	 * <em>Container Name Pn Object</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Name Pn
+	 *         Object</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject()
 	 * @see #getName_()
 	 * @generated
@@ -2799,9 +2885,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getName_ContainerNamePnObject();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo <em>Tool Info</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo <em>Tool
+	 * Info</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Tool Info</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo
 	 * @generated
@@ -2809,9 +2896,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getToolInfo();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool <em>Tool</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool
+	 * <em>Tool</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Tool</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool()
 	 * @see #getToolInfo()
@@ -2820,9 +2908,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getToolInfo_Tool();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion <em>Version</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion
+	 * <em>Version</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Version</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion()
 	 * @see #getToolInfo()
@@ -2831,9 +2920,11 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getToolInfo_Version();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer <em>Formatted XML Buffer</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer
+	 * <em>Formatted XML Buffer</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @return the meta object for the attribute '<em>Formatted XML Buffer</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer()
 	 * @see #getToolInfo()
@@ -2842,9 +2933,11 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getToolInfo_FormattedXMLBuffer();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI <em>Tool Info Grammar URI</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI
+	 * <em>Tool Info Grammar URI</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @return the meta object for the attribute '<em>Tool Info Grammar URI</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI()
 	 * @see #getToolInfo()
@@ -2853,10 +2946,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getToolInfo_ToolInfoGrammarURI();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet <em>Container Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Petri Net</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet
+	 * <em>Container Petri Net</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Petri
+	 *         Net</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet()
 	 * @see #getToolInfo()
 	 * @generated
@@ -2864,10 +2959,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getToolInfo_ContainerPetriNet();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject <em>Container Pn Object</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Pn Object</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject
+	 * <em>Container Pn Object</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Pn
+	 *         Object</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject()
 	 * @see #getToolInfo()
 	 * @generated
@@ -2875,10 +2972,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getToolInfo_ContainerPnObject();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel <em>Container Label</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Label</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel
+	 * <em>Container Label</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Label</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel()
 	 * @see #getToolInfo()
 	 * @generated
@@ -2886,10 +2985,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getToolInfo_ContainerLabel();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel <em>Tool Info Model</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Tool Info Model</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel
+	 * <em>Tool Info Model</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference '<em>Tool Info
+	 *         Model</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel()
 	 * @see #getToolInfo()
 	 * @generated
@@ -2897,9 +2998,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getToolInfo_ToolInfoModel();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label <em>Label</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label <em>Label</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Label</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Label
 	 * @generated
@@ -2907,10 +3009,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getLabel();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics <em>Toolspecifics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Toolspecifics</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics
+	 * <em>Toolspecifics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Toolspecifics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics()
 	 * @see #getLabel()
 	 * @generated
@@ -2918,9 +3022,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getLabel_Toolspecifics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics <em>Node Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics <em>Node
+	 * Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Node Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics
 	 * @generated
@@ -2928,9 +3033,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getNodeGraphics();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition <em>Position</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition
+	 * <em>Position</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Position</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition()
 	 * @see #getNodeGraphics()
@@ -2939,9 +3045,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNodeGraphics_Position();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension <em>Dimension</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension
+	 * <em>Dimension</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Dimension</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension()
 	 * @see #getNodeGraphics()
@@ -2950,9 +3057,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNodeGraphics_Dimension();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill <em>Fill</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill
+	 * <em>Fill</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Fill</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill()
 	 * @see #getNodeGraphics()
@@ -2961,9 +3069,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNodeGraphics_Fill();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine
+	 * <em>Line</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Line</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine()
 	 * @see #getNodeGraphics()
@@ -2972,10 +3081,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNodeGraphics_Line();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode <em>Container Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Node</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode
+	 * <em>Container Node</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Node</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode()
 	 * @see #getNodeGraphics()
 	 * @generated
@@ -2983,10 +3094,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNodeGraphics_ContainerNode();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage <em>Container Page</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Page</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage
+	 * <em>Container Page</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Page</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage()
 	 * @see #getNodeGraphics()
 	 * @generated
@@ -2994,9 +3107,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNodeGraphics_ContainerPage();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics <em>Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics
+	 * <em>Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics
 	 * @generated
@@ -3004,9 +3118,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getGraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate <em>Coordinate</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate
+	 * <em>Coordinate</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Coordinate</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate
 	 * @generated
@@ -3014,9 +3129,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getCoordinate();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX <em>X</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX
+	 * <em>X</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>X</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getX()
 	 * @see #getCoordinate()
@@ -3025,9 +3141,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getCoordinate_X();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY <em>Y</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY
+	 * <em>Y</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Y</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate#getY()
 	 * @see #getCoordinate()
@@ -3036,9 +3153,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getCoordinate_Y();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position <em>Position</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position
+	 * <em>Position</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Position</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Position
 	 * @generated
@@ -3046,10 +3164,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPosition();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics <em>Container Arc Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Arc Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics
+	 * <em>Container Arc Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Arc
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics()
 	 * @see #getPosition()
 	 * @generated
@@ -3057,10 +3178,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPosition_ContainerArcGraphics();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics <em>Container PNode Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container PNode Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics
+	 * <em>Container PNode Graphics</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container PNode
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics()
 	 * @see #getPosition()
 	 * @generated
@@ -3068,9 +3192,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPosition_ContainerPNodeGraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset <em>Offset</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset <em>Offset</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Offset</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset
 	 * @generated
@@ -3078,10 +3203,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getOffset();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Annotation Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Annotation
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics()
 	 * @see #getOffset()
 	 * @generated
@@ -3089,9 +3217,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getOffset_ContainerAnnotationGraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension <em>Dimension</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension
+	 * <em>Dimension</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Dimension</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension
 	 * @generated
@@ -3099,10 +3228,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getDimension();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics <em>Container DNode Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container DNode Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics
+	 * <em>Container DNode Graphics</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container DNode
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics()
 	 * @see #getDimension()
 	 * @generated
@@ -3110,9 +3242,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getDimension_ContainerDNodeGraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics <em>Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics
+	 * <em>Annotation Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Annotation Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics
 	 * @generated
@@ -3120,9 +3253,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getAnnotationGraphics();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset <em>Offset</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset
+	 * <em>Offset</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Offset</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset()
 	 * @see #getAnnotationGraphics()
@@ -3131,9 +3265,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnnotationGraphics_Offset();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill <em>Fill</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill
+	 * <em>Fill</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Fill</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFill()
 	 * @see #getAnnotationGraphics()
@@ -3142,9 +3277,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnnotationGraphics_Fill();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine
+	 * <em>Line</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Line</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine()
 	 * @see #getAnnotationGraphics()
@@ -3153,9 +3289,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnnotationGraphics_Line();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont <em>Font</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont
+	 * <em>Font</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Font</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getFont()
 	 * @see #getAnnotationGraphics()
@@ -3164,10 +3301,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnnotationGraphics_Font();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation <em>Container Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Annotation</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation
+	 * <em>Container Annotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Annotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getContainerAnnotation()
 	 * @see #getAnnotationGraphics()
 	 * @generated
@@ -3175,9 +3315,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnnotationGraphics_ContainerAnnotation();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill <em>Fill</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill <em>Fill</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Fill</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill
 	 * @generated
@@ -3185,9 +3326,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getFill();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor <em>Color</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor
+	 * <em>Color</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Color</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getColor()
 	 * @see #getFill()
@@ -3196,9 +3338,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFill_Color();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor <em>Gradientcolor</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor
+	 * <em>Gradientcolor</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Gradientcolor</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientcolor()
 	 * @see #getFill()
@@ -3207,9 +3350,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFill_Gradientcolor();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation <em>Gradientrotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation
+	 * <em>Gradientrotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Gradientrotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getGradientrotation()
 	 * @see #getFill()
@@ -3218,9 +3362,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFill_Gradientrotation();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage <em>Image</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage
+	 * <em>Image</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Image</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getImage()
 	 * @see #getFill()
@@ -3229,10 +3374,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFill_Image();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics <em>Container Node Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Node Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics
+	 * <em>Container Node Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Node
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics()
 	 * @see #getFill()
 	 * @generated
@@ -3240,10 +3388,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getFill_ContainerNodeGraphics();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Annotation Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Annotation
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerAnnotationGraphics()
 	 * @see #getFill()
 	 * @generated
@@ -3251,9 +3402,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getFill_ContainerAnnotationGraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line <em>Line</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Line</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line
 	 * @generated
@@ -3261,9 +3413,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getLine();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor <em>Color</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor
+	 * <em>Color</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Color</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor()
 	 * @see #getLine()
@@ -3272,9 +3425,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getLine_Color();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape <em>Shape</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape
+	 * <em>Shape</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Shape</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape()
 	 * @see #getLine()
@@ -3283,9 +3437,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getLine_Shape();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth <em>Width</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth
+	 * <em>Width</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Width</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth()
 	 * @see #getLine()
@@ -3294,10 +3449,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getLine_Width();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics <em>Container Node Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Node Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics
+	 * <em>Container Node Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Node
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics()
 	 * @see #getLine()
 	 * @generated
@@ -3305,10 +3463,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getLine_ContainerNodeGraphics();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics <em>Container Arc Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Arc Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics
+	 * <em>Container Arc Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Arc
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics()
 	 * @see #getLine()
 	 * @generated
@@ -3316,10 +3477,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getLine_ContainerArcGraphics();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Annotation Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Annotation
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics()
 	 * @see #getLine()
 	 * @generated
@@ -3327,9 +3491,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getLine_ContainerAnnotationGraphics();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle <em>Style</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle
+	 * <em>Style</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Style</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle()
 	 * @see #getLine()
@@ -3338,9 +3503,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getLine_Style();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics <em>Arc Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics <em>Arc
+	 * Graphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Arc Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics
 	 * @generated
@@ -3348,10 +3514,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getArcGraphics();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions <em>Positions</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Positions</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions
+	 * <em>Positions</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Positions</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions()
 	 * @see #getArcGraphics()
 	 * @generated
@@ -3359,9 +3527,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArcGraphics_Positions();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine
+	 * <em>Line</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Line</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine()
 	 * @see #getArcGraphics()
@@ -3370,9 +3539,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArcGraphics_Line();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc <em>Container Arc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc
+	 * <em>Container Arc</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the container reference '<em>Container Arc</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getContainerArc()
 	 * @see #getArcGraphics()
@@ -3381,9 +3551,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArcGraphics_ContainerArc();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc <em>Arc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc <em>Arc</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Arc</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc
 	 * @generated
@@ -3391,9 +3562,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getArc();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource <em>Source</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource
+	 * <em>Source</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Source</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource()
 	 * @see #getArc()
@@ -3402,9 +3574,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArc_Source();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget <em>Target</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget
+	 * <em>Target</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Target</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget()
 	 * @see #getArc()
@@ -3413,9 +3586,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArc_Target();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics <em>Arcgraphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics
+	 * <em>Arcgraphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Arcgraphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getArcgraphics()
 	 * @see #getArc()
@@ -3424,10 +3598,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArc_Arcgraphics();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription <em>Hlinscription</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Hlinscription</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription
+	 * <em>Hlinscription</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference
+	 *         '<em>Hlinscription</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getHlinscription()
 	 * @see #getArc()
 	 * @generated
@@ -3435,9 +3611,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getArc_Hlinscription();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node <em>Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node <em>Node</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Node</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node
 	 * @generated
@@ -3445,9 +3622,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getNode();
 
 	/**
-	 * Returns the meta object for the reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs <em>In Arcs</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs <em>In
+	 * Arcs</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference list '<em>In Arcs</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs()
 	 * @see #getNode()
@@ -3456,9 +3634,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNode_InArcs();
 
 	/**
-	 * Returns the meta object for the reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs <em>Out Arcs</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs <em>Out
+	 * Arcs</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference list '<em>Out Arcs</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs()
 	 * @see #getNode()
@@ -3467,10 +3646,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNode_OutArcs();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics <em>Nodegraphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Nodegraphics</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics
+	 * <em>Nodegraphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference
+	 *         '<em>Nodegraphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics()
 	 * @see #getNode()
 	 * @generated
@@ -3478,9 +3659,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getNode_Nodegraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font <em>Font</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font <em>Font</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Font</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font
 	 * @generated
@@ -3488,9 +3670,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getFont();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign <em>Align</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign
+	 * <em>Align</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Align</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getAlign()
 	 * @see #getFont()
@@ -3499,9 +3682,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Align();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration <em>Decoration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration
+	 * <em>Decoration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Decoration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getDecoration()
 	 * @see #getFont()
@@ -3510,9 +3694,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Decoration();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily <em>Family</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily
+	 * <em>Family</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Family</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getFamily()
 	 * @see #getFont()
@@ -3521,9 +3706,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Family();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation <em>Rotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation
+	 * <em>Rotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Rotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getRotation()
 	 * @see #getFont()
@@ -3532,9 +3718,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Rotation();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize <em>Size</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize
+	 * <em>Size</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Size</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getSize()
 	 * @see #getFont()
@@ -3543,9 +3730,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Size();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle <em>Style</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle
+	 * <em>Style</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Style</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getStyle()
 	 * @see #getFont()
@@ -3554,9 +3742,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Style();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight <em>Weight</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight
+	 * <em>Weight</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Weight</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getWeight()
 	 * @see #getFont()
@@ -3565,10 +3754,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getFont_Weight();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Annotation Graphics</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Annotation
+	 *         Graphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font#getContainerAnnotationGraphics()
 	 * @see #getFont()
 	 * @generated
@@ -3576,9 +3768,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getFont_ContainerAnnotationGraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode <em>Place Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode <em>Place
+	 * Node</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Place Node</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode
 	 * @generated
@@ -3586,9 +3779,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPlaceNode();
 
 	/**
-	 * Returns the meta object for the reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces <em>Referencing Places</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces
+	 * <em>Referencing Places</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference list '<em>Referencing Places</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces()
 	 * @see #getPlaceNode()
@@ -3597,9 +3791,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPlaceNode_ReferencingPlaces();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode <em>Transition Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode
+	 * <em>Transition Node</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Transition Node</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode
 	 * @generated
@@ -3607,10 +3802,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getTransitionNode();
 
 	/**
-	 * Returns the meta object for the reference list '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions <em>Referencing Transitions</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the reference list '<em>Referencing Transitions</em>'.
+	 * Returns the meta object for the reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions
+	 * <em>Referencing Transitions</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the reference list '<em>Referencing
+	 *         Transitions</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions()
 	 * @see #getTransitionNode()
 	 * @generated
@@ -3618,9 +3816,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getTransitionNode_ReferencingTransitions();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place <em>Place</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place <em>Place</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Place</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Place
 	 * @generated
@@ -3628,9 +3827,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getPlace();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Type</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType()
 	 * @see #getPlace()
@@ -3639,10 +3839,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPlace_Type();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking <em>Hlinitial Marking</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Hlinitial Marking</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking
+	 * <em>Hlinitial Marking</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference '<em>Hlinitial
+	 *         Marking</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking()
 	 * @see #getPlace()
 	 * @generated
@@ -3650,9 +3852,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getPlace_HlinitialMarking();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition <em>Ref Transition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition <em>Ref
+	 * Transition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Ref Transition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition
 	 * @generated
@@ -3660,9 +3863,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getRefTransition();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef <em>Ref</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef
+	 * <em>Ref</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Ref</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef()
 	 * @see #getRefTransition()
@@ -3671,9 +3875,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getRefTransition_Ref();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition <em>Transition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition
+	 * <em>Transition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Transition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition
 	 * @generated
@@ -3681,9 +3886,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getTransition();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition <em>Condition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition
+	 * <em>Condition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Condition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition()
 	 * @see #getTransition()
@@ -3692,9 +3898,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getTransition_Condition();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace <em>Ref Place</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace <em>Ref
+	 * Place</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Ref Place</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace
 	 * @generated
@@ -3702,9 +3909,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getRefPlace();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef <em>Ref</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef
+	 * <em>Ref</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Ref</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef()
 	 * @see #getRefPlace()
@@ -3713,9 +3921,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getRefPlace_Ref();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute <em>Attribute</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute
+	 * <em>Attribute</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Attribute</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute
 	 * @generated
@@ -3723,9 +3932,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getAttribute();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation <em>Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation
+	 * <em>Annotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Annotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation
 	 * @generated
@@ -3733,10 +3943,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getAnnotation();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics <em>Annotationgraphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference '<em>Annotationgraphics</em>'.
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics
+	 * <em>Annotationgraphics</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference
+	 *         '<em>Annotationgraphics</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation#getAnnotationgraphics()
 	 * @see #getAnnotation()
 	 * @generated
@@ -3744,9 +3956,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnnotation_Annotationgraphics();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject <em>Any Object</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject <em>Any
+	 * Object</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Any Object</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject
 	 * @generated
@@ -3754,10 +3967,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getAnyObject();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo <em>Container Tool Info</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Tool Info</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo
+	 * <em>Container Tool Info</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Tool
+	 *         Info</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo()
 	 * @see #getAnyObject()
 	 * @generated
@@ -3765,9 +3980,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getAnyObject_ContainerToolInfo();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation <em>HL Core Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation <em>HL
+	 * Core Annotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>HL Core Annotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation
 	 * @generated
@@ -3775,9 +3991,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getHLCoreAnnotation();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText <em>Text</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText
+	 * <em>Text</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Text</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation#getText()
 	 * @see #getHLCoreAnnotation()
@@ -3786,9 +4003,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EAttribute getHLCoreAnnotation_Text();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type <em>Type</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Type</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Type
 	 * @generated
@@ -3796,9 +4014,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getType();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Structure</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure()
 	 * @see #getType()
@@ -3807,10 +4026,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getType_Structure();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace <em>Container Place</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Place</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace
+	 * <em>Container Place</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Place</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace()
 	 * @see #getType()
 	 * @generated
@@ -3818,9 +4039,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getType_ContainerPlace();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking <em>HL Marking</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking <em>HL
+	 * Marking</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>HL Marking</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking
 	 * @generated
@@ -3828,9 +4050,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getHLMarking();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Structure</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure()
 	 * @see #getHLMarking()
@@ -3839,10 +4062,12 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getHLMarking_Structure();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace <em>Container Place</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Place</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace
+	 * <em>Container Place</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Place</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace()
 	 * @see #getHLMarking()
 	 * @generated
@@ -3850,9 +4075,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getHLMarking_ContainerPlace();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition <em>Condition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition
+	 * <em>Condition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Condition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition
 	 * @generated
@@ -3860,9 +4086,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getCondition();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Structure</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure()
 	 * @see #getCondition()
@@ -3871,10 +4098,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getCondition_Structure();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition <em>Container Transition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Transition</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition
+	 * <em>Container Transition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Transition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition()
 	 * @see #getCondition()
 	 * @generated
@@ -3882,9 +4112,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getCondition_ContainerTransition();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation <em>HL Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation <em>HL
+	 * Annotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>HL Annotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation
 	 * @generated
@@ -3892,9 +4123,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getHLAnnotation();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Structure</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure()
 	 * @see #getHLAnnotation()
@@ -3903,9 +4135,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getHLAnnotation_Structure();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc <em>Container Arc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc
+	 * <em>Container Arc</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the container reference '<em>Container Arc</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getContainerArc()
 	 * @see #getHLAnnotation()
@@ -3914,9 +4147,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getHLAnnotation_ContainerArc();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration
 	 * @generated
@@ -3924,9 +4158,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EClass getDeclaration();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Structure</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure()
 	 * @see #getDeclaration()
@@ -3935,10 +4170,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getDeclaration_Structure();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet <em>Container Declaration Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Declaration Petri Net</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet
+	 * <em>Container Declaration Petri Net</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Declaration Petri Net</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet()
 	 * @see #getDeclaration()
 	 * @generated
@@ -3946,10 +4184,13 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getDeclaration_ContainerDeclarationPetriNet();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage <em>Container Declaration Page</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Declaration Page</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage
+	 * <em>Container Declaration Page</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Declaration Page</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage()
 	 * @see #getDeclaration()
 	 * @generated
@@ -3957,9 +4198,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EReference getDeclaration_ContainerDeclarationPage();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType <em>PN Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType <em>PN Type</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>PN Type</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType
 	 * @generated
@@ -3967,9 +4209,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getPNType();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color <em>CSS2 Color</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color <em>CSS2
+	 * Color</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>CSS2 Color</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @generated
@@ -3977,9 +4220,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getCSS2Color();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient <em>Gradient</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
+	 * <em>Gradient</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>Gradient</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
 	 * @generated
@@ -3987,9 +4231,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getGradient();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape <em>Line Shape</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape <em>Line
+	 * Shape</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>Line Shape</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape
 	 * @generated
@@ -3997,9 +4242,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getLineShape();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign <em>Font Align</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign <em>Font
+	 * Align</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>Font Align</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign
 	 * @generated
@@ -4007,9 +4253,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getFontAlign();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration <em>Font Decoration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration <em>Font
+	 * Decoration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>Font Decoration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration
 	 * @generated
@@ -4017,9 +4264,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getFontDecoration();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily <em>CSS2 Font Family</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily <em>CSS2
+	 * Font Family</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>CSS2 Font Family</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily
 	 * @generated
@@ -4027,9 +4275,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getCSS2FontFamily();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize <em>CSS2 Font Size</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize <em>CSS2 Font
+	 * Size</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>CSS2 Font Size</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize
 	 * @generated
@@ -4037,9 +4286,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getCSS2FontSize();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle <em>CSS2 Font Style</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle <em>CSS2 Font
+	 * Style</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>CSS2 Font Style</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle
 	 * @generated
@@ -4047,9 +4297,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getCSS2FontStyle();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight <em>CSS2 Font Weight</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight <em>CSS2
+	 * Font Weight</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>CSS2 Font Weight</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight
 	 * @generated
@@ -4057,9 +4308,10 @@ public interface HlcorestructurePackage extends EPackage {
 	EEnum getCSS2FontWeight();
 
 	/**
-	 * Returns the meta object for enum '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle <em>Line Style</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for enum
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle <em>Line
+	 * Style</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for enum '<em>Line Style</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle
 	 * @generated
@@ -4068,8 +4320,8 @@ public interface HlcorestructurePackage extends EPackage {
 
 	/**
 	 * Returns the meta object for data type '{@link java.net.URI <em>URI</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for data type '<em>URI</em>'.
 	 * @see java.net.URI
 	 * @model instanceClass="java.net.URI"
@@ -4078,9 +4330,9 @@ public interface HlcorestructurePackage extends EPackage {
 	EDataType getURI();
 
 	/**
-	 * Returns the meta object for data type '{@link java.lang.StringBuffer <em>Long String</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for data type '{@link java.lang.StringBuffer <em>Long
+	 * String</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for data type '<em>Long String</em>'.
 	 * @see java.lang.StringBuffer
 	 * @model instanceClass="java.lang.StringBuffer"
@@ -4089,31 +4341,32 @@ public interface HlcorestructurePackage extends EPackage {
 	EDataType getLongString();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	HlcorestructureFactory getHlcorestructureFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl <em>Petri Net Doc</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl
+		 * <em>Petri Net Doc</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPetriNetDoc()
 		 * @generated
@@ -4121,25 +4374,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass PETRI_NET_DOC = eINSTANCE.getPetriNetDoc();
 
 		/**
-		 * The meta object literal for the '<em><b>Nets</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Nets</b></em>' containment reference
+		 * list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PETRI_NET_DOC__NETS = eINSTANCE.getPetriNetDoc_Nets();
 
 		/**
 		 * The meta object literal for the '<em><b>Xmlns</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute PETRI_NET_DOC__XMLNS = eINSTANCE.getPetriNetDoc_Xmlns();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl <em>Petri Net</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl <em>Petri
+		 * Net</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPetriNet()
 		 * @generated
@@ -4147,65 +4401,66 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass PETRI_NET = eINSTANCE.getPetriNet();
 
 		/**
-		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute PETRI_NET__ID = eINSTANCE.getPetriNet_Id();
 
 		/**
 		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute PETRI_NET__TYPE = eINSTANCE.getPetriNet_Type();
 
 		/**
-		 * The meta object literal for the '<em><b>Pages</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Pages</b></em>' containment reference
+		 * list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PETRI_NET__PAGES = eINSTANCE.getPetriNet_Pages();
 
 		/**
-		 * The meta object literal for the '<em><b>Name</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PETRI_NET__NAME = eINSTANCE.getPetriNet_Name();
 
 		/**
-		 * The meta object literal for the '<em><b>Toolspecifics</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Toolspecifics</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PETRI_NET__TOOLSPECIFICS = eINSTANCE.getPetriNet_Toolspecifics();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Petri Net Doc</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Petri Net Doc</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PETRI_NET__CONTAINER_PETRI_NET_DOC = eINSTANCE.getPetriNet_ContainerPetriNetDoc();
 
 		/**
-		 * The meta object literal for the '<em><b>Declaration</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Declaration</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PETRI_NET__DECLARATION = eINSTANCE.getPetriNet_Declaration();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl <em>Page</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl
+		 * <em>Page</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPage()
 		 * @generated
@@ -4213,41 +4468,42 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass PAGE = eINSTANCE.getPage();
 
 		/**
-		 * The meta object literal for the '<em><b>Objects</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Objects</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PAGE__OBJECTS = eINSTANCE.getPage_Objects();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Petri Net</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Petri Net</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PAGE__CONTAINER_PETRI_NET = eINSTANCE.getPage_ContainerPetriNet();
 
 		/**
-		 * The meta object literal for the '<em><b>Nodegraphics</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Nodegraphics</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PAGE__NODEGRAPHICS = eINSTANCE.getPage_Nodegraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Declaration</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Declaration</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PAGE__DECLARATION = eINSTANCE.getPage_Declaration();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl <em>Pn Object</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl <em>Pn
+		 * Object</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPnObject()
 		 * @generated
@@ -4255,41 +4511,42 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass PN_OBJECT = eINSTANCE.getPnObject();
 
 		/**
-		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute PN_OBJECT__ID = eINSTANCE.getPnObject_Id();
 
 		/**
-		 * The meta object literal for the '<em><b>Name</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Name</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PN_OBJECT__NAME = eINSTANCE.getPnObject_Name();
 
 		/**
-		 * The meta object literal for the '<em><b>Toolspecifics</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Toolspecifics</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PN_OBJECT__TOOLSPECIFICS = eINSTANCE.getPnObject_Toolspecifics();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Page</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Page</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PN_OBJECT__CONTAINER_PAGE = eINSTANCE.getPnObject_ContainerPage();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl <em>Name</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl
+		 * <em>Name</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getName_()
 		 * @generated
@@ -4298,32 +4555,33 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Text</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute NAME__TEXT = eINSTANCE.getName_Text();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Name Petri Net</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Name Petri Net</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NAME__CONTAINER_NAME_PETRI_NET = eINSTANCE.getName_ContainerNamePetriNet();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Name Pn Object</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Name Pn Object</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NAME__CONTAINER_NAME_PN_OBJECT = eINSTANCE.getName_ContainerNamePnObject();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl <em>Tool Info</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl <em>Tool
+		 * Info</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getToolInfo()
 		 * @generated
@@ -4332,72 +4590,73 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Tool</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute TOOL_INFO__TOOL = eINSTANCE.getToolInfo_Tool();
 
 		/**
 		 * The meta object literal for the '<em><b>Version</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute TOOL_INFO__VERSION = eINSTANCE.getToolInfo_Version();
 
 		/**
-		 * The meta object literal for the '<em><b>Formatted XML Buffer</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Formatted XML Buffer</b></em>'
+		 * attribute feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute TOOL_INFO__FORMATTED_XML_BUFFER = eINSTANCE.getToolInfo_FormattedXMLBuffer();
 
 		/**
-		 * The meta object literal for the '<em><b>Tool Info Grammar URI</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Tool Info Grammar URI</b></em>'
+		 * attribute feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute TOOL_INFO__TOOL_INFO_GRAMMAR_URI = eINSTANCE.getToolInfo_ToolInfoGrammarURI();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Petri Net</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Petri Net</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TOOL_INFO__CONTAINER_PETRI_NET = eINSTANCE.getToolInfo_ContainerPetriNet();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Pn Object</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Pn Object</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TOOL_INFO__CONTAINER_PN_OBJECT = eINSTANCE.getToolInfo_ContainerPnObject();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Label</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Label</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TOOL_INFO__CONTAINER_LABEL = eINSTANCE.getToolInfo_ContainerLabel();
 
 		/**
-		 * The meta object literal for the '<em><b>Tool Info Model</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Tool Info Model</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TOOL_INFO__TOOL_INFO_MODEL = eINSTANCE.getToolInfo_ToolInfoModel();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl <em>Label</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl
+		 * <em>Label</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLabel()
 		 * @generated
@@ -4405,17 +4664,18 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass LABEL = eINSTANCE.getLabel();
 
 		/**
-		 * The meta object literal for the '<em><b>Toolspecifics</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Toolspecifics</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference LABEL__TOOLSPECIFICS = eINSTANCE.getLabel_Toolspecifics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl <em>Node Graphics</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl
+		 * <em>Node Graphics</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getNodeGraphics()
 		 * @generated
@@ -4423,57 +4683,58 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass NODE_GRAPHICS = eINSTANCE.getNodeGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Position</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Position</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE_GRAPHICS__POSITION = eINSTANCE.getNodeGraphics_Position();
 
 		/**
-		 * The meta object literal for the '<em><b>Dimension</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Dimension</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE_GRAPHICS__DIMENSION = eINSTANCE.getNodeGraphics_Dimension();
 
 		/**
-		 * The meta object literal for the '<em><b>Fill</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Fill</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE_GRAPHICS__FILL = eINSTANCE.getNodeGraphics_Fill();
 
 		/**
-		 * The meta object literal for the '<em><b>Line</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Line</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE_GRAPHICS__LINE = eINSTANCE.getNodeGraphics_Line();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Node</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Node</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE_GRAPHICS__CONTAINER_NODE = eINSTANCE.getNodeGraphics_ContainerNode();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Page</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Page</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE_GRAPHICS__CONTAINER_PAGE = eINSTANCE.getNodeGraphics_ContainerPage();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.GraphicsImpl <em>Graphics</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.GraphicsImpl
+		 * <em>Graphics</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.GraphicsImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getGraphics()
 		 * @generated
@@ -4481,9 +4742,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass GRAPHICS = eINSTANCE.getGraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl <em>Coordinate</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl
+		 * <em>Coordinate</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCoordinate()
 		 * @generated
@@ -4491,25 +4753,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass COORDINATE = eINSTANCE.getCoordinate();
 
 		/**
-		 * The meta object literal for the '<em><b>X</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>X</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute COORDINATE__X = eINSTANCE.getCoordinate_X();
 
 		/**
-		 * The meta object literal for the '<em><b>Y</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Y</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute COORDINATE__Y = eINSTANCE.getCoordinate_Y();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl <em>Position</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl
+		 * <em>Position</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPosition()
 		 * @generated
@@ -4517,25 +4780,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass POSITION = eINSTANCE.getPosition();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Arc Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Arc Graphics</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference POSITION__CONTAINER_ARC_GRAPHICS = eINSTANCE.getPosition_ContainerArcGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Container PNode Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container PNode Graphics</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference POSITION__CONTAINER_PNODE_GRAPHICS = eINSTANCE.getPosition_ContainerPNodeGraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl <em>Offset</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl
+		 * <em>Offset</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getOffset()
 		 * @generated
@@ -4543,17 +4807,19 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass OFFSET = eINSTANCE.getOffset();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Annotation Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Annotation
+		 * Graphics</b></em>' container reference feature. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference OFFSET__CONTAINER_ANNOTATION_GRAPHICS = eINSTANCE.getOffset_ContainerAnnotationGraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl <em>Dimension</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl
+		 * <em>Dimension</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getDimension()
 		 * @generated
@@ -4561,17 +4827,19 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass DIMENSION = eINSTANCE.getDimension();
 
 		/**
-		 * The meta object literal for the '<em><b>Container DNode Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container DNode Graphics</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DIMENSION__CONTAINER_DNODE_GRAPHICS = eINSTANCE.getDimension_ContainerDNodeGraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl <em>Annotation Graphics</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl
+		 * <em>Annotation Graphics</em>}' class. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAnnotationGraphics()
 		 * @generated
@@ -4579,49 +4847,50 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass ANNOTATION_GRAPHICS = eINSTANCE.getAnnotationGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Offset</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Offset</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANNOTATION_GRAPHICS__OFFSET = eINSTANCE.getAnnotationGraphics_Offset();
 
 		/**
-		 * The meta object literal for the '<em><b>Fill</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Fill</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANNOTATION_GRAPHICS__FILL = eINSTANCE.getAnnotationGraphics_Fill();
 
 		/**
-		 * The meta object literal for the '<em><b>Line</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Line</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANNOTATION_GRAPHICS__LINE = eINSTANCE.getAnnotationGraphics_Line();
 
 		/**
-		 * The meta object literal for the '<em><b>Font</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Font</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANNOTATION_GRAPHICS__FONT = eINSTANCE.getAnnotationGraphics_Font();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Annotation</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Annotation</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANNOTATION_GRAPHICS__CONTAINER_ANNOTATION = eINSTANCE.getAnnotationGraphics_ContainerAnnotation();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl <em>Fill</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl
+		 * <em>Fill</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFill()
 		 * @generated
@@ -4630,56 +4899,58 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Color</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FILL__COLOR = eINSTANCE.getFill_Color();
 
 		/**
-		 * The meta object literal for the '<em><b>Gradientcolor</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Gradientcolor</b></em>' attribute
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FILL__GRADIENTCOLOR = eINSTANCE.getFill_Gradientcolor();
 
 		/**
-		 * The meta object literal for the '<em><b>Gradientrotation</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Gradientrotation</b></em>' attribute
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FILL__GRADIENTROTATION = eINSTANCE.getFill_Gradientrotation();
 
 		/**
 		 * The meta object literal for the '<em><b>Image</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FILL__IMAGE = eINSTANCE.getFill_Image();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Node Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Node Graphics</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference FILL__CONTAINER_NODE_GRAPHICS = eINSTANCE.getFill_ContainerNodeGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Annotation Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Annotation
+		 * Graphics</b></em>' container reference feature. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference FILL__CONTAINER_ANNOTATION_GRAPHICS = eINSTANCE.getFill_ContainerAnnotationGraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl <em>Line</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl
+		 * <em>Line</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLine()
 		 * @generated
@@ -4688,64 +4959,66 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Color</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute LINE__COLOR = eINSTANCE.getLine_Color();
 
 		/**
 		 * The meta object literal for the '<em><b>Shape</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute LINE__SHAPE = eINSTANCE.getLine_Shape();
 
 		/**
 		 * The meta object literal for the '<em><b>Width</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute LINE__WIDTH = eINSTANCE.getLine_Width();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Node Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Node Graphics</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference LINE__CONTAINER_NODE_GRAPHICS = eINSTANCE.getLine_ContainerNodeGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Arc Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Arc Graphics</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference LINE__CONTAINER_ARC_GRAPHICS = eINSTANCE.getLine_ContainerArcGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Annotation Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Annotation
+		 * Graphics</b></em>' container reference feature. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference LINE__CONTAINER_ANNOTATION_GRAPHICS = eINSTANCE.getLine_ContainerAnnotationGraphics();
 
 		/**
 		 * The meta object literal for the '<em><b>Style</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute LINE__STYLE = eINSTANCE.getLine_Style();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl <em>Arc Graphics</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl
+		 * <em>Arc Graphics</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getArcGraphics()
 		 * @generated
@@ -4753,33 +5026,34 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass ARC_GRAPHICS = eINSTANCE.getArcGraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Positions</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Positions</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC_GRAPHICS__POSITIONS = eINSTANCE.getArcGraphics_Positions();
 
 		/**
-		 * The meta object literal for the '<em><b>Line</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Line</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC_GRAPHICS__LINE = eINSTANCE.getArcGraphics_Line();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Arc</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Arc</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC_GRAPHICS__CONTAINER_ARC = eINSTANCE.getArcGraphics_ContainerArc();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl <em>Arc</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl <em>Arc</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getArc()
 		 * @generated
@@ -4788,40 +5062,41 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Source</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC__SOURCE = eINSTANCE.getArc_Source();
 
 		/**
 		 * The meta object literal for the '<em><b>Target</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC__TARGET = eINSTANCE.getArc_Target();
 
 		/**
-		 * The meta object literal for the '<em><b>Arcgraphics</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Arcgraphics</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC__ARCGRAPHICS = eINSTANCE.getArc_Arcgraphics();
 
 		/**
-		 * The meta object literal for the '<em><b>Hlinscription</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Hlinscription</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ARC__HLINSCRIPTION = eINSTANCE.getArc_Hlinscription();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl <em>Node</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl
+		 * <em>Node</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getNode()
 		 * @generated
@@ -4829,33 +5104,34 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass NODE = eINSTANCE.getNode();
 
 		/**
-		 * The meta object literal for the '<em><b>In Arcs</b></em>' reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>In Arcs</b></em>' reference list
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE__IN_ARCS = eINSTANCE.getNode_InArcs();
 
 		/**
-		 * The meta object literal for the '<em><b>Out Arcs</b></em>' reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Out Arcs</b></em>' reference list
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE__OUT_ARCS = eINSTANCE.getNode_OutArcs();
 
 		/**
-		 * The meta object literal for the '<em><b>Nodegraphics</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Nodegraphics</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NODE__NODEGRAPHICS = eINSTANCE.getNode_Nodegraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl <em>Font</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl
+		 * <em>Font</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFont()
 		 * @generated
@@ -4864,72 +5140,74 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Align</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__ALIGN = eINSTANCE.getFont_Align();
 
 		/**
-		 * The meta object literal for the '<em><b>Decoration</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Decoration</b></em>' attribute
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__DECORATION = eINSTANCE.getFont_Decoration();
 
 		/**
 		 * The meta object literal for the '<em><b>Family</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__FAMILY = eINSTANCE.getFont_Family();
 
 		/**
 		 * The meta object literal for the '<em><b>Rotation</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__ROTATION = eINSTANCE.getFont_Rotation();
 
 		/**
 		 * The meta object literal for the '<em><b>Size</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__SIZE = eINSTANCE.getFont_Size();
 
 		/**
 		 * The meta object literal for the '<em><b>Style</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__STYLE = eINSTANCE.getFont_Style();
 
 		/**
 		 * The meta object literal for the '<em><b>Weight</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute FONT__WEIGHT = eINSTANCE.getFont_Weight();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Annotation Graphics</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Annotation
+		 * Graphics</b></em>' container reference feature. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference FONT__CONTAINER_ANNOTATION_GRAPHICS = eINSTANCE.getFont_ContainerAnnotationGraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl <em>Place Node</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl
+		 * <em>Place Node</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPlaceNode()
 		 * @generated
@@ -4937,17 +5215,19 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass PLACE_NODE = eINSTANCE.getPlaceNode();
 
 		/**
-		 * The meta object literal for the '<em><b>Referencing Places</b></em>' reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Referencing Places</b></em>'
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PLACE_NODE__REFERENCING_PLACES = eINSTANCE.getPlaceNode_ReferencingPlaces();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl <em>Transition Node</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl
+		 * <em>Transition Node</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getTransitionNode()
 		 * @generated
@@ -4955,17 +5235,18 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass TRANSITION_NODE = eINSTANCE.getTransitionNode();
 
 		/**
-		 * The meta object literal for the '<em><b>Referencing Transitions</b></em>' reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Referencing Transitions</b></em>'
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TRANSITION_NODE__REFERENCING_TRANSITIONS = eINSTANCE.getTransitionNode_ReferencingTransitions();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl <em>Place</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl
+		 * <em>Place</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPlace()
 		 * @generated
@@ -4973,25 +5254,27 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass PLACE = eINSTANCE.getPlace();
 
 		/**
-		 * The meta object literal for the '<em><b>Type</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Type</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PLACE__TYPE = eINSTANCE.getPlace_Type();
 
 		/**
-		 * The meta object literal for the '<em><b>Hlinitial Marking</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Hlinitial Marking</b></em>'
+		 * containment reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PLACE__HLINITIAL_MARKING = eINSTANCE.getPlace_HlinitialMarking();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl <em>Ref Transition</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl
+		 * <em>Ref Transition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getRefTransition()
 		 * @generated
@@ -4999,17 +5282,18 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass REF_TRANSITION = eINSTANCE.getRefTransition();
 
 		/**
-		 * The meta object literal for the '<em><b>Ref</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Ref</b></em>' reference feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference REF_TRANSITION__REF = eINSTANCE.getRefTransition_Ref();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl <em>Transition</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl
+		 * <em>Transition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getTransition()
 		 * @generated
@@ -5017,17 +5301,18 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass TRANSITION = eINSTANCE.getTransition();
 
 		/**
-		 * The meta object literal for the '<em><b>Condition</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Condition</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TRANSITION__CONDITION = eINSTANCE.getTransition_Condition();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl <em>Ref Place</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl <em>Ref
+		 * Place</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getRefPlace()
 		 * @generated
@@ -5035,17 +5320,18 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass REF_PLACE = eINSTANCE.getRefPlace();
 
 		/**
-		 * The meta object literal for the '<em><b>Ref</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Ref</b></em>' reference feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference REF_PLACE__REF = eINSTANCE.getRefPlace_Ref();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AttributeImpl <em>Attribute</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AttributeImpl
+		 * <em>Attribute</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AttributeImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAttribute()
 		 * @generated
@@ -5053,9 +5339,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass ATTRIBUTE = eINSTANCE.getAttribute();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl <em>Annotation</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl
+		 * <em>Annotation</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAnnotation()
 		 * @generated
@@ -5063,17 +5350,18 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass ANNOTATION = eINSTANCE.getAnnotation();
 
 		/**
-		 * The meta object literal for the '<em><b>Annotationgraphics</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Annotationgraphics</b></em>'
+		 * containment reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANNOTATION__ANNOTATIONGRAPHICS = eINSTANCE.getAnnotation_Annotationgraphics();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl <em>Any Object</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl <em>Any
+		 * Object</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getAnyObject()
 		 * @generated
@@ -5081,17 +5369,19 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass ANY_OBJECT = eINSTANCE.getAnyObject();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Tool Info</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Tool Info</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ANY_OBJECT__CONTAINER_TOOL_INFO = eINSTANCE.getAnyObject_ContainerToolInfo();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl <em>HL Core Annotation</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl
+		 * <em>HL Core Annotation</em>}' class. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getHLCoreAnnotation()
 		 * @generated
@@ -5100,16 +5390,17 @@ public interface HlcorestructurePackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Text</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute HL_CORE_ANNOTATION__TEXT = eINSTANCE.getHLCoreAnnotation_Text();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl <em>Type</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl
+		 * <em>Type</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getType()
 		 * @generated
@@ -5117,25 +5408,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass TYPE = eINSTANCE.getType();
 
 		/**
-		 * The meta object literal for the '<em><b>Structure</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Structure</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TYPE__STRUCTURE = eINSTANCE.getType_Structure();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Place</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Place</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TYPE__CONTAINER_PLACE = eINSTANCE.getType_ContainerPlace();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl <em>HL Marking</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl <em>HL
+		 * Marking</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getHLMarking()
 		 * @generated
@@ -5143,25 +5435,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass HL_MARKING = eINSTANCE.getHLMarking();
 
 		/**
-		 * The meta object literal for the '<em><b>Structure</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Structure</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference HL_MARKING__STRUCTURE = eINSTANCE.getHLMarking_Structure();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Place</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Place</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference HL_MARKING__CONTAINER_PLACE = eINSTANCE.getHLMarking_ContainerPlace();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl <em>Condition</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl
+		 * <em>Condition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCondition()
 		 * @generated
@@ -5169,25 +5462,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass CONDITION = eINSTANCE.getCondition();
 
 		/**
-		 * The meta object literal for the '<em><b>Structure</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Structure</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference CONDITION__STRUCTURE = eINSTANCE.getCondition_Structure();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Transition</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Transition</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference CONDITION__CONTAINER_TRANSITION = eINSTANCE.getCondition_ContainerTransition();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl <em>HL Annotation</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl
+		 * <em>HL Annotation</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getHLAnnotation()
 		 * @generated
@@ -5195,25 +5489,26 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass HL_ANNOTATION = eINSTANCE.getHLAnnotation();
 
 		/**
-		 * The meta object literal for the '<em><b>Structure</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Structure</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference HL_ANNOTATION__STRUCTURE = eINSTANCE.getHLAnnotation_Structure();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Arc</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Arc</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference HL_ANNOTATION__CONTAINER_ARC = eINSTANCE.getHLAnnotation_ContainerArc();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl <em>Declaration</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl
+		 * <em>Declaration</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getDeclaration()
 		 * @generated
@@ -5221,34 +5516,36 @@ public interface HlcorestructurePackage extends EPackage {
 		EClass DECLARATION = eINSTANCE.getDeclaration();
 
 		/**
-		 * The meta object literal for the '<em><b>Structure</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Structure</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DECLARATION__STRUCTURE = eINSTANCE.getDeclaration_Structure();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Declaration Petri Net</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Declaration Petri
+		 * Net</b></em>' container reference feature. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DECLARATION__CONTAINER_DECLARATION_PETRI_NET = eINSTANCE
 				.getDeclaration_ContainerDeclarationPetriNet();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Declaration Page</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Declaration Page</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DECLARATION__CONTAINER_DECLARATION_PAGE = eINSTANCE.getDeclaration_ContainerDeclarationPage();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType <em>PN Type</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType <em>PN Type</em>}'
+		 * enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getPNType()
 		 * @generated
@@ -5256,9 +5553,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum PN_TYPE = eINSTANCE.getPNType();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color <em>CSS2 Color</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color <em>CSS2
+		 * Color</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2Color()
 		 * @generated
@@ -5266,9 +5564,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum CSS2_COLOR = eINSTANCE.getCSS2Color();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient <em>Gradient</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
+		 * <em>Gradient</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getGradient()
 		 * @generated
@@ -5276,9 +5575,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum GRADIENT = eINSTANCE.getGradient();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape <em>Line Shape</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape <em>Line
+		 * Shape</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLineShape()
 		 * @generated
@@ -5286,9 +5586,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum LINE_SHAPE = eINSTANCE.getLineShape();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign <em>Font Align</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign <em>Font
+		 * Align</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFontAlign()
 		 * @generated
@@ -5296,9 +5597,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum FONT_ALIGN = eINSTANCE.getFontAlign();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration <em>Font Decoration</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration <em>Font
+		 * Decoration</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getFontDecoration()
 		 * @generated
@@ -5306,9 +5608,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum FONT_DECORATION = eINSTANCE.getFontDecoration();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily <em>CSS2 Font Family</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily <em>CSS2
+		 * Font Family</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontFamily()
 		 * @generated
@@ -5316,9 +5619,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum CSS2_FONT_FAMILY = eINSTANCE.getCSS2FontFamily();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize <em>CSS2 Font Size</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize <em>CSS2 Font
+		 * Size</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontSize()
 		 * @generated
@@ -5326,9 +5630,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum CSS2_FONT_SIZE = eINSTANCE.getCSS2FontSize();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle <em>CSS2 Font Style</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle <em>CSS2 Font
+		 * Style</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontStyle()
 		 * @generated
@@ -5336,9 +5641,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum CSS2_FONT_STYLE = eINSTANCE.getCSS2FontStyle();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight <em>CSS2 Font Weight</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight <em>CSS2
+		 * Font Weight</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getCSS2FontWeight()
 		 * @generated
@@ -5346,9 +5652,10 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum CSS2_FONT_WEIGHT = eINSTANCE.getCSS2FontWeight();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle <em>Line Style</em>}' enum.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle <em>Line
+		 * Style</em>}' enum. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLineStyle()
 		 * @generated
@@ -5356,9 +5663,9 @@ public interface HlcorestructurePackage extends EPackage {
 		EEnum LINE_STYLE = eINSTANCE.getLineStyle();
 
 		/**
-		 * The meta object literal for the '<em>URI</em>' data type.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em>URI</em>' data type. <!-- begin-user-doc
+		 * --> <!-- end-user-doc -->
+		 * 
 		 * @see java.net.URI
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getURI()
 		 * @generated
@@ -5366,9 +5673,9 @@ public interface HlcorestructurePackage extends EPackage {
 		EDataType URI = eINSTANCE.getURI();
 
 		/**
-		 * The meta object literal for the '<em>Long String</em>' data type.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em>Long String</em>' data type. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see java.lang.StringBuffer
 		 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructurePackageImpl#getLongString()
 		 * @generated
@@ -5377,4 +5684,4 @@ public interface HlcorestructurePackage extends EPackage {
 
 	}
 
-} //HlcorestructurePackage
+} // HlcorestructurePackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Label.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Label.java
@@ -56,7 +56,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLabel()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Label extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Label.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Label.java
@@ -44,14 +44,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Label</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Label</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics <em>Toolspecifics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics
+ * <em>Toolspecifics</em>}</li>
  * </ul>
  * </p>
  *
@@ -61,15 +61,18 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Label extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel <em>Container Label</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Toolspecifics</b></em>' containment
+	 * reference list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel
+	 * <em>Container Label</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Toolspecifics</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Toolspecifics</em>' containment reference list
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Toolspecifics</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLabel_Toolspecifics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel
@@ -81,8 +84,8 @@ public interface Label extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Line.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Line.java
@@ -67,7 +67,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='line' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='line' kind='son'"
  * @generated
  */
 public interface Line extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Line.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Line.java
@@ -43,20 +43,26 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Line</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Line</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor <em>Color</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape <em>Shape</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth <em>Width</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics <em>Container Node Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics <em>Container Arc Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle <em>Style</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor
+ * <em>Color</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape
+ * <em>Shape</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth
+ * <em>Width</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics
+ * <em>Container Node Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics
+ * <em>Container Arc Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle
+ * <em>Style</em>}</li>
  * </ul>
  * </p>
  *
@@ -66,29 +72,32 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Line extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Color</b></em>' attribute.
-	 * The default value is <code>"BLACK"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Color</b></em>' attribute. The default value
+	 * is <code>"BLACK"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Color</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Color</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Color</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see #setColor(CSS2Color)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_Color()
 	 * @model default="BLACK" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='color' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='color'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	CSS2Color getColor();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor <em>Color</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getColor
+	 * <em>Color</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Color</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color
 	 * @see #getColor()
@@ -97,29 +106,32 @@ public interface Line extends EObject {
 	void setColor(CSS2Color value);
 
 	/**
-	 * Returns the value of the '<em><b>Shape</b></em>' attribute.
-	 * The default value is <code>"line"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Shape</b></em>' attribute. The default value
+	 * is <code>"line"</code>. The literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Shape</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Shape</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Shape</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape
 	 * @see #setShape(LineShape)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_Shape()
 	 * @model default="line" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='shape' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='shape'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	LineShape getShape();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape <em>Shape</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getShape
+	 * <em>Shape</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Shape</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape
 	 * @see #getShape()
@@ -128,26 +140,28 @@ public interface Line extends EObject {
 	void setShape(LineShape value);
 
 	/**
-	 * Returns the value of the '<em><b>Width</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Width</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Width</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Width</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Width</em>' attribute.
 	 * @see #setWidth(Integer)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_Width()
-	 * @model ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='width' kind='attribute'"
+	 * @model ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='width' kind='attribute'"
 	 * @generated
 	 */
 	Integer getWidth();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth <em>Width</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getWidth
+	 * <em>Width</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Width</em>' attribute.
 	 * @see #getWidth()
 	 * @generated
@@ -155,15 +169,18 @@ public interface Line extends EObject {
 	void setWidth(Integer value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Node Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Node Graphics</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine
+	 * <em>Line</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Node Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Node Graphics</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Node Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Node Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerNodeGraphics(NodeGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_ContainerNodeGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine
@@ -173,25 +190,31 @@ public interface Line extends EObject {
 	NodeGraphics getContainerNodeGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics <em>Container Node Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Node Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics
+	 * <em>Container Node Graphics</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Node Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerNodeGraphics()
 	 * @generated
 	 */
 	void setContainerNodeGraphics(NodeGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Arc Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Arc Graphics</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine
+	 * <em>Line</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Arc Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Arc Graphics</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Arc Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Arc Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerArcGraphics(ArcGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_ContainerArcGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getLine
@@ -201,25 +224,31 @@ public interface Line extends EObject {
 	ArcGraphics getContainerArcGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics <em>Container Arc Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Arc Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerArcGraphics
+	 * <em>Container Arc Graphics</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Arc Graphics</em>' container
+	 *              reference.
 	 * @see #getContainerArcGraphics()
 	 * @generated
 	 */
 	void setContainerArcGraphics(ArcGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine
+	 * <em>Line</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Annotation Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Annotation Graphics</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Annotation Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerAnnotationGraphics(AnnotationGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_ContainerAnnotationGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getLine
@@ -229,37 +258,44 @@ public interface Line extends EObject {
 	AnnotationGraphics getContainerAnnotationGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Annotation Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerAnnotationGraphics()
 	 * @generated
 	 */
 	void setContainerAnnotationGraphics(AnnotationGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Style</b></em>' attribute.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Style</b></em>' attribute. The literals are
+	 * from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Style</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Style</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Style</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle
 	 * @see #setStyle(LineStyle)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLine_Style()
-	 * @model annotation="http://www.pnml.org/models/ToPNML tag='style' kind='attribute'"
+	 * @model annotation="http://www.pnml.org/models/ToPNML tag='style'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	LineStyle getStyle();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle <em>Style</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getStyle
+	 * <em>Style</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Style</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle
 	 * @see #getStyle()
@@ -275,8 +311,8 @@ public interface Line extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineShape.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineShape.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>Line Shape</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>Line Shape</b></em>', and utility methods for working with them. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLineShape()
  * @model
  * @generated
  */
 public enum LineShape implements Enumerator {
 	/**
-	 * The '<em><b>LINE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>LINE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #LINE_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum LineShape implements Enumerator {
 	LINE(0, "LINE", "line"),
 
 	/**
-	 * The '<em><b>CURVE</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>CURVE</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #CURVE_VALUE
 	 * @generated
 	 * @ordered
@@ -68,13 +68,13 @@ public enum LineShape implements Enumerator {
 	CURVE(1, "CURVE", "curve");
 
 	/**
-	 * The '<em><b>LINE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>LINE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>LINE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>LINE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #LINE
 	 * @model literal="line"
 	 * @generated
@@ -83,13 +83,13 @@ public enum LineShape implements Enumerator {
 	public static final int LINE_VALUE = 0;
 
 	/**
-	 * The '<em><b>CURVE</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>CURVE</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>CURVE</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>CURVE</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #CURVE
 	 * @model literal="curve"
 	 * @generated
@@ -98,25 +98,25 @@ public enum LineShape implements Enumerator {
 	public static final int CURVE_VALUE = 1;
 
 	/**
-	 * An array of all the '<em><b>Line Shape</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>Line Shape</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final LineShape[] VALUES_ARRAY = new LineShape[] { LINE, CURVE, };
 
 	/**
 	 * A public read-only list of all the '<em><b>Line Shape</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<LineShape> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>Line Shape</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Line Shape</b></em>' literal with the specified literal
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static LineShape get(String literal) {
@@ -131,8 +131,8 @@ public enum LineShape implements Enumerator {
 
 	/**
 	 * Returns the '<em><b>Line Shape</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static LineShape getByName(String name) {
@@ -146,9 +146,9 @@ public enum LineShape implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Line Shape</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Line Shape</b></em>' literal with the specified integer
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static LineShape get(int value) {
@@ -162,30 +162,30 @@ public enum LineShape implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private LineShape(int value, String name, String literal) {
@@ -195,8 +195,8 @@ public enum LineShape implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -204,8 +204,8 @@ public enum LineShape implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -213,8 +213,8 @@ public enum LineShape implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -222,9 +222,9 @@ public enum LineShape implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -232,4 +232,4 @@ public enum LineShape implements Enumerator {
 		return literal;
 	}
 
-} //LineShape
+} // LineShape

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineShape.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineShape.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLineShape()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum LineShape implements Enumerator {
@@ -199,6 +199,7 @@ public enum LineShape implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -208,6 +209,7 @@ public enum LineShape implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -217,6 +219,7 @@ public enum LineShape implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineStyle.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineStyle.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>Line Style</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>Line Style</b></em>', and utility methods for working with them. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLineStyle()
  * @model
  * @generated
  */
 public enum LineStyle implements Enumerator {
 	/**
-	 * The '<em><b>SOLID</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>SOLID</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #SOLID_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum LineStyle implements Enumerator {
 	SOLID(0, "SOLID", "SOLID"),
 
 	/**
-	 * The '<em><b>DASH</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>DASH</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #DASH_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum LineStyle implements Enumerator {
 	DASH(1, "DASH", "DASH"),
 
 	/**
-	 * The '<em><b>DOT</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>DOT</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #DOT_VALUE
 	 * @generated
 	 * @ordered
@@ -78,13 +78,13 @@ public enum LineStyle implements Enumerator {
 	DOT(2, "DOT", "DOT");
 
 	/**
-	 * The '<em><b>SOLID</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>SOLID</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>SOLID</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>SOLID</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #SOLID
 	 * @model
 	 * @generated
@@ -93,13 +93,13 @@ public enum LineStyle implements Enumerator {
 	public static final int SOLID_VALUE = 0;
 
 	/**
-	 * The '<em><b>DASH</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>DASH</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>DASH</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>DASH</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #DASH
 	 * @model
 	 * @generated
@@ -108,13 +108,13 @@ public enum LineStyle implements Enumerator {
 	public static final int DASH_VALUE = 1;
 
 	/**
-	 * The '<em><b>DOT</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>DOT</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>DOT</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>DOT</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #DOT
 	 * @model
 	 * @generated
@@ -123,25 +123,25 @@ public enum LineStyle implements Enumerator {
 	public static final int DOT_VALUE = 2;
 
 	/**
-	 * An array of all the '<em><b>Line Style</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>Line Style</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final LineStyle[] VALUES_ARRAY = new LineStyle[] { SOLID, DASH, DOT, };
 
 	/**
 	 * A public read-only list of all the '<em><b>Line Style</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<LineStyle> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>Line Style</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Line Style</b></em>' literal with the specified literal
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static LineStyle get(String literal) {
@@ -156,8 +156,8 @@ public enum LineStyle implements Enumerator {
 
 	/**
 	 * Returns the '<em><b>Line Style</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static LineStyle getByName(String name) {
@@ -171,9 +171,9 @@ public enum LineStyle implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>Line Style</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>Line Style</b></em>' literal with the specified integer
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static LineStyle get(int value) {
@@ -189,30 +189,30 @@ public enum LineStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private LineStyle(int value, String name, String literal) {
@@ -222,8 +222,8 @@ public enum LineStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -231,8 +231,8 @@ public enum LineStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -240,8 +240,8 @@ public enum LineStyle implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -249,9 +249,9 @@ public enum LineStyle implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,4 +259,4 @@ public enum LineStyle implements Enumerator {
 		return literal;
 	}
 
-} //LineStyle
+} // LineStyle

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineStyle.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/LineStyle.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getLineStyle()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum LineStyle implements Enumerator {
@@ -226,6 +226,7 @@ public enum LineStyle implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -235,6 +236,7 @@ public enum LineStyle implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -244,6 +246,7 @@ public enum LineStyle implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Name.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Name.java
@@ -42,16 +42,18 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Name</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Name</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText <em>Text</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet <em>Container Name Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject <em>Container Name Pn Object</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText
+ * <em>Text</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet
+ * <em>Container Name Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject
+ * <em>Container Name Pn Object</em>}</li>
  * </ul>
  * </p>
  *
@@ -61,13 +63,14 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Name extends Annotation {
 	/**
-	 * Returns the value of the '<em><b>Text</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Text</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Text</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Text</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Text</em>' attribute.
 	 * @see #setText(String)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getName_Text()
@@ -78,9 +81,10 @@ public interface Name extends Annotation {
 	String getText();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText <em>Text</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getText
+	 * <em>Text</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Text</em>' attribute.
 	 * @see #getText()
 	 * @generated
@@ -88,15 +92,18 @@ public interface Name extends Annotation {
 	void setText(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Name Petri Net</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Name Petri Net</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Name Petri Net</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Name Petri Net</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Name Petri Net</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Name Petri Net</em>' container
+	 *         reference.
 	 * @see #setContainerNamePetriNet(PetriNet)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getName_ContainerNamePetriNet()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName
@@ -106,25 +113,31 @@ public interface Name extends Annotation {
 	PetriNet getContainerNamePetriNet();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet <em>Container Name Petri Net</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Name Petri Net</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet
+	 * <em>Container Name Petri Net</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Name Petri Net</em>'
+	 *              container reference.
 	 * @see #getContainerNamePetriNet()
 	 * @generated
 	 */
 	void setContainerNamePetriNet(PetriNet value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Name Pn Object</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Name Pn Object</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Name Pn Object</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Name Pn Object</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Name Pn Object</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Name Pn Object</em>' container
+	 *         reference.
 	 * @see #setContainerNamePnObject(PnObject)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getName_ContainerNamePnObject()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName
@@ -134,10 +147,13 @@ public interface Name extends Annotation {
 	PnObject getContainerNamePnObject();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject <em>Container Name Pn Object</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Name Pn Object</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject
+	 * <em>Container Name Pn Object</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Name Pn Object</em>'
+	 *              container reference.
 	 * @see #getContainerNamePnObject()
 	 * @generated
 	 */
@@ -153,8 +169,8 @@ public interface Name extends Annotation {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Name.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Name.java
@@ -59,6 +59,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getName_()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='name' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Name extends Annotation {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Node.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Node.java
@@ -59,7 +59,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNode()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Node extends PnObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Node.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Node.java
@@ -43,16 +43,18 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Node</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Node</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs <em>In Arcs</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs <em>Out Arcs</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics <em>Nodegraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getInArcs <em>In
+ * Arcs</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getOutArcs <em>Out
+ * Arcs</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics
+ * <em>Nodegraphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -62,15 +64,17 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Node extends PnObject {
 	/**
-	 * Returns the value of the '<em><b>In Arcs</b></em>' reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget <em>Target</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>In Arcs</b></em>' reference list. The list
+	 * contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc}.
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget
+	 * <em>Target</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>In Arcs</em>' reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>In Arcs</em>' reference list isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>In Arcs</em>' reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNode_InArcs()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getTarget
@@ -80,15 +84,17 @@ public interface Node extends PnObject {
 	List<Arc> getInArcs();
 
 	/**
-	 * Returns the value of the '<em><b>Out Arcs</b></em>' reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource <em>Source</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Out Arcs</b></em>' reference list. The list
+	 * contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc}.
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource
+	 * <em>Source</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Out Arcs</em>' reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Out Arcs</em>' reference list isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Out Arcs</em>' reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNode_OutArcs()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc#getSource
@@ -98,14 +104,16 @@ public interface Node extends PnObject {
 	List<Arc> getOutArcs();
 
 	/**
-	 * Returns the value of the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode <em>Container Node</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Nodegraphics</b></em>' containment
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode
+	 * <em>Container Node</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Nodegraphics</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Nodegraphics</em>' containment reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Nodegraphics</em>' containment reference.
 	 * @see #setNodegraphics(NodeGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNode_Nodegraphics()
@@ -117,10 +125,13 @@ public interface Node extends PnObject {
 	NodeGraphics getNodegraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics <em>Nodegraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Nodegraphics</em>' containment reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics
+	 * <em>Nodegraphics</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Nodegraphics</em>' containment
+	 *              reference.
 	 * @see #getNodegraphics()
 	 * @generated
 	 */
@@ -130,8 +141,8 @@ public interface Node extends PnObject {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/NodeGraphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/NodeGraphics.java
@@ -42,36 +42,44 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Node Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Node
+ * Graphics</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition <em>Position</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension <em>Dimension</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill <em>Fill</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine <em>Line</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode <em>Container Node</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage <em>Container Page</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition
+ * <em>Position</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension
+ * <em>Dimension</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill
+ * <em>Fill</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine
+ * <em>Line</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode
+ * <em>Container Node</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage
+ * <em>Container Page</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics'
+ *        kind='son'"
  * @generated
  */
 public interface NodeGraphics extends Graphics {
 	/**
-	 * Returns the value of the '<em><b>Position</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics <em>Container PNode Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Position</b></em>' containment reference. It
+	 * is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics
+	 * <em>Container PNode Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Position</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Position</em>' containment reference.
 	 * @see #setPosition(Position)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics_Position()
@@ -83,9 +91,11 @@ public interface NodeGraphics extends Graphics {
 	Position getPosition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition <em>Position</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition
+	 * <em>Position</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Position</em>' containment reference.
 	 * @see #getPosition()
 	 * @generated
@@ -94,13 +104,15 @@ public interface NodeGraphics extends Graphics {
 
 	/**
 	 * Returns the value of the '<em><b>Dimension</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics <em>Container DNode Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension#getContainerDNodeGraphics
+	 * <em>Container DNode Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Dimension</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Dimension</em>' containment reference.
 	 * @see #setDimension(Dimension)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics_Dimension()
@@ -112,9 +124,11 @@ public interface NodeGraphics extends Graphics {
 	Dimension getDimension();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension <em>Dimension</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getDimension
+	 * <em>Dimension</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Dimension</em>' containment reference.
 	 * @see #getDimension()
 	 * @generated
@@ -122,14 +136,16 @@ public interface NodeGraphics extends Graphics {
 	void setDimension(Dimension value);
 
 	/**
-	 * Returns the value of the '<em><b>Fill</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics <em>Container Node Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Fill</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill#getContainerNodeGraphics
+	 * <em>Container Node Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Fill</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Fill</em>' containment reference.
 	 * @see #setFill(Fill)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics_Fill()
@@ -141,9 +157,11 @@ public interface NodeGraphics extends Graphics {
 	Fill getFill();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill <em>Fill</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getFill
+	 * <em>Fill</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Fill</em>' containment reference.
 	 * @see #getFill()
 	 * @generated
@@ -151,14 +169,16 @@ public interface NodeGraphics extends Graphics {
 	void setFill(Fill value);
 
 	/**
-	 * Returns the value of the '<em><b>Line</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics <em>Container Node Graphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Line</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line#getContainerNodeGraphics
+	 * <em>Container Node Graphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Line</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Line</em>' containment reference.
 	 * @see #setLine(Line)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics_Line()
@@ -170,9 +190,11 @@ public interface NodeGraphics extends Graphics {
 	Line getLine();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine <em>Line</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getLine
+	 * <em>Line</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Line</em>' containment reference.
 	 * @see #getLine()
 	 * @generated
@@ -180,14 +202,16 @@ public interface NodeGraphics extends Graphics {
 	void setLine(Line value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Node</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics <em>Nodegraphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Node</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node#getNodegraphics
+	 * <em>Nodegraphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Node</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Node</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Node</em>' container reference.
 	 * @see #setContainerNode(Node)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics_ContainerNode()
@@ -198,24 +222,29 @@ public interface NodeGraphics extends Graphics {
 	Node getContainerNode();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode <em>Container Node</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Node</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerNode
+	 * <em>Container Node</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Node</em>' container
+	 *              reference.
 	 * @see #getContainerNode()
 	 * @generated
 	 */
 	void setContainerNode(Node value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Page</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics <em>Nodegraphics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Page</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics
+	 * <em>Nodegraphics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Page</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Page</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Page</em>' container reference.
 	 * @see #setContainerPage(Page)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics_ContainerPage()
@@ -226,10 +255,13 @@ public interface NodeGraphics extends Graphics {
 	Page getContainerPage();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage <em>Container Page</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Page</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage
+	 * <em>Container Page</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Page</em>' container
+	 *              reference.
 	 * @see #getContainerPage()
 	 * @generated
 	 */
@@ -245,8 +277,8 @@ public interface NodeGraphics extends Graphics {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/NodeGraphics.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/NodeGraphics.java
@@ -64,7 +64,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getNodeGraphics()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='graphics'
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='graphics'
  *        kind='son'"
  * @generated
  */

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Offset.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Offset.java
@@ -42,14 +42,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Offset</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Offset</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -59,15 +59,18 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Offset extends Coordinate {
 	/**
-	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset <em>Offset</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Annotation Graphics</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset
+	 * <em>Offset</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Annotation Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Annotation Graphics</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Annotation Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerAnnotationGraphics(AnnotationGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getOffset_ContainerAnnotationGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics#getOffset
@@ -77,10 +80,13 @@ public interface Offset extends Coordinate {
 	AnnotationGraphics getContainerAnnotationGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Annotation Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset#getContainerAnnotationGraphics
+	 * <em>Container Annotation Graphics</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Annotation Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerAnnotationGraphics()
 	 * @generated
 	 */
@@ -96,8 +102,8 @@ public interface Offset extends Coordinate {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Offset.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Offset.java
@@ -55,6 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getOffset()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='offset' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Offset extends Coordinate {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PNType.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PNType.java
@@ -38,19 +38,19 @@ import java.util.List;
 import org.eclipse.emf.common.util.Enumerator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the literals of the enumeration '<em><b>PN Type</b></em>',
- * and utility methods for working with them.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the literals of the enumeration
+ * '<em><b>PN Type</b></em>', and utility methods for working with them. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPNType()
  * @model
  * @generated
  */
 public enum PNType implements Enumerator {
 	/**
-	 * The '<em><b>SYMNET</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>SYMNET</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #SYMNET_VALUE
 	 * @generated
 	 * @ordered
@@ -58,9 +58,9 @@ public enum PNType implements Enumerator {
 	SYMNET(2, "SYMNET", "http://www.pnml.org/version-2009/grammar/symmetricnet"),
 
 	/**
-	 * The '<em><b>COREMODEL</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>COREMODEL</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #COREMODEL_VALUE
 	 * @generated
 	 * @ordered
@@ -68,9 +68,9 @@ public enum PNType implements Enumerator {
 	COREMODEL(0, "COREMODEL", "http://www.pnml.org/version-2009/grammar/pnmlcoremodel"),
 
 	/**
-	 * The '<em><b>PTNET</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>PTNET</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #PTNET_VALUE
 	 * @generated
 	 * @ordered
@@ -78,9 +78,9 @@ public enum PNType implements Enumerator {
 	PTNET(1, "PTNET", "http://www.pnml.org/version-2009/grammar/ptnet"),
 
 	/**
-	 * The '<em><b>HLPN</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>HLPN</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #HLPN_VALUE
 	 * @generated
 	 * @ordered
@@ -88,9 +88,9 @@ public enum PNType implements Enumerator {
 	HLPN(3, "HLPN", "http://www.pnml.org/version-2009/grammar/highlevelnet"),
 
 	/**
-	 * The '<em><b>PTHLPN</b></em>' literal object.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The '<em><b>PTHLPN</b></em>' literal object. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #PTHLPN_VALUE
 	 * @generated
 	 * @ordered
@@ -98,13 +98,13 @@ public enum PNType implements Enumerator {
 	PTHLPN(4, "PTHLPN", "http://www.pnml.org/version-2009/grammar/pt-hlpng");
 
 	/**
-	 * The '<em><b>SYMNET</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>SYMNET</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>SYMNET</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>SYMNET</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #SYMNET
 	 * @model literal="http://www.pnml.org/version-2009/grammar/symmetricnet"
 	 * @generated
@@ -113,13 +113,13 @@ public enum PNType implements Enumerator {
 	public static final int SYMNET_VALUE = 2;
 
 	/**
-	 * The '<em><b>COREMODEL</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>COREMODEL</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of '<em><b>COREMODEL</b></em>' literal object isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #COREMODEL
 	 * @model literal="http://www.pnml.org/version-2009/grammar/pnmlcoremodel"
 	 * @generated
@@ -128,13 +128,13 @@ public enum PNType implements Enumerator {
 	public static final int COREMODEL_VALUE = 0;
 
 	/**
-	 * The '<em><b>PTNET</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>PTNET</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>PTNET</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>PTNET</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #PTNET
 	 * @model literal="http://www.pnml.org/version-2009/grammar/ptnet"
 	 * @generated
@@ -143,13 +143,13 @@ public enum PNType implements Enumerator {
 	public static final int PTNET_VALUE = 1;
 
 	/**
-	 * The '<em><b>HLPN</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>HLPN</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>HLPN</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>HLPN</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #HLPN
 	 * @model literal="http://www.pnml.org/version-2009/grammar/highlevelnet"
 	 * @generated
@@ -158,13 +158,13 @@ public enum PNType implements Enumerator {
 	public static final int HLPN_VALUE = 3;
 
 	/**
-	 * The '<em><b>PTHLPN</b></em>' literal value.
-	 * <!-- begin-user-doc -->
+	 * The '<em><b>PTHLPN</b></em>' literal value. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of '<em><b>PTHLPN</b></em>' literal object isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of '<em><b>PTHLPN</b></em>' literal object isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #PTHLPN
 	 * @model literal="http://www.pnml.org/version-2009/grammar/pt-hlpng"
 	 * @generated
@@ -173,25 +173,25 @@ public enum PNType implements Enumerator {
 	public static final int PTHLPN_VALUE = 4;
 
 	/**
-	 * An array of all the '<em><b>PN Type</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * An array of all the '<em><b>PN Type</b></em>' enumerators. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static final PNType[] VALUES_ARRAY = new PNType[] { SYMNET, COREMODEL, PTNET, HLPN, PTHLPN, };
 
 	/**
 	 * A public read-only list of all the '<em><b>PN Type</b></em>' enumerators.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final List<PNType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
 
 	/**
-	 * Returns the '<em><b>PN Type</b></em>' literal with the specified literal value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>PN Type</b></em>' literal with the specified literal
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static PNType get(String literal) {
@@ -205,9 +205,9 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>PN Type</b></em>' literal with the specified name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>PN Type</b></em>' literal with the specified name. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static PNType getByName(String name) {
@@ -221,9 +221,9 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * Returns the '<em><b>PN Type</b></em>' literal with the specified integer value.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the '<em><b>PN Type</b></em>' literal with the specified integer
+	 * value. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static PNType get(int value) {
@@ -243,30 +243,30 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final int value;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String name;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private final String literal;
 
 	/**
-	 * Only this class can construct instances.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Only this class can construct instances. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private PNType(int value, String name, String literal) {
@@ -276,8 +276,8 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public int getValue() {
@@ -285,8 +285,8 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getName() {
@@ -294,8 +294,8 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String getLiteral() {
@@ -303,9 +303,9 @@ public enum PNType implements Enumerator {
 	}
 
 	/**
-	 * Returns the literal value of the enumerator, which is its string representation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the literal value of the enumerator, which is its string
+	 * representation. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -313,4 +313,4 @@ public enum PNType implements Enumerator {
 		return literal;
 	}
 
-} //PNType
+} // PNType

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PNType.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PNType.java
@@ -43,7 +43,7 @@ import org.eclipse.emf.common.util.Enumerator;
  * end-user-doc -->
  * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPNType()
- * @model
+ * @model annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public enum PNType implements Enumerator {
@@ -280,6 +280,7 @@ public enum PNType implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public int getValue() {
 		return value;
 	}
@@ -289,6 +290,7 @@ public enum PNType implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getName() {
 		return name;
 	}
@@ -298,6 +300,7 @@ public enum PNType implements Enumerator {
 	 * 
 	 * @generated
 	 */
+	@Override
 	public String getLiteral() {
 		return literal;
 	}

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Page.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Page.java
@@ -61,7 +61,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPage()
- * @model annotation="http://www.pnml.org/models/ToPNML kind='son' tag='page'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML kind='son' tag='page'"
  * @generated
  */
 public interface Page extends PnObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Page.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Page.java
@@ -43,17 +43,20 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Page</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Page</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects <em>Objects</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet <em>Container Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics <em>Nodegraphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects
+ * <em>Objects</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet
+ * <em>Container Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics
+ * <em>Nodegraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -63,15 +66,18 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Page extends PnObject {
 	/**
-	 * Returns the value of the '<em><b>Objects</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage <em>Container Page</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Objects</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage
+	 * <em>Container Page</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Objects</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Objects</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Objects</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPage_Objects()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage
@@ -82,14 +88,16 @@ public interface Page extends PnObject {
 	List<PnObject> getObjects();
 
 	/**
-	 * Returns the value of the '<em><b>Container Petri Net</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages <em>Pages</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Petri Net</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages
+	 * <em>Pages</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Petri Net</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Petri Net</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Petri Net</em>' container reference.
 	 * @see #setContainerPetriNet(PetriNet)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPage_ContainerPetriNet()
@@ -100,24 +108,29 @@ public interface Page extends PnObject {
 	PetriNet getContainerPetriNet();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet <em>Container Petri Net</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet
+	 * <em>Container Petri Net</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Petri Net</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Petri Net</em>' container
+	 *              reference.
 	 * @see #getContainerPetriNet()
 	 * @generated
 	 */
 	void setContainerPetriNet(PetriNet value);
 
 	/**
-	 * Returns the value of the '<em><b>Nodegraphics</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage <em>Container Page</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Nodegraphics</b></em>' containment
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getContainerPage
+	 * <em>Container Page</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Nodegraphics</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Nodegraphics</em>' containment reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Nodegraphics</em>' containment reference.
 	 * @see #setNodegraphics(NodeGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPage_Nodegraphics()
@@ -129,25 +142,31 @@ public interface Page extends PnObject {
 	NodeGraphics getNodegraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics <em>Nodegraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Nodegraphics</em>' containment reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getNodegraphics
+	 * <em>Nodegraphics</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Nodegraphics</em>' containment
+	 *              reference.
 	 * @see #getNodegraphics()
 	 * @generated
 	 */
 	void setNodegraphics(NodeGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Declaration</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage <em>Container Declaration Page</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Declaration</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage
+	 * <em>Container Declaration Page</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Declaration</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Declaration</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Declaration</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPage_Declaration()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPage
@@ -167,8 +186,8 @@ public interface Page extends PnObject {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNet.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNet.java
@@ -68,7 +68,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet()
- * @model annotation="http://www.pnml.org/models/ToPNML kind='son' tag='net'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML kind='son' tag='net'"
  * @generated
  */
 public interface PetriNet extends EObject {
@@ -176,7 +177,8 @@ public interface PetriNet extends EObject {
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Name()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet
 	 * @model opposite="containerNamePetriNet" containment="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 *        annotation="redefines" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Name getName();

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNet.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNet.java
@@ -44,20 +44,26 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Petri Net</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Petri
+ * Net</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId <em>Id</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType <em>Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages <em>Pages</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName <em>Name</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics <em>Toolspecifics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc <em>Container Petri Net Doc</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId
+ * <em>Id</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType
+ * <em>Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getPages
+ * <em>Pages</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName
+ * <em>Name</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics
+ * <em>Toolspecifics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc
+ * <em>Container Petri Net Doc</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -67,14 +73,14 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface PetriNet extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Id</b></em>' attribute.
-	 * The default value is <code>""</code>.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute. The default value is
+	 * <code>""</code>. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Id</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Id</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Id</em>' attribute.
 	 * @see #setId(String)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Id()
@@ -85,9 +91,10 @@ public interface PetriNet extends EObject {
 	String getId();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getId
+	 * <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Id</em>' attribute.
 	 * @see #getId()
 	 * @generated
@@ -95,29 +102,34 @@ public interface PetriNet extends EObject {
 	void setId(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Type</b></em>' attribute.
-	 * The default value is <code>"http://www.pnml.org/version-2009/grammar/pt-hlpng"</code>.
-	 * The literals are from the enumeration {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Type</b></em>' attribute. The default value
+	 * is <code>"http://www.pnml.org/version-2009/grammar/pt-hlpng"</code>. The
+	 * literals are from the enumeration
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType}. <!-- begin-user-doc
+	 * -->
 	 * <p>
-	 * If the meaning of the '<em>Type</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Type</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Type</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType
 	 * @see #setType(PNType)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Type()
-	 * @model default="http://www.pnml.org/version-2009/grammar/pt-hlpng" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='type' kind='attribute'"
+	 * @model default="http://www.pnml.org/version-2009/grammar/pt-hlpng"
+	 *        required="true" ordered="false"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='type'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	PNType getType();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getType
+	 * <em>Type</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Type</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType
 	 * @see #getType()
@@ -127,32 +139,38 @@ public interface PetriNet extends EObject {
 
 	/**
 	 * Returns the value of the '<em><b>Pages</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet <em>Container Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
+	 * The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page}. It is bidirectional
+	 * and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet
+	 * <em>Container Petri Net</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Pages</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Pages</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Pages</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Pages()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getContainerPetriNet
-	 * @model opposite="containerPetriNet" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerPetriNet" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	List<Page> getPages();
 
 	/**
-	 * Returns the value of the '<em><b>Name</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet <em>Container Name Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePetriNet
+	 * <em>Container Name Petri Net</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Name</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Name</em>' containment reference.
 	 * @see #setName(Name)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Name()
@@ -164,9 +182,11 @@ public interface PetriNet extends EObject {
 	Name getName();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName <em>Name</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getName
+	 * <em>Name</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Name</em>' containment reference.
 	 * @see #getName()
 	 * @generated
@@ -174,15 +194,18 @@ public interface PetriNet extends EObject {
 	void setName(Name value);
 
 	/**
-	 * Returns the value of the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet <em>Container Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Toolspecifics</b></em>' containment
+	 * reference list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet
+	 * <em>Container Petri Net</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Toolspecifics</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Toolspecifics</em>' containment reference list
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Toolspecifics</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Toolspecifics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet
@@ -193,15 +216,18 @@ public interface PetriNet extends EObject {
 	List<ToolInfo> getToolspecifics();
 
 	/**
-	 * Returns the value of the '<em><b>Container Petri Net Doc</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets <em>Nets</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Petri Net Doc</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets
+	 * <em>Nets</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Petri Net Doc</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Petri Net Doc</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Petri Net Doc</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Petri Net Doc</em>' container
+	 *         reference.
 	 * @see #setContainerPetriNetDoc(PetriNetDoc)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_ContainerPetriNetDoc()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets
@@ -211,25 +237,31 @@ public interface PetriNet extends EObject {
 	PetriNetDoc getContainerPetriNetDoc();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc <em>Container Petri Net Doc</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Petri Net Doc</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc
+	 * <em>Container Petri Net Doc</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Petri Net Doc</em>'
+	 *              container reference.
 	 * @see #getContainerPetriNetDoc()
 	 * @generated
 	 */
 	void setContainerPetriNetDoc(PetriNetDoc value);
 
 	/**
-	 * Returns the value of the '<em><b>Declaration</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet <em>Container Declaration Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Declaration</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet
+	 * <em>Container Declaration Petri Net</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Declaration</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Declaration</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Declaration</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNet_Declaration()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getContainerDeclarationPetriNet
@@ -247,8 +279,8 @@ public interface PetriNet extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNetDoc.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNetDoc.java
@@ -44,15 +44,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Petri Net Doc</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Petri
+ * Net Doc</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets <em>Nets</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getXmlns <em>Xmlns</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getNets
+ * <em>Nets</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc#getXmlns
+ * <em>Xmlns</em>}</li>
  * </ul>
  * </p>
  *
@@ -63,36 +64,43 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 public interface PetriNetDoc extends EObject {
 	/**
 	 * Returns the value of the '<em><b>Nets</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc <em>Container Petri Net Doc</em>}'.
-	 * <!-- begin-user-doc -->
+	 * The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc
+	 * <em>Container Petri Net Doc</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Nets</em>' containment reference list isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Nets</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNetDoc_Nets()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getContainerPetriNetDoc
-	 * @model opposite="containerPetriNetDoc" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerPetriNetDoc" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	List<PetriNet> getNets();
 
 	/**
-	 * Returns the value of the '<em><b>Xmlns</b></em>' attribute.
-	 * The default value is <code>"http://www.pnml.org/version-2009/grammar/pnml"</code>.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Xmlns</b></em>' attribute. The default value
+	 * is <code>"http://www.pnml.org/version-2009/grammar/pnml"</code>. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Xmlns</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Xmlns</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Xmlns</em>' attribute.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNetDoc_Xmlns()
-	 * @model default="http://www.pnml.org/version-2009/grammar/pnml" changeable="false" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='xmlns' kind='attribute'"
+	 * @model default="http://www.pnml.org/version-2009/grammar/pnml"
+	 *        changeable="false" ordered="false"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='xmlns'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	String getXmlns();
@@ -105,8 +113,8 @@ public interface PetriNetDoc extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNetDoc.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PetriNetDoc.java
@@ -58,7 +58,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPetriNetDoc()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='pnml' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='pnml' kind='son'"
  * @generated
  */
 public interface PetriNetDoc extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Place.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Place.java
@@ -56,7 +56,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPlace()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='place' kind='son'"
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='place' kind='son'"
  * @generated
  */
 public interface Place extends PlaceNode {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Place.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Place.java
@@ -42,15 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Place</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Place</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType <em>Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking <em>Hlinitial Marking</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType
+ * <em>Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking
+ * <em>Hlinitial Marking</em>}</li>
  * </ul>
  * </p>
  *
@@ -60,14 +61,16 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface Place extends PlaceNode {
 	/**
-	 * Returns the value of the '<em><b>Type</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace <em>Container Place</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Type</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace
+	 * <em>Container Place</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Type</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Type</em>' containment reference.
 	 * @see #setType(Type)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPlace_Type()
@@ -79,9 +82,11 @@ public interface Place extends PlaceNode {
 	Type getType();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType <em>Type</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType
+	 * <em>Type</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Type</em>' containment reference.
 	 * @see #getType()
 	 * @generated
@@ -89,14 +94,16 @@ public interface Place extends PlaceNode {
 	void setType(Type value);
 
 	/**
-	 * Returns the value of the '<em><b>Hlinitial Marking</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace <em>Container Place</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Hlinitial Marking</b></em>' containment
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getContainerPlace
+	 * <em>Container Place</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Hlinitial Marking</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Hlinitial Marking</em>' containment reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Hlinitial Marking</em>' containment reference.
 	 * @see #setHlinitialMarking(HLMarking)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPlace_HlinitialMarking()
@@ -108,10 +115,13 @@ public interface Place extends PlaceNode {
 	HLMarking getHlinitialMarking();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking <em>Hlinitial Marking</em>}' containment reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getHlinitialMarking
+	 * <em>Hlinitial Marking</em>}' containment reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Hlinitial Marking</em>' containment reference.
+	 * 
+	 * @param value the new value of the '<em>Hlinitial Marking</em>' containment
+	 *              reference.
 	 * @see #getHlinitialMarking()
 	 * @generated
 	 */
@@ -127,8 +137,8 @@ public interface Place extends PlaceNode {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PlaceNode.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PlaceNode.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPlaceNode()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface PlaceNode extends Node {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PlaceNode.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PlaceNode.java
@@ -43,14 +43,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Place Node</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Place
+ * Node</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces <em>Referencing Places</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces
+ * <em>Referencing Places</em>}</li>
  * </ul>
  * </p>
  *
@@ -61,14 +61,17 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 public interface PlaceNode extends Node {
 	/**
 	 * Returns the value of the '<em><b>Referencing Places</b></em>' reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef <em>Ref</em>}'.
-	 * <!-- begin-user-doc -->
+	 * The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef
+	 * <em>Ref</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Referencing Places</em>' reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Referencing Places</em>' reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Referencing Places</em>' reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPlaceNode_ReferencingPlaces()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef
@@ -81,8 +84,8 @@ public interface PlaceNode extends Node {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PnObject.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PnObject.java
@@ -62,7 +62,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPnObject()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface PnObject extends EObject {
@@ -111,7 +111,8 @@ public interface PnObject extends EObject {
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPnObject_Name()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject
 	 * @model opposite="containerNamePnObject" containment="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 *        annotation="redefines" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Name getName();

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PnObject.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/PnObject.java
@@ -44,17 +44,20 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Pn Object</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Pn
+ * Object</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId <em>Id</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName <em>Name</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics <em>Toolspecifics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage <em>Container Page</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId
+ * <em>Id</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName
+ * <em>Name</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics
+ * <em>Toolspecifics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage
+ * <em>Container Page</em>}</li>
  * </ul>
  * </p>
  *
@@ -64,13 +67,14 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface PnObject extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * -->
 	 * <p>
-	 * If the meaning of the '<em>Id</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Id</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Id</em>' attribute.
 	 * @see #setId(String)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPnObject_Id()
@@ -81,9 +85,10 @@ public interface PnObject extends EObject {
 	String getId();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getId
+	 * <em>Id</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Id</em>' attribute.
 	 * @see #getId()
 	 * @generated
@@ -91,14 +96,16 @@ public interface PnObject extends EObject {
 	void setId(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Name</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject <em>Container Name Pn Object</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name#getContainerNamePnObject
+	 * <em>Container Name Pn Object</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Name</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Name</em>' containment reference.
 	 * @see #setName(Name)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPnObject_Name()
@@ -110,9 +117,11 @@ public interface PnObject extends EObject {
 	Name getName();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName <em>Name</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getName
+	 * <em>Name</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Name</em>' containment reference.
 	 * @see #getName()
 	 * @generated
@@ -120,15 +129,18 @@ public interface PnObject extends EObject {
 	void setName(Name value);
 
 	/**
-	 * Returns the value of the '<em><b>Toolspecifics</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject <em>Container Pn Object</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Toolspecifics</b></em>' containment
+	 * reference list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject
+	 * <em>Container Pn Object</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Toolspecifics</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Toolspecifics</em>' containment reference list
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Toolspecifics</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPnObject_Toolspecifics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject
@@ -139,14 +151,16 @@ public interface PnObject extends EObject {
 	List<ToolInfo> getToolspecifics();
 
 	/**
-	 * Returns the value of the '<em><b>Container Page</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects <em>Objects</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Page</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page#getObjects
+	 * <em>Objects</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Page</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Page</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Page</em>' container reference.
 	 * @see #setContainerPage(Page)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPnObject_ContainerPage()
@@ -157,10 +171,13 @@ public interface PnObject extends EObject {
 	Page getContainerPage();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage <em>Container Page</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Page</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getContainerPage
+	 * <em>Container Page</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Page</em>' container
+	 *              reference.
 	 * @see #getContainerPage()
 	 * @generated
 	 */
@@ -168,8 +185,8 @@ public interface PnObject extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Position.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Position.java
@@ -42,33 +42,38 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Position</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Position</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics <em>Container Arc Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics <em>Container PNode Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics
+ * <em>Container Arc Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics
+ * <em>Container PNode Graphics</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPosition()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='position' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='position'
+ *        kind='son'"
  * @generated
  */
 public interface Position extends Coordinate {
 	/**
-	 * Returns the value of the '<em><b>Container Arc Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions <em>Positions</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Arc Graphics</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions
+	 * <em>Positions</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Arc Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Arc Graphics</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Arc Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Arc Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerArcGraphics(ArcGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPosition_ContainerArcGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics#getPositions
@@ -78,25 +83,31 @@ public interface Position extends Coordinate {
 	ArcGraphics getContainerArcGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics <em>Container Arc Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Arc Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerArcGraphics
+	 * <em>Container Arc Graphics</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Arc Graphics</em>' container
+	 *              reference.
 	 * @see #getContainerArcGraphics()
 	 * @generated
 	 */
 	void setContainerArcGraphics(ArcGraphics value);
 
 	/**
-	 * Returns the value of the '<em><b>Container PNode Graphics</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition <em>Position</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container PNode Graphics</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition
+	 * <em>Position</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container PNode Graphics</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container PNode Graphics</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container PNode Graphics</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container PNode Graphics</em>' container
+	 *         reference.
 	 * @see #setContainerPNodeGraphics(NodeGraphics)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPosition_ContainerPNodeGraphics()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics#getPosition
@@ -106,10 +117,13 @@ public interface Position extends Coordinate {
 	NodeGraphics getContainerPNodeGraphics();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics <em>Container PNode Graphics</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container PNode Graphics</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position#getContainerPNodeGraphics
+	 * <em>Container PNode Graphics</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container PNode Graphics</em>'
+	 *              container reference.
 	 * @see #getContainerPNodeGraphics()
 	 * @generated
 	 */
@@ -125,8 +139,8 @@ public interface Position extends Coordinate {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Position.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Position.java
@@ -57,7 +57,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getPosition()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='position'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Position extends Coordinate {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefPlace.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefPlace.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getRefPlace()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='referencePlace'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface RefPlace extends PlaceNode {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefPlace.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefPlace.java
@@ -42,31 +42,34 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Ref Place</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Ref
+ * Place</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef <em>Ref</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef
+ * <em>Ref</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getRefPlace()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='referencePlace' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='referencePlace'
+ *        kind='son'"
  * @generated
  */
 public interface RefPlace extends PlaceNode {
 	/**
-	 * Returns the value of the '<em><b>Ref</b></em>' reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces <em>Referencing Places</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Ref</b></em>' reference. It is bidirectional
+	 * and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode#getReferencingPlaces
+	 * <em>Referencing Places</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Ref</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Ref</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Ref</em>' reference.
 	 * @see #setRef(PlaceNode)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getRefPlace_Ref()
@@ -78,9 +81,10 @@ public interface RefPlace extends PlaceNode {
 	PlaceNode getRef();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef <em>Ref</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace#getRef
+	 * <em>Ref</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Ref</em>' reference.
 	 * @see #getRef()
 	 * @generated
@@ -97,8 +101,8 @@ public interface RefPlace extends PlaceNode {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefTransition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefTransition.java
@@ -56,6 +56,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getRefTransition()
  * @model annotation="http://www.pnml.org/models/ToPNML
  *        tag='referenceTransition' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface RefTransition extends TransitionNode {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefTransition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/RefTransition.java
@@ -42,31 +42,34 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Ref Transition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Ref
+ * Transition</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef <em>Ref</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef
+ * <em>Ref</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getRefTransition()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='referenceTransition' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML
+ *        tag='referenceTransition' kind='son'"
  * @generated
  */
 public interface RefTransition extends TransitionNode {
 	/**
-	 * Returns the value of the '<em><b>Ref</b></em>' reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions <em>Referencing Transitions</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Ref</b></em>' reference. It is bidirectional
+	 * and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions
+	 * <em>Referencing Transitions</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Ref</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Ref</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Ref</em>' reference.
 	 * @see #setRef(TransitionNode)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getRefTransition_Ref()
@@ -78,9 +81,10 @@ public interface RefTransition extends TransitionNode {
 	TransitionNode getRef();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef <em>Ref</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef
+	 * <em>Ref</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Ref</em>' reference.
 	 * @see #getRef()
 	 * @generated
@@ -97,8 +101,8 @@ public interface RefTransition extends TransitionNode {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ToolInfo.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ToolInfo.java
@@ -70,7 +70,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='toolspecific'
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='toolspecific'
  *        kind='son'"
  * @generated
  */

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ToolInfo.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/ToolInfo.java
@@ -44,50 +44,61 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Tool Info</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Tool
+ * Info</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool <em>Tool</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion <em>Version</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer <em>Formatted XML Buffer</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI <em>Tool Info Grammar URI</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet <em>Container Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject <em>Container Pn Object</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel <em>Container Label</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel <em>Tool Info Model</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool
+ * <em>Tool</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion
+ * <em>Version</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer
+ * <em>Formatted XML Buffer</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI
+ * <em>Tool Info Grammar URI</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet
+ * <em>Container Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject
+ * <em>Container Pn Object</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel
+ * <em>Container Label</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel
+ * <em>Tool Info Model</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='toolspecific' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='toolspecific'
+ *        kind='son'"
  * @generated
  */
 public interface ToolInfo extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Tool</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Tool</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Tool</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Tool</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Tool</em>' attribute.
 	 * @see #setTool(String)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_Tool()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='tool' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='tool'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	String getTool();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool <em>Tool</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getTool
+	 * <em>Tool</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Tool</em>' attribute.
 	 * @see #getTool()
 	 * @generated
@@ -95,26 +106,29 @@ public interface ToolInfo extends EObject {
 	void setTool(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Version</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Version</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Version</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Version</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Version</em>' attribute.
 	 * @see #setVersion(String)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_Version()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='version' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='version'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	String getVersion();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion <em>Version</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getVersion
+	 * <em>Version</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Version</em>' attribute.
 	 * @see #getVersion()
 	 * @generated
@@ -129,19 +143,23 @@ public interface ToolInfo extends EObject {
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Formatted XML Buffer</em>' attribute.
 	 * @see #setFormattedXMLBuffer(StringBuffer)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_FormattedXMLBuffer()
-	 * @model dataType="fr.lip6.move.pnml.pthlpng.hlcorestructure.LongString" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='son' tag=''"
+	 * @model dataType="fr.lip6.move.pnml.pthlpng.hlcorestructure.LongString"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='son' tag=''"
 	 * @generated
 	 */
 	StringBuffer getFormattedXMLBuffer();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer <em>Formatted XML Buffer</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getFormattedXMLBuffer
+	 * <em>Formatted XML Buffer</em>}' attribute. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Formatted XML Buffer</em>' attribute.
 	 * @see #getFormattedXMLBuffer()
 	 * @generated
@@ -156,18 +174,22 @@ public interface ToolInfo extends EObject {
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Tool Info Grammar URI</em>' attribute.
 	 * @see #setToolInfoGrammarURI(URI)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_ToolInfoGrammarURI()
-	 * @model dataType="fr.lip6.move.pnml.pthlpng.hlcorestructure.URI" ordered="false"
+	 * @model dataType="fr.lip6.move.pnml.pthlpng.hlcorestructure.URI"
+	 *        ordered="false"
 	 * @generated
 	 */
 	URI getToolInfoGrammarURI();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI <em>Tool Info Grammar URI</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoGrammarURI
+	 * <em>Tool Info Grammar URI</em>}' attribute. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Tool Info Grammar URI</em>' attribute.
 	 * @see #getToolInfoGrammarURI()
 	 * @generated
@@ -175,14 +197,16 @@ public interface ToolInfo extends EObject {
 	void setToolInfoGrammarURI(URI value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Petri Net</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics <em>Toolspecifics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Petri Net</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet#getToolspecifics
+	 * <em>Toolspecifics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Petri Net</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Petri Net</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Petri Net</em>' container reference.
 	 * @see #setContainerPetriNet(PetriNet)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_ContainerPetriNet()
@@ -193,24 +217,29 @@ public interface ToolInfo extends EObject {
 	PetriNet getContainerPetriNet();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet <em>Container Petri Net</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPetriNet
+	 * <em>Container Petri Net</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Petri Net</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Petri Net</em>' container
+	 *              reference.
 	 * @see #getContainerPetriNet()
 	 * @generated
 	 */
 	void setContainerPetriNet(PetriNet value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Pn Object</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics <em>Toolspecifics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Pn Object</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject#getToolspecifics
+	 * <em>Toolspecifics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Pn Object</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Pn Object</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Pn Object</em>' container reference.
 	 * @see #setContainerPnObject(PnObject)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_ContainerPnObject()
@@ -221,24 +250,29 @@ public interface ToolInfo extends EObject {
 	PnObject getContainerPnObject();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject <em>Container Pn Object</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerPnObject
+	 * <em>Container Pn Object</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Pn Object</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Pn Object</em>' container
+	 *              reference.
 	 * @see #getContainerPnObject()
 	 * @generated
 	 */
 	void setContainerPnObject(PnObject value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Label</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics <em>Toolspecifics</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Label</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label#getToolspecifics
+	 * <em>Toolspecifics</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Label</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Label</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Label</em>' container reference.
 	 * @see #setContainerLabel(Label)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_ContainerLabel()
@@ -249,24 +283,29 @@ public interface ToolInfo extends EObject {
 	Label getContainerLabel();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel <em>Container Label</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Label</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getContainerLabel
+	 * <em>Container Label</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Label</em>' container
+	 *              reference.
 	 * @see #getContainerLabel()
 	 * @generated
 	 */
 	void setContainerLabel(Label value);
 
 	/**
-	 * Returns the value of the '<em><b>Tool Info Model</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo <em>Container Tool Info</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Tool Info Model</b></em>' containment
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject#getContainerToolInfo
+	 * <em>Container Tool Info</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Tool Info Model</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Tool Info Model</em>' containment reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Tool Info Model</em>' containment reference.
 	 * @see #setToolInfoModel(AnyObject)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getToolInfo_ToolInfoModel()
@@ -277,10 +316,13 @@ public interface ToolInfo extends EObject {
 	AnyObject getToolInfoModel();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel <em>Tool Info Model</em>}' containment reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo#getToolInfoModel
+	 * <em>Tool Info Model</em>}' containment reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Tool Info Model</em>' containment reference.
+	 * 
+	 * @param value the new value of the '<em>Tool Info Model</em>' containment
+	 *              reference.
 	 * @see #getToolInfoModel()
 	 * @generated
 	 */
@@ -294,8 +336,8 @@ public interface ToolInfo extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Transition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Transition.java
@@ -54,7 +54,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getTransition()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='transition'
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='transition'
  *        kind='son'"
  * @generated
  */

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Transition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Transition.java
@@ -42,31 +42,34 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Transition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Transition</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition <em>Condition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition
+ * <em>Condition</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getTransition()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='transition' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='transition'
+ *        kind='son'"
  * @generated
  */
 public interface Transition extends TransitionNode {
 	/**
 	 * Returns the value of the '<em><b>Condition</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition <em>Container Transition</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getContainerTransition
+	 * <em>Container Transition</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Condition</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Condition</em>' containment reference.
 	 * @see #setCondition(Condition)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getTransition_Condition()
@@ -78,9 +81,11 @@ public interface Transition extends TransitionNode {
 	Condition getCondition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition <em>Condition</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition#getCondition
+	 * <em>Condition</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Condition</em>' containment reference.
 	 * @see #getCondition()
 	 * @generated
@@ -97,8 +102,8 @@ public interface Transition extends TransitionNode {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/TransitionNode.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/TransitionNode.java
@@ -43,14 +43,14 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Transition Node</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Transition Node</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions <em>Referencing Transitions</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode#getReferencingTransitions
+ * <em>Referencing Transitions</em>}</li>
  * </ul>
  * </p>
  *
@@ -60,15 +60,18 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface TransitionNode extends Node {
 	/**
-	 * Returns the value of the '<em><b>Referencing Transitions</b></em>' reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef <em>Ref</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Referencing Transitions</b></em>' reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef
+	 * <em>Ref</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Referencing Transitions</em>' reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Referencing Transitions</em>' reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Referencing Transitions</em>' reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getTransitionNode_ReferencingTransitions()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition#getRef
@@ -81,8 +84,8 @@ public interface TransitionNode extends Node {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/TransitionNode.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/TransitionNode.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getTransitionNode()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface TransitionNode extends Node {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Type.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Type.java
@@ -58,6 +58,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
  *
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getType()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='type' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Type extends HLCoreAnnotation {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Type.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/Type.java
@@ -43,15 +43,16 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Sort;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Type</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Type</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace <em>Container Place</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace
+ * <em>Container Place</em>}</li>
  * </ul>
  * </p>
  *
@@ -62,27 +63,32 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 public interface Type extends HLCoreAnnotation {
 	/**
 	 * Returns the value of the '<em><b>Structure</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container Type</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container
+	 * Type</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Structure</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Structure</em>' containment reference.
 	 * @see #setStructure(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getType_Structure()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType
 	 * @model opposite="containerType" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='structure'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	Sort getStructure();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure
+	 * <em>Structure</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Structure</em>' containment reference.
 	 * @see #getStructure()
 	 * @generated
@@ -90,14 +96,16 @@ public interface Type extends HLCoreAnnotation {
 	void setStructure(Sort value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Place</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Place</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Place</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Place</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Place</em>' container reference.
 	 * @see #setContainerPlace(Place)
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#getType_ContainerPlace()
@@ -108,10 +116,13 @@ public interface Type extends HLCoreAnnotation {
 	Place getContainerPlace();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace <em>Container Place</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Place</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getContainerPlace
+	 * <em>Container Place</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Place</em>' container
+	 *              reference.
 	 * @see #getContainerPlace()
 	 * @generated
 	 */
@@ -127,8 +138,8 @@ public interface Type extends HLCoreAnnotation {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/AnnotationGraphicsHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/AnnotationGraphicsHLAPI.java
@@ -52,8 +52,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Line;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class AnnotationGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
+public class AnnotationGraphicsHLAPI implements HLAPIClass, GraphicsHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -61,113 +60,89 @@ public class AnnotationGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
 	private AnnotationGraphics item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public AnnotationGraphicsHLAPI(
-		 OffsetHLAPI offset
-	
-		, FillHLAPI fill
-	
-		, LineHLAPI line
-	
-		, FontHLAPI font
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AnnotationGraphicsHLAPI(OffsetHLAPI offset
+
+			, FillHLAPI fill
+
+			, LineHLAPI line
+
+			, FontHLAPI font) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnnotationGraphics();}
-	
- 		
- 		if(offset!=null)
-			item.setOffset((Offset)offset.getContainedItem());
-		
-	
- 		
- 		if(fill!=null)
-			item.setFill((Fill)fill.getContainedItem());
-		
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
- 		
- 		if(font!=null)
-			item.setFont((Font)font.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnnotationGraphics();
+		}
+
+		if (offset != null)
+			item.setOffset((Offset) offset.getContainedItem());
+
+		if (fill != null)
+			item.setFill((Fill) fill.getContainedItem());
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
+		if (font != null)
+			item.setFont((Font) font.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AnnotationGraphicsHLAPI(
-		 OffsetHLAPI offset
-	
-		, FillHLAPI fill
-	
-		, LineHLAPI line
-	
-		, FontHLAPI font
-	
-		, AnnotationHLAPI containerAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AnnotationGraphicsHLAPI(OffsetHLAPI offset
+
+			, FillHLAPI fill
+
+			, LineHLAPI line
+
+			, FontHLAPI font
+
+			, AnnotationHLAPI containerAnnotation) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnnotationGraphics();}
-	
- 		
- 		if(offset!=null)
-			item.setOffset((Offset)offset.getContainedItem());
-		
-	
- 		
- 		if(fill!=null)
-			item.setFill((Fill)fill.getContainedItem());
-		
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
- 		
- 		if(font!=null)
-			item.setFont((Font)font.getContainedItem());
-		
-	
- 		
- 		if(containerAnnotation!=null)
-			item.setContainerAnnotation((Annotation)containerAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnnotationGraphics();
+		}
+
+		if (offset != null)
+			item.setOffset((Offset) offset.getContainedItem());
+
+		if (fill != null)
+			item.setFill((Fill) fill.getContainedItem());
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
+		if (font != null)
+			item.setFont((Font) font.getContainedItem());
+
+		if (containerAnnotation != null)
+			item.setContainerAnnotation((Annotation) containerAnnotation.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AnnotationGraphicsHLAPI(
-		 AnnotationHLAPI containerAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AnnotationGraphicsHLAPI(AnnotationHLAPI containerAnnotation) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAnnotationGraphics();}
-	
- 		
- 		if(containerAnnotation!=null)
-			item.setContainerAnnotation((Annotation)containerAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAnnotationGraphics();
+		}
+
+		if (containerAnnotation != null)
+			item.setContainerAnnotation((Annotation) containerAnnotation.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public AnnotationGraphicsHLAPI(AnnotationGraphics lowLevelAPI){
+	public AnnotationGraphicsHLAPI(AnnotationGraphics lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -175,263 +150,242 @@ public class AnnotationGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public AnnotationGraphics getContainedItem(){
+	public AnnotationGraphics getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Offset getOffset(){
+	public Offset getOffset() {
 		return item.getOffset();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Fill getFill(){
+	public Fill getFill() {
 		return item.getFill();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Line getLine(){
+	public Line getLine() {
 		return item.getLine();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Font getFont(){
+	public Font getFont() {
 		return item.getFont();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Annotation getContainerAnnotation(){
+	public Annotation getContainerAnnotation() {
 		return item.getContainerAnnotation();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public OffsetHLAPI getOffsetHLAPI(){
-			if(item.getOffset() == null) return null;
-			return new OffsetHLAPI(item.getOffset());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public FillHLAPI getFillHLAPI(){
-			if(item.getFill() == null) return null;
-			return new FillHLAPI(item.getFill());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public LineHLAPI getLineHLAPI(){
-			if(item.getLine() == null) return null;
-			return new LineHLAPI(item.getLine());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public FontHLAPI getFontHLAPI(){
-			if(item.getFont() == null) return null;
-			return new FontHLAPI(item.getFont());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public AnnotationHLAPI getContainerAnnotationHLAPI(){
-			if(item.getContainerAnnotation() == null) return null;
-			Annotation object = item.getContainerAnnotation();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.NameHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Name)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TypeHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Type)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLMarkingHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ConditionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLAnnotationHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.DeclarationHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OffsetHLAPI getOffsetHLAPI() {
+		if (item.getOffset() == null)
 			return null;
+		return new OffsetHLAPI(item.getOffset());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public FillHLAPI getFillHLAPI() {
+		if (item.getFill() == null)
+			return null;
+		return new FillHLAPI(item.getFill());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public LineHLAPI getLineHLAPI() {
+		if (item.getLine() == null)
+			return null;
+		return new LineHLAPI(item.getLine());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public FontHLAPI getFontHLAPI() {
+		if (item.getFont() == null)
+			return null;
+		return new FontHLAPI(item.getFont());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationHLAPI getContainerAnnotationHLAPI() {
+		if (item.getContainerAnnotation() == null)
+			return null;
+		Annotation object = item.getContainerAnnotation();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.NameHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Name) object);
 		}
-		
-	
-	
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TypeHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Type) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLMarkingHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ConditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLAnnotationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.DeclarationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Offset
 	 */
 	public void setOffsetHLAPI(
-	
-	OffsetHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOffset((Offset)elem.getContainedItem());
-	
+
+			OffsetHLAPI elem) {
+
+		if (elem != null)
+			item.setOffset((Offset) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Fill
 	 */
 	public void setFillHLAPI(
-	
-	FillHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setFill((Fill)elem.getContainedItem());
-	
+
+			FillHLAPI elem) {
+
+		if (elem != null)
+			item.setFill((Fill) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Line
 	 */
 	public void setLineHLAPI(
-	
-	LineHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setLine((Line)elem.getContainedItem());
-	
+
+			LineHLAPI elem) {
+
+		if (elem != null)
+			item.setLine((Line) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Font
 	 */
 	public void setFontHLAPI(
-	
-	FontHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setFont((Font)elem.getContainedItem());
-	
+
+			FontHLAPI elem) {
+
+		if (elem != null)
+			item.setFont((Font) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAnnotation
 	 */
 	public void setContainerAnnotationHLAPI(
-	
-	AnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAnnotation((Annotation)elem.getContainedItem());
-	
+
+			AnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAnnotation((Annotation) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(AnnotationGraphicsHLAPI item){
+	// equals method
+	public boolean equals(AnnotationGraphicsHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/AnnotationHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/AnnotationHLAPI.java
@@ -39,68 +39,50 @@ import fr.lip6.move.pnml.framework.hlapi.HLAPIClass;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface AnnotationHLAPI extends HLAPIClass,LabelHLAPI{
+public interface AnnotationHLAPI extends HLAPIClass, LabelHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public List<ToolInfo> getToolspecifics();
-	
+
 	/**
 	 *
 	 */
 	public AnnotationGraphics getAnnotationgraphics();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
-	public void setAnnotationgraphicsHLAPI(
-	AnnotationGraphicsHLAPI elem);
-	
+	public void setAnnotationgraphicsHLAPI(AnnotationGraphicsHLAPI elem);
 
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
 	public void addToolspecificsHLAPI(ToolInfoHLAPI unit);
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
-	
 
-	//equals method
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/AnyObjectHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/AnyObjectHLAPI.java
@@ -36,42 +36,29 @@ package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
 import fr.lip6.move.pnml.framework.hlapi.HLAPIClass;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface AnyObjectHLAPI extends HLAPIClass{
+public interface AnyObjectHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public ToolInfo getContainerToolInfo();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public ToolInfoHLAPI getContainerToolInfoHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
 
-	
-	
+	public ToolInfoHLAPI getContainerToolInfoHLAPI();
 
+	// setters (including container setter if aviable)
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ArcGraphicsHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ArcGraphicsHLAPI.java
@@ -52,8 +52,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Line;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Position;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class ArcGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
+public class ArcGraphicsHLAPI implements HLAPIClass, GraphicsHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -61,71 +60,59 @@ public class ArcGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
 	private ArcGraphics item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ArcGraphicsHLAPI(
-		 LineHLAPI line
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ArcGraphicsHLAPI(LineHLAPI line) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArcGraphics();}
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createArcGraphics();
+		}
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ArcGraphicsHLAPI(
-		 LineHLAPI line
-	
-		, ArcHLAPI containerArc
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ArcGraphicsHLAPI(LineHLAPI line
+
+			, ArcHLAPI containerArc) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArcGraphics();}
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
- 		
- 		if(containerArc!=null)
-			item.setContainerArc((Arc)containerArc.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createArcGraphics();
+		}
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
+		if (containerArc != null)
+			item.setContainerArc((Arc) containerArc.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ArcGraphicsHLAPI(
-		 ArcHLAPI containerArc
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ArcGraphicsHLAPI(ArcHLAPI containerArc) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArcGraphics();}
-	
- 		
- 		if(containerArc!=null)
-			item.setContainerArc((Arc)containerArc.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createArcGraphics();
+		}
+
+		if (containerArc != null)
+			item.setContainerArc((Arc) containerArc.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ArcGraphicsHLAPI(ArcGraphics lowLevelAPI){
+	public ArcGraphicsHLAPI(ArcGraphics lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -133,163 +120,143 @@ public class ArcGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public ArcGraphics getContainedItem(){
+	public ArcGraphics getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Position> getPositions(){
+	public List<Position> getPositions() {
 		return item.getPositions();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Line getLine(){
+	public Line getLine() {
 		return item.getLine();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Arc getContainerArc(){
+	public Arc getContainerArc() {
 		return item.getContainerArc();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<PositionHLAPI> getPositionsHLAPI(){
-			java.util.List<PositionHLAPI> retour = new ArrayList<PositionHLAPI>();
-			for (Position elemnt : getPositions()) {
-				retour.add(new PositionHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public LineHLAPI getLineHLAPI(){
-			if(item.getLine() == null) return null;
-			return new LineHLAPI(item.getLine());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ArcHLAPI getContainerArcHLAPI(){
-			if(item.getContainerArc() == null) return null;
-			return new ArcHLAPI(item.getContainerArc());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public java.util.List<PositionHLAPI> getPositionsHLAPI() {
+		java.util.List<PositionHLAPI> retour = new ArrayList<PositionHLAPI>();
+		for (Position elemnt : getPositions()) {
+			retour.add(new PositionHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public LineHLAPI getLineHLAPI() {
+		if (item.getLine() == null)
+			return null;
+		return new LineHLAPI(item.getLine());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ArcHLAPI getContainerArcHLAPI() {
+		if (item.getContainerArc() == null)
+			return null;
+		return new ArcHLAPI(item.getContainerArc());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Line
 	 */
 	public void setLineHLAPI(
-	
-	LineHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setLine((Line)elem.getContainedItem());
-	
+
+			LineHLAPI elem) {
+
+		if (elem != null)
+			item.setLine((Line) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerArc
 	 */
 	public void setContainerArcHLAPI(
-	
-	ArcHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerArc((Arc)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addPositionsHLAPI(PositionHLAPI unit){
-	
-		item.getPositions().add((Position)unit.getContainedItem());
+			ArcHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerArc((Arc) elem.getContainedItem());
+
 	}
 
-	public void removePositionsHLAPI(PositionHLAPI unit){
-		item.getPositions().remove((Position)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ArcGraphicsHLAPI item){
+	public void addPositionsHLAPI(PositionHLAPI unit) {
+
+		item.getPositions().add((Position) unit.getContainedItem());
+	}
+
+	public void removePositionsHLAPI(PositionHLAPI unit) {
+		item.getPositions().remove((Position) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ArcGraphicsHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ArcHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ArcHLAPI.java
@@ -57,8 +57,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Page;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class ArcHLAPI implements HLAPIClass,PnObjectHLAPI{
+public class ArcHLAPI implements HLAPIClass, PnObjectHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -66,200 +65,157 @@ public class ArcHLAPI implements HLAPIClass,PnObjectHLAPI{
 	private Arc item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ArcHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeHLAPI source
-	
-		, NodeHLAPI target
-	
-		, ArcGraphicsHLAPI arcgraphics
-	
-		, HLAnnotationHLAPI hlinscription
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public ArcHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeHLAPI source
+
+			, NodeHLAPI target
+
+			, ArcGraphicsHLAPI arcgraphics
+
+			, HLAnnotationHLAPI hlinscription) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR
+																									// BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArc();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(source!=null)
-			item.setSource((Node)source.getContainedItem());
-		
-	
- 		
- 		if(target!=null)
-			item.setTarget((Node)target.getContainedItem());
-		
-	
- 		
- 		if(arcgraphics!=null)
-			item.setArcgraphics((ArcGraphics)arcgraphics.getContainedItem());
-		
-	
- 		
- 		if(hlinscription!=null)
-			item.setHlinscription((HLAnnotation)hlinscription.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createArc();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (source != null)
+			item.setSource((Node) source.getContainedItem());
+
+		if (target != null)
+			item.setTarget((Node) target.getContainedItem());
+
+		if (arcgraphics != null)
+			item.setArcgraphics((ArcGraphics) arcgraphics.getContainedItem());
+
+		if (hlinscription != null)
+			item.setHlinscription((HLAnnotation) hlinscription.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ArcHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeHLAPI source
-	
-		, NodeHLAPI target
-	
-		, ArcGraphicsHLAPI arcgraphics
-	
-		, HLAnnotationHLAPI hlinscription
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArc();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(source!=null)
-			item.setSource((Node)source.getContainedItem());
-		
-	
- 		
- 		if(target!=null)
-			item.setTarget((Node)target.getContainedItem());
-		
-	
- 		
- 		if(arcgraphics!=null)
-			item.setArcgraphics((ArcGraphics)arcgraphics.getContainedItem());
-		
-	
- 		
- 		if(hlinscription!=null)
-			item.setHlinscription((HLAnnotation)hlinscription.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
-	}
 
+	public ArcHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeHLAPI source
+
+			, NodeHLAPI target
+
+			, ArcGraphicsHLAPI arcgraphics
+
+			, HLAnnotationHLAPI hlinscription
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createArc();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (source != null)
+			item.setSource((Node) source.getContainedItem());
+
+		if (target != null)
+			item.setTarget((Node) target.getContainedItem());
+
+		if (arcgraphics != null)
+			item.setArcgraphics((ArcGraphics) arcgraphics.getContainedItem());
+
+		if (hlinscription != null)
+			item.setHlinscription((HLAnnotation) hlinscription.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public ArcHLAPI(
-		 java.lang.String id
-	
-		, NodeHLAPI source
-	
-		, NodeHLAPI target
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public ArcHLAPI(java.lang.String id
+
+			, NodeHLAPI source
+
+			, NodeHLAPI target) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArc();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(source!=null)
-			item.setSource((Node)source.getContainedItem());
-		
-	
- 		
- 		if(target!=null)
-			item.setTarget((Node)target.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createArc();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (source != null)
+			item.setSource((Node) source.getContainedItem());
+
+		if (target != null)
+			item.setTarget((Node) target.getContainedItem());
+
 	}
 
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ArcHLAPI(
-		 java.lang.String id
-	
-		, NodeHLAPI source
-	
-		, NodeHLAPI target
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ArcHLAPI(java.lang.String id
+
+			, NodeHLAPI source
+
+			, NodeHLAPI target
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createArc();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(source!=null)
-			item.setSource((Node)source.getContainedItem());
-		
-	
- 		
- 		if(target!=null)
-			item.setTarget((Node)target.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createArc();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (source != null)
+			item.setSource((Node) source.getContainedItem());
+
+		if (target != null)
+			item.setTarget((Node) target.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ArcHLAPI(Arc lowLevelAPI){
+	public ArcHLAPI(Arc lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -267,372 +223,340 @@ public class ArcHLAPI implements HLAPIClass,PnObjectHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Arc getContainedItem(){
+	public Arc getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Node getSource(){
+	public Node getSource() {
 		return item.getSource();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Node getTarget(){
+	public Node getTarget() {
 		return item.getTarget();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ArcGraphics getArcgraphics(){
+	public ArcGraphics getArcgraphics() {
 		return item.getArcgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getHlinscription(){
+	public HLAnnotation getHlinscription() {
 		return item.getHlinscription();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public NodeHLAPI getSourceHLAPI(){
-			if(item.getSource() == null) return null;
-			Node object = item.getSource();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
 			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public NodeHLAPI getTargetHLAPI(){
-			if(item.getTarget() == null) return null;
-			Node object = item.getTarget();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)object);
-			}
-			
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ArcGraphicsHLAPI getArcgraphicsHLAPI(){
-			if(item.getArcgraphics() == null) return null;
-			return new ArcGraphicsHLAPI(item.getArcgraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getHlinscriptionHLAPI(){
-			if(item.getHlinscription() == null) return null;
-			return new HLAnnotationHLAPI(item.getHlinscription());
-		}
-		
-	
-	
+		return new PageHLAPI(item.getContainerPage());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NodeHLAPI getSourceHLAPI() {
+		if (item.getSource() == null)
+			return null;
+		Node object = item.getSource();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeHLAPI getTargetHLAPI() {
+		if (item.getTarget() == null)
+			return null;
+		Node object = item.getTarget();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ArcGraphicsHLAPI getArcgraphicsHLAPI() {
+		if (item.getArcgraphics() == null)
+			return null;
+		return new ArcGraphicsHLAPI(item.getArcgraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getHlinscriptionHLAPI() {
+		if (item.getHlinscription() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getHlinscription());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Source
 	 */
 	public void setSourceHLAPI(
-	
-	NodeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSource((Node)elem.getContainedItem());
-	
+
+			NodeHLAPI elem) {
+
+		if (elem != null)
+			item.setSource((Node) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Target
 	 */
 	public void setTargetHLAPI(
-	
-	NodeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setTarget((Node)elem.getContainedItem());
-	
+
+			NodeHLAPI elem) {
+
+		if (elem != null)
+			item.setTarget((Node) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Arcgraphics
 	 */
 	public void setArcgraphicsHLAPI(
-	
-	ArcGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setArcgraphics((ArcGraphics)elem.getContainedItem());
-	
+
+			ArcGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setArcgraphics((ArcGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Hlinscription
 	 */
 	public void setHlinscriptionHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setHlinscription((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setHlinscription((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ArcHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ArcHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2ColorHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2ColorHLAPI.java
@@ -32,106 +32,95 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color;
-public enum CSS2ColorHLAPI{
-	AQUA("AQUA"),
-	BLACK("BLACK"),
-	BLUE("BLUE"),
-	FUCHSIA("FUCHSIA"),
-	GRAY("GRAY"),
-	GREEN("GREEN"),
-	LIME("LIME"),
-	MAROON("MAROON"),
-	NAVY("NAVY"),
-	OLIVE("OLIVE"),
-	ORANGE("ORANGE"),
-	PURPLE("PURPLE"),
-	RED("RED"),
-	SILVER("SILVER"),
-	TEAL("TEAL"),
-	WHITE("WHITE"),
-	YELLOW("YELLOW");
+
+public enum CSS2ColorHLAPI {
+	AQUA("AQUA"), BLACK("BLACK"), BLUE("BLUE"), FUCHSIA("FUCHSIA"), GRAY("GRAY"), GREEN("GREEN"), LIME("LIME"),
+	MAROON("MAROON"), NAVY("NAVY"), OLIVE("OLIVE"), ORANGE("ORANGE"), PURPLE("PURPLE"), RED("RED"), SILVER("SILVER"),
+	TEAL("TEAL"), WHITE("WHITE"), YELLOW("YELLOW");
 
 	private final CSS2Color item;
 
 	private CSS2ColorHLAPI(String name) {
 		this.item = CSS2Color.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static CSS2ColorHLAPI get(int num) {
-	
-      if(num == 0){
-         return AQUA;
-      }
-	
-      if(num == 1){
-         return BLACK;
-      }
-	
-      if(num == 2){
-         return BLUE;
-      }
-	
-      if(num == 3){
-         return FUCHSIA;
-      }
-	
-      if(num == 4){
-         return GRAY;
-      }
-	
-      if(num == 5){
-         return GREEN;
-      }
-	
-      if(num == 6){
-         return LIME;
-      }
-	
-      if(num == 7){
-         return MAROON;
-      }
-	
-      if(num == 8){
-         return NAVY;
-      }
-	
-      if(num == 9){
-         return OLIVE;
-      }
-	
-      if(num == 10){
-         return ORANGE;
-      }
-	
-      if(num == 11){
-         return PURPLE;
-      }
-	
-      if(num == 12){
-         return RED;
-      }
-	
-      if(num == 13){
-         return SILVER;
-      }
-	
-      if(num == 14){
-         return TEAL;
-      }
-	
-      if(num == 15){
-         return WHITE;
-      }
-	
-      if(num == 16){
-         return YELLOW;
-      }
-	
+
+		if (num == 0) {
+			return AQUA;
+		}
+
+		if (num == 1) {
+			return BLACK;
+		}
+
+		if (num == 2) {
+			return BLUE;
+		}
+
+		if (num == 3) {
+			return FUCHSIA;
+		}
+
+		if (num == 4) {
+			return GRAY;
+		}
+
+		if (num == 5) {
+			return GREEN;
+		}
+
+		if (num == 6) {
+			return LIME;
+		}
+
+		if (num == 7) {
+			return MAROON;
+		}
+
+		if (num == 8) {
+			return NAVY;
+		}
+
+		if (num == 9) {
+			return OLIVE;
+		}
+
+		if (num == 10) {
+			return ORANGE;
+		}
+
+		if (num == 11) {
+			return PURPLE;
+		}
+
+		if (num == 12) {
+			return RED;
+		}
+
+		if (num == 13) {
+			return SILVER;
+		}
+
+		if (num == 14) {
+			return TEAL;
+		}
+
+		if (num == 15) {
+			return WHITE;
+		}
+
+		if (num == 16) {
+			return YELLOW;
+		}
+
 		return null;
 	}
 
@@ -139,5 +128,4 @@ public enum CSS2ColorHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontFamilyHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontFamilyHLAPI.java
@@ -32,46 +32,45 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily;
-public enum CSS2FontFamilyHLAPI{
-	VERDANA("VERDANA"),
-	ARIAL("ARIAL"),
-	TIMES("TIMES"),
-	GEORGIA("GEORGIA"),
-	TREBUCHET("TREBUCHET");
+
+public enum CSS2FontFamilyHLAPI {
+	VERDANA("VERDANA"), ARIAL("ARIAL"), TIMES("TIMES"), GEORGIA("GEORGIA"), TREBUCHET("TREBUCHET");
 
 	private final CSS2FontFamily item;
 
 	private CSS2FontFamilyHLAPI(String name) {
 		this.item = CSS2FontFamily.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static CSS2FontFamilyHLAPI get(int num) {
-	
-      if(num == 0){
-         return VERDANA;
-      }
-	
-      if(num == 1){
-         return ARIAL;
-      }
-	
-      if(num == 2){
-         return TIMES;
-      }
-	
-      if(num == 3){
-         return GEORGIA;
-      }
-	
-      if(num == 4){
-         return TREBUCHET;
-      }
-	
+
+		if (num == 0) {
+			return VERDANA;
+		}
+
+		if (num == 1) {
+			return ARIAL;
+		}
+
+		if (num == 2) {
+			return TIMES;
+		}
+
+		if (num == 3) {
+			return GEORGIA;
+		}
+
+		if (num == 4) {
+			return TREBUCHET;
+		}
+
 		return null;
 	}
 
@@ -79,5 +78,4 @@ public enum CSS2FontFamilyHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontSizeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontSizeHLAPI.java
@@ -32,14 +32,11 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize;
-public enum CSS2FontSizeHLAPI{
-	XXSMALL("XXSMALL"),
-	XSMALL("XSMALL"),
-	SMALL("SMALL"),
-	MEDIUM("MEDIUM"),
-	LARGE("LARGE"),
-	XLARGE("XLARGE"),
+
+public enum CSS2FontSizeHLAPI {
+	XXSMALL("XXSMALL"), XSMALL("XSMALL"), SMALL("SMALL"), MEDIUM("MEDIUM"), LARGE("LARGE"), XLARGE("XLARGE"),
 	XXLARGE("XXLARGE");
 
 	private final CSS2FontSize item;
@@ -47,41 +44,42 @@ public enum CSS2FontSizeHLAPI{
 	private CSS2FontSizeHLAPI(String name) {
 		this.item = CSS2FontSize.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static CSS2FontSizeHLAPI get(int num) {
-	
-      if(num == 0){
-         return XXSMALL;
-      }
-	
-      if(num == 1){
-         return XSMALL;
-      }
-	
-      if(num == 2){
-         return SMALL;
-      }
-	
-      if(num == 3){
-         return MEDIUM;
-      }
-	
-      if(num == 4){
-         return LARGE;
-      }
-	
-      if(num == 5){
-         return XLARGE;
-      }
-	
-      if(num == 6){
-         return XXLARGE;
-      }
-	
+
+		if (num == 0) {
+			return XXSMALL;
+		}
+
+		if (num == 1) {
+			return XSMALL;
+		}
+
+		if (num == 2) {
+			return SMALL;
+		}
+
+		if (num == 3) {
+			return MEDIUM;
+		}
+
+		if (num == 4) {
+			return LARGE;
+		}
+
+		if (num == 5) {
+			return XLARGE;
+		}
+
+		if (num == 6) {
+			return XXLARGE;
+		}
+
 		return null;
 	}
 
@@ -89,5 +87,4 @@ public enum CSS2FontSizeHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontStyleHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontStyleHLAPI.java
@@ -32,36 +32,37 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle;
-public enum CSS2FontStyleHLAPI{
-	NORMAL("NORMAL"),
-	ITALIC("ITALIC"),
-	OBLIQUE("OBLIQUE");
+
+public enum CSS2FontStyleHLAPI {
+	NORMAL("NORMAL"), ITALIC("ITALIC"), OBLIQUE("OBLIQUE");
 
 	private final CSS2FontStyle item;
 
 	private CSS2FontStyleHLAPI(String name) {
 		this.item = CSS2FontStyle.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static CSS2FontStyleHLAPI get(int num) {
-	
-      if(num == 0){
-         return NORMAL;
-      }
-	
-      if(num == 1){
-         return ITALIC;
-      }
-	
-      if(num == 2){
-         return OBLIQUE;
-      }
-	
+
+		if (num == 0) {
+			return NORMAL;
+		}
+
+		if (num == 1) {
+			return ITALIC;
+		}
+
+		if (num == 2) {
+			return OBLIQUE;
+		}
+
 		return null;
 	}
 
@@ -69,5 +70,4 @@ public enum CSS2FontStyleHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontWeightHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CSS2FontWeightHLAPI.java
@@ -32,41 +32,41 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight;
-public enum CSS2FontWeightHLAPI{
-	NORMAL("NORMAL"),
-	BOLD("BOLD"),
-	BOLDER("BOLDER"),
-	LIGHTER("LIGHTER");
+
+public enum CSS2FontWeightHLAPI {
+	NORMAL("NORMAL"), BOLD("BOLD"), BOLDER("BOLDER"), LIGHTER("LIGHTER");
 
 	private final CSS2FontWeight item;
 
 	private CSS2FontWeightHLAPI(String name) {
 		this.item = CSS2FontWeight.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static CSS2FontWeightHLAPI get(int num) {
-	
-      if(num == 0){
-         return NORMAL;
-      }
-	
-      if(num == 1){
-         return BOLD;
-      }
-	
-      if(num == 2){
-         return BOLDER;
-      }
-	
-      if(num == 3){
-         return LIGHTER;
-      }
-	
+
+		if (num == 0) {
+			return NORMAL;
+		}
+
+		if (num == 1) {
+			return BOLD;
+		}
+
+		if (num == 2) {
+			return BOLDER;
+		}
+
+		if (num == 3) {
+			return LIGHTER;
+		}
+
 		return null;
 	}
 
@@ -74,5 +74,4 @@ public enum CSS2FontWeightHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ConditionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ConditionHLAPI.java
@@ -54,8 +54,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class ConditionHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
+public class ConditionHLAPI implements HLAPIClass, LabelHLAPI, AnnotationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -63,103 +62,83 @@ public class ConditionHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	private Condition item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ConditionHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, TermHLAPI structure
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ConditionHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, TermHLAPI structure) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCondition();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Term)structure.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCondition();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Term) structure.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ConditionHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, TermHLAPI structure
-	
-		, TransitionHLAPI containerTransition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ConditionHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, TermHLAPI structure
+
+			, TransitionHLAPI containerTransition) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCondition();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Term)structure.getContainedItem());
-		
-	
- 		
- 		if(containerTransition!=null)
-			item.setContainerTransition((Transition)containerTransition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCondition();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Term) structure.getContainedItem());
+
+		if (containerTransition != null)
+			item.setContainerTransition((Transition) containerTransition.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ConditionHLAPI(
-		 TransitionHLAPI containerTransition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ConditionHLAPI(TransitionHLAPI containerTransition) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCondition();}
-	
- 		
- 		if(containerTransition!=null)
-			item.setContainerTransition((Transition)containerTransition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCondition();
+		}
+
+		if (containerTransition != null)
+			item.setContainerTransition((Transition) containerTransition.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ConditionHLAPI(Condition lowLevelAPI){
+	public ConditionHLAPI(Condition lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -167,357 +146,361 @@ public class ConditionHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Condition getContainedItem(){
+	public Condition getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getAnnotationgraphics(){
+	public AnnotationGraphics getAnnotationgraphics() {
 		return item.getAnnotationgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getText(){
+	public String getText() {
 		return item.getText();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Term getStructure(){
+	public Term getStructure() {
 		return item.getStructure();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Transition getContainerTransition(){
+	public Transition getContainerTransition() {
 		return item.getContainerTransition();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI(){
-			if(item.getAnnotationgraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
-		}
-		
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public TermHLAPI getStructureHLAPI(){
-			if(item.getStructure() == null) return null;
-			Term object = item.getStructure();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI((fr.lip6.move.pnml.pthlpng.terms.Variable)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI() {
+		if (item.getAnnotationgraphics() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TransitionHLAPI getContainerTransitionHLAPI(){
-			if(item.getContainerTransition() == null) return null;
-			return new TransitionHLAPI(item.getContainerTransition());
-		}
-		
-	
-	
+		return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public TermHLAPI getStructureHLAPI() {
+		if (item.getStructure() == null)
+			return null;
+		Term object = item.getStructure();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.Variable) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TransitionHLAPI getContainerTransitionHLAPI() {
+		if (item.getContainerTransition() == null)
+			return null;
+		return new TransitionHLAPI(item.getContainerTransition());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
 	public void setAnnotationgraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setAnnotationgraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Text
 	 */
 	public void setTextHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setText(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Structure
 	 */
 	public void setStructureHLAPI(
-	
-	TermHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setStructure((Term)elem.getContainedItem());
-	
+
+			TermHLAPI elem) {
+
+		if (elem != null)
+			item.setStructure((Term) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerTransition
 	 */
 	public void setContainerTransitionHLAPI(
-	
-	TransitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerTransition((Transition)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			TransitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerTransition((Transition) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ConditionHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ConditionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CoordinateHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/CoordinateHLAPI.java
@@ -35,49 +35,37 @@ package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
 
 import fr.lip6.move.pnml.framework.hlapi.HLAPIClass;
 
-public interface CoordinateHLAPI extends HLAPIClass{
+public interface CoordinateHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public Integer getX();
-	
+
 	/**
 	 *
 	 */
 	public Integer getY();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	// setters (including container setter if aviable)
+
 	/**
 	 * set X
 	 */
-	public void setXHLAPI(
-	java.lang.Integer elem);
-	
+	public void setXHLAPI(java.lang.Integer elem);
+
 	/**
 	 * set Y
 	 */
-	public void setYHLAPI(
-	java.lang.Integer elem);
-	
+	public void setYHLAPI(java.lang.Integer elem);
 
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/DeclarationHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/DeclarationHLAPI.java
@@ -55,8 +55,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl
 import fr.lip6.move.pnml.pthlpng.terms.Declarations;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.DeclarationsHLAPI;
 
-
-public class DeclarationHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
+public class DeclarationHLAPI implements HLAPIClass, LabelHLAPI, AnnotationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -64,160 +63,130 @@ public class DeclarationHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	private Declaration item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public DeclarationHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, DeclarationsHLAPI structure
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DeclarationHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, DeclarationsHLAPI structure) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclaration();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Declarations)structure.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDeclaration();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Declarations) structure.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DeclarationHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, DeclarationsHLAPI structure
-	
-		, PetriNetHLAPI containerDeclarationPetriNet
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DeclarationHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, DeclarationsHLAPI structure
+
+			, PetriNetHLAPI containerDeclarationPetriNet) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclaration();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Declarations)structure.getContainedItem());
-		
-	
- 		
- 		if(containerDeclarationPetriNet!=null)
-			item.setContainerDeclarationPetriNet((PetriNet)containerDeclarationPetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDeclaration();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Declarations) structure.getContainedItem());
+
+		if (containerDeclarationPetriNet != null)
+			item.setContainerDeclarationPetriNet((PetriNet) containerDeclarationPetriNet.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DeclarationHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, DeclarationsHLAPI structure
-	
-		, PageHLAPI containerDeclarationPage
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DeclarationHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, DeclarationsHLAPI structure
+
+			, PageHLAPI containerDeclarationPage) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclaration();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Declarations)structure.getContainedItem());
-		
-	
- 		
- 		if(containerDeclarationPage!=null)
-			item.setContainerDeclarationPage((Page)containerDeclarationPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDeclaration();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Declarations) structure.getContainedItem());
+
+		if (containerDeclarationPage != null)
+			item.setContainerDeclarationPage((Page) containerDeclarationPage.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DeclarationHLAPI(
-		 PetriNetHLAPI containerDeclarationPetriNet
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DeclarationHLAPI(PetriNetHLAPI containerDeclarationPetriNet) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclaration();}
-	
- 		
- 		if(containerDeclarationPetriNet!=null)
-			item.setContainerDeclarationPetriNet((PetriNet)containerDeclarationPetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDeclaration();
+		}
+
+		if (containerDeclarationPetriNet != null)
+			item.setContainerDeclarationPetriNet((PetriNet) containerDeclarationPetriNet.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DeclarationHLAPI(
-		 PageHLAPI containerDeclarationPage
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DeclarationHLAPI(PageHLAPI containerDeclarationPage) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclaration();}
-	
- 		
- 		if(containerDeclarationPage!=null)
-			item.setContainerDeclarationPage((Page)containerDeclarationPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDeclaration();
+		}
+
+		if (containerDeclarationPage != null)
+			item.setContainerDeclarationPage((Page) containerDeclarationPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public DeclarationHLAPI(Declaration lowLevelAPI){
+	public DeclarationHLAPI(Declaration lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -225,258 +194,228 @@ public class DeclarationHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Declaration getContainedItem(){
+	public Declaration getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getAnnotationgraphics(){
+	public AnnotationGraphics getAnnotationgraphics() {
 		return item.getAnnotationgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getText(){
+	public String getText() {
 		return item.getText();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declarations getStructure(){
+	public Declarations getStructure() {
 		return item.getStructure();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PetriNet getContainerDeclarationPetriNet(){
+	public PetriNet getContainerDeclarationPetriNet() {
 		return item.getContainerDeclarationPetriNet();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerDeclarationPage(){
+	public Page getContainerDeclarationPage() {
 		return item.getContainerDeclarationPage();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI(){
-			if(item.getAnnotationgraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
-		}
-		
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationsHLAPI getStructureHLAPI(){
-			if(item.getStructure() == null) return null;
-			return new DeclarationsHLAPI(item.getStructure());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PetriNetHLAPI getContainerDeclarationPetriNetHLAPI(){
-			if(item.getContainerDeclarationPetriNet() == null) return null;
-			return new PetriNetHLAPI(item.getContainerDeclarationPetriNet());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerDeclarationPageHLAPI(){
-			if(item.getContainerDeclarationPage() == null) return null;
-			return new PageHLAPI(item.getContainerDeclarationPage());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI() {
+		if (item.getAnnotationgraphics() == null)
+			return null;
+		return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public DeclarationsHLAPI getStructureHLAPI() {
+		if (item.getStructure() == null)
+			return null;
+		return new DeclarationsHLAPI(item.getStructure());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PetriNetHLAPI getContainerDeclarationPetriNetHLAPI() {
+		if (item.getContainerDeclarationPetriNet() == null)
+			return null;
+		return new PetriNetHLAPI(item.getContainerDeclarationPetriNet());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PageHLAPI getContainerDeclarationPageHLAPI() {
+		if (item.getContainerDeclarationPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerDeclarationPage());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
 	public void setAnnotationgraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setAnnotationgraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Text
 	 */
 	public void setTextHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setText(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Structure
 	 */
 	public void setStructureHLAPI(
-	
-	DeclarationsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setStructure((Declarations)elem.getContainedItem());
-	
+
+			DeclarationsHLAPI elem) {
+
+		if (elem != null)
+			item.setStructure((Declarations) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarationPetriNet
 	 */
 	public void setContainerDeclarationPetriNetHLAPI(
-	
-	PetriNetHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarationPetriNet((PetriNet)elem.getContainedItem());
-	
+
+			PetriNetHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarationPetriNet((PetriNet) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarationPage
 	 */
 	public void setContainerDeclarationPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarationPage((Page)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarationPage((Page) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(DeclarationHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(DeclarationHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/DimensionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/DimensionHLAPI.java
@@ -48,8 +48,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructureFactory;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class DimensionHLAPI implements HLAPIClass,CoordinateHLAPI{
+public class DimensionHLAPI implements HLAPIClass, CoordinateHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -57,77 +56,63 @@ public class DimensionHLAPI implements HLAPIClass,CoordinateHLAPI{
 	private Dimension item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public DimensionHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DimensionHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDimension();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createDimension();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DimensionHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	
-		, NodeGraphicsHLAPI containerDNodeGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DimensionHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y
+
+			, NodeGraphicsHLAPI containerDNodeGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDimension();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
- 		
- 		if(containerDNodeGraphics!=null)
-			item.setContainerDNodeGraphics((NodeGraphics)containerDNodeGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDimension();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
+		if (containerDNodeGraphics != null)
+			item.setContainerDNodeGraphics((NodeGraphics) containerDNodeGraphics.getContainedItem());
+
 	}
-
-
-
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public DimensionHLAPI(Dimension lowLevelAPI){
+	public DimensionHLAPI(Dimension lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -135,138 +120,124 @@ public class DimensionHLAPI implements HLAPIClass,CoordinateHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Dimension getContainedItem(){
+	public Dimension getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getX(){
+	public Integer getX() {
 		return item.getX();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getY(){
+	public Integer getY() {
 		return item.getY();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getContainerDNodeGraphics(){
+	public NodeGraphics getContainerDNodeGraphics() {
 		return item.getContainerDNodeGraphics();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getContainerDNodeGraphicsHLAPI(){
-			if(item.getContainerDNodeGraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getContainerDNodeGraphics());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NodeGraphicsHLAPI getContainerDNodeGraphicsHLAPI() {
+		if (item.getContainerDNodeGraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getContainerDNodeGraphics());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set X
 	 */
 	public void setXHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setX(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Y
 	 */
 	public void setYHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setY(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerDNodeGraphics
 	 */
 	public void setContainerDNodeGraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDNodeGraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDNodeGraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(DimensionHLAPI item){
+	// equals method
+	public boolean equals(DimensionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FillHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FillHLAPI.java
@@ -52,8 +52,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructureFactory;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class FillHLAPI implements HLAPIClass{
+public class FillHLAPI implements HLAPIClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -61,181 +60,145 @@ public class FillHLAPI implements HLAPIClass{
 	private Fill item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public FillHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, CSS2ColorHLAPI gradientcolor
-	
-		, GradientHLAPI gradientrotation
-	
-		, java.net.URI image
-	){//BEGIN CONSTRUCTOR BODY
+
+	public FillHLAPI(CSS2ColorHLAPI color
+
+			, CSS2ColorHLAPI gradientcolor
+
+			, GradientHLAPI gradientrotation
+
+			, java.net.URI image) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFill();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(gradientcolor!=null)
-			item.setGradientcolor((CSS2Color)gradientcolor.getContainedItem());
-		
-	
- 		
- 		if(gradientrotation!=null)
-			item.setGradientrotation((Gradient)gradientrotation.getContainedItem());
-		
-	
- 		
-			if(image!=null){
-			
-				item.setImage(image);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createFill();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (gradientcolor != null)
+			item.setGradientcolor((CSS2Color) gradientcolor.getContainedItem());
+
+		if (gradientrotation != null)
+			item.setGradientrotation((Gradient) gradientrotation.getContainedItem());
+
+		if (image != null) {
+
+			item.setImage(image);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public FillHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, CSS2ColorHLAPI gradientcolor
-	
-		, GradientHLAPI gradientrotation
-	
-		, java.net.URI image
-	
-		, NodeGraphicsHLAPI containerNodeGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public FillHLAPI(CSS2ColorHLAPI color
+
+			, CSS2ColorHLAPI gradientcolor
+
+			, GradientHLAPI gradientrotation
+
+			, java.net.URI image
+
+			, NodeGraphicsHLAPI containerNodeGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFill();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(gradientcolor!=null)
-			item.setGradientcolor((CSS2Color)gradientcolor.getContainedItem());
-		
-	
- 		
- 		if(gradientrotation!=null)
-			item.setGradientrotation((Gradient)gradientrotation.getContainedItem());
-		
-	
- 		
-			if(image!=null){
-			
-				item.setImage(image);
-			}
-		
-	
- 		
- 		if(containerNodeGraphics!=null)
-			item.setContainerNodeGraphics((NodeGraphics)containerNodeGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFill();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (gradientcolor != null)
+			item.setGradientcolor((CSS2Color) gradientcolor.getContainedItem());
+
+		if (gradientrotation != null)
+			item.setGradientrotation((Gradient) gradientrotation.getContainedItem());
+
+		if (image != null) {
+
+			item.setImage(image);
+		}
+
+		if (containerNodeGraphics != null)
+			item.setContainerNodeGraphics((NodeGraphics) containerNodeGraphics.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public FillHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, CSS2ColorHLAPI gradientcolor
-	
-		, GradientHLAPI gradientrotation
-	
-		, java.net.URI image
-	
-		, AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public FillHLAPI(CSS2ColorHLAPI color
+
+			, CSS2ColorHLAPI gradientcolor
+
+			, GradientHLAPI gradientrotation
+
+			, java.net.URI image
+
+			, AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFill();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(gradientcolor!=null)
-			item.setGradientcolor((CSS2Color)gradientcolor.getContainedItem());
-		
-	
- 		
- 		if(gradientrotation!=null)
-			item.setGradientrotation((Gradient)gradientrotation.getContainedItem());
-		
-	
- 		
-			if(image!=null){
-			
-				item.setImage(image);
-			}
-		
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFill();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (gradientcolor != null)
+			item.setGradientcolor((CSS2Color) gradientcolor.getContainedItem());
+
+		if (gradientrotation != null)
+			item.setGradientrotation((Gradient) gradientrotation.getContainedItem());
+
+		if (image != null) {
+
+			item.setImage(image);
+		}
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public FillHLAPI(
-		 NodeGraphicsHLAPI containerNodeGraphics
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public FillHLAPI(NodeGraphicsHLAPI containerNodeGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFill();}
-	
- 		
- 		if(containerNodeGraphics!=null)
-			item.setContainerNodeGraphics((NodeGraphics)containerNodeGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFill();
+		}
+
+		if (containerNodeGraphics != null)
+			item.setContainerNodeGraphics((NodeGraphics) containerNodeGraphics.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public FillHLAPI(
-		 AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public FillHLAPI(AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFill();}
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFill();
+		}
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public FillHLAPI(Fill lowLevelAPI){
+	public FillHLAPI(Fill lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -243,220 +206,198 @@ public class FillHLAPI implements HLAPIClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public Fill getContainedItem(){
+	public Fill getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2Color getColor(){
+	public CSS2Color getColor() {
 		return item.getColor();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2Color getGradientcolor(){
+	public CSS2Color getGradientcolor() {
 		return item.getGradientcolor();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Gradient getGradientrotation(){
+	public Gradient getGradientrotation() {
 		return item.getGradientrotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public URI getImage(){
+	public URI getImage() {
 		return item.getImage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getContainerNodeGraphics(){
+	public NodeGraphics getContainerNodeGraphics() {
 		return item.getContainerNodeGraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getContainerAnnotationGraphics(){
+	public AnnotationGraphics getContainerAnnotationGraphics() {
 		return item.getContainerAnnotationGraphics();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getContainerNodeGraphicsHLAPI(){
-			if(item.getContainerNodeGraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getContainerNodeGraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI(){
-			if(item.getContainerAnnotationGraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NodeGraphicsHLAPI getContainerNodeGraphicsHLAPI() {
+		if (item.getContainerNodeGraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getContainerNodeGraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI() {
+		if (item.getContainerAnnotationGraphics() == null)
+			return null;
+		return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Color
 	 */
 	public void setColorHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color elem) {
+
+		if (elem != null) {
+
 			item.setColor(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Gradientcolor
 	 */
 	public void setGradientcolorHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color elem) {
+
+		if (elem != null) {
+
 			item.setGradientcolor(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Gradientrotation
 	 */
 	public void setGradientrotationHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient elem) {
+
+		if (elem != null) {
+
 			item.setGradientrotation(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Image
 	 */
 	public void setImageHLAPI(
-	
-	java.net.URI elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.net.URI elem) {
+
+		if (elem != null) {
+
 			item.setImage(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerNodeGraphics
 	 */
 	public void setContainerNodeGraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNodeGraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNodeGraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAnnotationGraphics
 	 */
 	public void setContainerAnnotationGraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(FillHLAPI item){
+	// equals method
+	public boolean equals(FillHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FontAlignHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FontAlignHLAPI.java
@@ -32,36 +32,37 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign;
-public enum FontAlignHLAPI{
-	LEFT("LEFT"),
-	CENTER("CENTER"),
-	RIGHT("RIGHT");
+
+public enum FontAlignHLAPI {
+	LEFT("LEFT"), CENTER("CENTER"), RIGHT("RIGHT");
 
 	private final FontAlign item;
 
 	private FontAlignHLAPI(String name) {
 		this.item = FontAlign.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static FontAlignHLAPI get(int num) {
-	
-      if(num == 0){
-         return LEFT;
-      }
-	
-      if(num == 1){
-         return CENTER;
-      }
-	
-      if(num == 2){
-         return RIGHT;
-      }
-	
+
+		if (num == 0) {
+			return LEFT;
+		}
+
+		if (num == 1) {
+			return CENTER;
+		}
+
+		if (num == 2) {
+			return RIGHT;
+		}
+
 		return null;
 	}
 
@@ -69,5 +70,4 @@ public enum FontAlignHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FontDecorationHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FontDecorationHLAPI.java
@@ -32,36 +32,37 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration;
-public enum FontDecorationHLAPI{
-	UNDERLINE("UNDERLINE"),
-	OVERLINE("OVERLINE"),
-	LINETHROUGH("LINETHROUGH");
+
+public enum FontDecorationHLAPI {
+	UNDERLINE("UNDERLINE"), OVERLINE("OVERLINE"), LINETHROUGH("LINETHROUGH");
 
 	private final FontDecoration item;
 
 	private FontDecorationHLAPI(String name) {
 		this.item = FontDecoration.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static FontDecorationHLAPI get(int num) {
-	
-      if(num == 0){
-         return UNDERLINE;
-      }
-	
-      if(num == 1){
-         return OVERLINE;
-      }
-	
-      if(num == 2){
-         return LINETHROUGH;
-      }
-	
+
+		if (num == 0) {
+			return UNDERLINE;
+		}
+
+		if (num == 1) {
+			return OVERLINE;
+		}
+
+		if (num == 2) {
+			return LINETHROUGH;
+		}
+
 		return null;
 	}
 
@@ -69,5 +70,4 @@ public enum FontDecorationHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FontHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/FontHLAPI.java
@@ -55,8 +55,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructureFactory;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class FontHLAPI implements HLAPIClass{
+public class FontHLAPI implements HLAPIClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -64,159 +63,123 @@ public class FontHLAPI implements HLAPIClass{
 	private Font item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public FontHLAPI(
-		 FontAlignHLAPI align
-	
-		, FontDecorationHLAPI decoration
-	
-		, CSS2FontFamilyHLAPI family
-	
-		, java.math.BigDecimal rotation
-	
-		, CSS2FontSizeHLAPI size
-	
-		, CSS2FontStyleHLAPI style
-	
-		, CSS2FontWeightHLAPI weight
-	){//BEGIN CONSTRUCTOR BODY
+
+	public FontHLAPI(FontAlignHLAPI align
+
+			, FontDecorationHLAPI decoration
+
+			, CSS2FontFamilyHLAPI family
+
+			, java.math.BigDecimal rotation
+
+			, CSS2FontSizeHLAPI size
+
+			, CSS2FontStyleHLAPI style
+
+			, CSS2FontWeightHLAPI weight) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFont();}
-	
- 		
- 		if(align!=null)
-			item.setAlign((FontAlign)align.getContainedItem());
-		
-	
- 		
- 		if(decoration!=null)
-			item.setDecoration((FontDecoration)decoration.getContainedItem());
-		
-	
- 		
- 		if(family!=null)
-			item.setFamily((CSS2FontFamily)family.getContainedItem());
-		
-	
- 		
-			if(rotation!=null){
-			
-				item.setRotation(rotation);
-			}
-		
-	
- 		
- 		if(size!=null)
-			item.setSize((CSS2FontSize)size.getContainedItem());
-		
-	
- 		
- 		if(style!=null)
-			item.setStyle((CSS2FontStyle)style.getContainedItem());
-		
-	
- 		
- 		if(weight!=null)
-			item.setWeight((CSS2FontWeight)weight.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFont();
+		}
+
+		if (align != null)
+			item.setAlign((FontAlign) align.getContainedItem());
+
+		if (decoration != null)
+			item.setDecoration((FontDecoration) decoration.getContainedItem());
+
+		if (family != null)
+			item.setFamily((CSS2FontFamily) family.getContainedItem());
+
+		if (rotation != null) {
+
+			item.setRotation(rotation);
+		}
+
+		if (size != null)
+			item.setSize((CSS2FontSize) size.getContainedItem());
+
+		if (style != null)
+			item.setStyle((CSS2FontStyle) style.getContainedItem());
+
+		if (weight != null)
+			item.setWeight((CSS2FontWeight) weight.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public FontHLAPI(
-		 FontAlignHLAPI align
-	
-		, FontDecorationHLAPI decoration
-	
-		, CSS2FontFamilyHLAPI family
-	
-		, java.math.BigDecimal rotation
-	
-		, CSS2FontSizeHLAPI size
-	
-		, CSS2FontStyleHLAPI style
-	
-		, CSS2FontWeightHLAPI weight
-	
-		, AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public FontHLAPI(FontAlignHLAPI align
+
+			, FontDecorationHLAPI decoration
+
+			, CSS2FontFamilyHLAPI family
+
+			, java.math.BigDecimal rotation
+
+			, CSS2FontSizeHLAPI size
+
+			, CSS2FontStyleHLAPI style
+
+			, CSS2FontWeightHLAPI weight
+
+			, AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFont();}
-	
- 		
- 		if(align!=null)
-			item.setAlign((FontAlign)align.getContainedItem());
-		
-	
- 		
- 		if(decoration!=null)
-			item.setDecoration((FontDecoration)decoration.getContainedItem());
-		
-	
- 		
- 		if(family!=null)
-			item.setFamily((CSS2FontFamily)family.getContainedItem());
-		
-	
- 		
-			if(rotation!=null){
-			
-				item.setRotation(rotation);
-			}
-		
-	
- 		
- 		if(size!=null)
-			item.setSize((CSS2FontSize)size.getContainedItem());
-		
-	
- 		
- 		if(style!=null)
-			item.setStyle((CSS2FontStyle)style.getContainedItem());
-		
-	
- 		
- 		if(weight!=null)
-			item.setWeight((CSS2FontWeight)weight.getContainedItem());
-		
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFont();
+		}
+
+		if (align != null)
+			item.setAlign((FontAlign) align.getContainedItem());
+
+		if (decoration != null)
+			item.setDecoration((FontDecoration) decoration.getContainedItem());
+
+		if (family != null)
+			item.setFamily((CSS2FontFamily) family.getContainedItem());
+
+		if (rotation != null) {
+
+			item.setRotation(rotation);
+		}
+
+		if (size != null)
+			item.setSize((CSS2FontSize) size.getContainedItem());
+
+		if (style != null)
+			item.setStyle((CSS2FontStyle) style.getContainedItem());
+
+		if (weight != null)
+			item.setWeight((CSS2FontWeight) weight.getContainedItem());
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public FontHLAPI(
-		 AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public FontHLAPI(AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createFont();}
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createFont();
+		}
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public FontHLAPI(Font lowLevelAPI){
+	public FontHLAPI(Font lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -224,253 +187,229 @@ public class FontHLAPI implements HLAPIClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public Font getContainedItem(){
+	public Font getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public FontAlign getAlign(){
+	public FontAlign getAlign() {
 		return item.getAlign();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public FontDecoration getDecoration(){
+	public FontDecoration getDecoration() {
 		return item.getDecoration();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2FontFamily getFamily(){
+	public CSS2FontFamily getFamily() {
 		return item.getFamily();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public BigDecimal getRotation(){
+	public BigDecimal getRotation() {
 		return item.getRotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2FontSize getSize(){
+	public CSS2FontSize getSize() {
 		return item.getSize();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2FontStyle getStyle(){
+	public CSS2FontStyle getStyle() {
 		return item.getStyle();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2FontWeight getWeight(){
+	public CSS2FontWeight getWeight() {
 		return item.getWeight();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getContainerAnnotationGraphics(){
+	public AnnotationGraphics getContainerAnnotationGraphics() {
 		return item.getContainerAnnotationGraphics();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI(){
-			if(item.getContainerAnnotationGraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI() {
+		if (item.getContainerAnnotationGraphics() == null)
+			return null;
+		return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Align
 	 */
 	public void setAlignHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.FontAlign elem) {
+
+		if (elem != null) {
+
 			item.setAlign(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Decoration
 	 */
 	public void setDecorationHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.FontDecoration elem) {
+
+		if (elem != null) {
+
 			item.setDecoration(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Family
 	 */
 	public void setFamilyHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontFamily elem) {
+
+		if (elem != null) {
+
 			item.setFamily(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Rotation
 	 */
 	public void setRotationHLAPI(
-	
-	java.math.BigDecimal elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.math.BigDecimal elem) {
+
+		if (elem != null) {
+
 			item.setRotation(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Size
 	 */
 	public void setSizeHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontSize elem) {
+
+		if (elem != null) {
+
 			item.setSize(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Style
 	 */
 	public void setStyleHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontStyle elem) {
+
+		if (elem != null) {
+
 			item.setStyle(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Weight
 	 */
 	public void setWeightHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2FontWeight elem) {
+
+		if (elem != null) {
+
 			item.setWeight(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerAnnotationGraphics
 	 */
 	public void setContainerAnnotationGraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(FontHLAPI item){
+	// equals method
+	public boolean equals(FontHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/GradientHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/GradientHLAPI.java
@@ -32,36 +32,37 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Gradient;
-public enum GradientHLAPI{
-	HORIZONTAL("HORIZONTAL"),
-	VERTICAL("VERTICAL"),
-	DIAGONAL("DIAGONAL");
+
+public enum GradientHLAPI {
+	HORIZONTAL("HORIZONTAL"), VERTICAL("VERTICAL"), DIAGONAL("DIAGONAL");
 
 	private final Gradient item;
 
 	private GradientHLAPI(String name) {
 		this.item = Gradient.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static GradientHLAPI get(int num) {
-	
-      if(num == 0){
-         return HORIZONTAL;
-      }
-	
-      if(num == 1){
-         return VERTICAL;
-      }
-	
-      if(num == 2){
-         return DIAGONAL;
-      }
-	
+
+		if (num == 0) {
+			return HORIZONTAL;
+		}
+
+		if (num == 1) {
+			return VERTICAL;
+		}
+
+		if (num == 2) {
+			return DIAGONAL;
+		}
+
 		return null;
 	}
 
@@ -69,5 +70,4 @@ public enum GradientHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/GraphicsHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/GraphicsHLAPI.java
@@ -35,25 +35,17 @@ package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
 
 import fr.lip6.move.pnml.framework.hlapi.HLAPIClass;
 
-public interface GraphicsHLAPI extends HLAPIClass{
+public interface GraphicsHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
 
-	//getters giving HLAPI object
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	// setters (including container setter if aviable)
 
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/HLAnnotationHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/HLAnnotationHLAPI.java
@@ -54,8 +54,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class HLAnnotationHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
+public class HLAnnotationHLAPI implements HLAPIClass, LabelHLAPI, AnnotationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -63,103 +62,83 @@ public class HLAnnotationHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	private HLAnnotation item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public HLAnnotationHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, TermHLAPI structure
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLAnnotationHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, TermHLAPI structure) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLAnnotation();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Term)structure.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLAnnotation();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Term) structure.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLAnnotationHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, TermHLAPI structure
-	
-		, ArcHLAPI containerArc
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLAnnotationHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, TermHLAPI structure
+
+			, ArcHLAPI containerArc) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLAnnotation();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Term)structure.getContainedItem());
-		
-	
- 		
- 		if(containerArc!=null)
-			item.setContainerArc((Arc)containerArc.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLAnnotation();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Term) structure.getContainedItem());
+
+		if (containerArc != null)
+			item.setContainerArc((Arc) containerArc.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public HLAnnotationHLAPI(
-		 ArcHLAPI containerArc
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public HLAnnotationHLAPI(ArcHLAPI containerArc) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLAnnotation();}
-	
- 		
- 		if(containerArc!=null)
-			item.setContainerArc((Arc)containerArc.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLAnnotation();
+		}
+
+		if (containerArc != null)
+			item.setContainerArc((Arc) containerArc.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public HLAnnotationHLAPI(HLAnnotation lowLevelAPI){
+	public HLAnnotationHLAPI(HLAnnotation lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -167,357 +146,361 @@ public class HLAnnotationHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public HLAnnotation getContainedItem(){
+	public HLAnnotation getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getAnnotationgraphics(){
+	public AnnotationGraphics getAnnotationgraphics() {
 		return item.getAnnotationgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getText(){
+	public String getText() {
 		return item.getText();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Term getStructure(){
+	public Term getStructure() {
 		return item.getStructure();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Arc getContainerArc(){
+	public Arc getContainerArc() {
 		return item.getContainerArc();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI(){
-			if(item.getAnnotationgraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
-		}
-		
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public TermHLAPI getStructureHLAPI(){
-			if(item.getStructure() == null) return null;
-			Term object = item.getStructure();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI((fr.lip6.move.pnml.pthlpng.terms.Variable)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI() {
+		if (item.getAnnotationgraphics() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ArcHLAPI getContainerArcHLAPI(){
-			if(item.getContainerArc() == null) return null;
-			return new ArcHLAPI(item.getContainerArc());
-		}
-		
-	
-	
+		return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public TermHLAPI getStructureHLAPI() {
+		if (item.getStructure() == null)
+			return null;
+		Term object = item.getStructure();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.Variable) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ArcHLAPI getContainerArcHLAPI() {
+		if (item.getContainerArc() == null)
+			return null;
+		return new ArcHLAPI(item.getContainerArc());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
 	public void setAnnotationgraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setAnnotationgraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Text
 	 */
 	public void setTextHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setText(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Structure
 	 */
 	public void setStructureHLAPI(
-	
-	TermHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setStructure((Term)elem.getContainedItem());
-	
+
+			TermHLAPI elem) {
+
+		if (elem != null)
+			item.setStructure((Term) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerArc
 	 */
 	public void setContainerArcHLAPI(
-	
-	ArcHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerArc((Arc)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			ArcHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerArc((Arc) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(HLAnnotationHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(HLAnnotationHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/HLMarkingHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/HLMarkingHLAPI.java
@@ -54,8 +54,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class HLMarkingHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
+public class HLMarkingHLAPI implements HLAPIClass, LabelHLAPI, AnnotationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -63,103 +62,83 @@ public class HLMarkingHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	private HLMarking item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public HLMarkingHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, TermHLAPI structure
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLMarkingHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, TermHLAPI structure) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLMarking();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Term)structure.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLMarking();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Term) structure.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLMarkingHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, TermHLAPI structure
-	
-		, PlaceHLAPI containerPlace
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLMarkingHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, TermHLAPI structure
+
+			, PlaceHLAPI containerPlace) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLMarking();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Term)structure.getContainedItem());
-		
-	
- 		
- 		if(containerPlace!=null)
-			item.setContainerPlace((Place)containerPlace.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLMarking();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Term) structure.getContainedItem());
+
+		if (containerPlace != null)
+			item.setContainerPlace((Place) containerPlace.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public HLMarkingHLAPI(
-		 PlaceHLAPI containerPlace
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public HLMarkingHLAPI(PlaceHLAPI containerPlace) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLMarking();}
-	
- 		
- 		if(containerPlace!=null)
-			item.setContainerPlace((Place)containerPlace.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLMarking();
+		}
+
+		if (containerPlace != null)
+			item.setContainerPlace((Place) containerPlace.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public HLMarkingHLAPI(HLMarking lowLevelAPI){
+	public HLMarkingHLAPI(HLMarking lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -167,357 +146,361 @@ public class HLMarkingHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public HLMarking getContainedItem(){
+	public HLMarking getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getAnnotationgraphics(){
+	public AnnotationGraphics getAnnotationgraphics() {
 		return item.getAnnotationgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getText(){
+	public String getText() {
 		return item.getText();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Term getStructure(){
+	public Term getStructure() {
 		return item.getStructure();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Place getContainerPlace(){
+	public Place getContainerPlace() {
 		return item.getContainerPlace();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI(){
-			if(item.getAnnotationgraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
-		}
-		
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public TermHLAPI getStructureHLAPI(){
-			if(item.getStructure() == null) return null;
-			Term object = item.getStructure();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI((fr.lip6.move.pnml.pthlpng.terms.Variable)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI() {
+		if (item.getAnnotationgraphics() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PlaceHLAPI getContainerPlaceHLAPI(){
-			if(item.getContainerPlace() == null) return null;
-			return new PlaceHLAPI(item.getContainerPlace());
-		}
-		
-	
-	
+		return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public TermHLAPI getStructureHLAPI() {
+		if (item.getStructure() == null)
+			return null;
+		Term object = item.getStructure();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.Variable) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PlaceHLAPI getContainerPlaceHLAPI() {
+		if (item.getContainerPlace() == null)
+			return null;
+		return new PlaceHLAPI(item.getContainerPlace());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
 	public void setAnnotationgraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setAnnotationgraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Text
 	 */
 	public void setTextHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setText(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Structure
 	 */
 	public void setStructureHLAPI(
-	
-	TermHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setStructure((Term)elem.getContainedItem());
-	
+
+			TermHLAPI elem) {
+
+		if (elem != null)
+			item.setStructure((Term) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPlace
 	 */
 	public void setContainerPlaceHLAPI(
-	
-	PlaceHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPlace((Place)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PlaceHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPlace((Place) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(HLMarkingHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(HLMarkingHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LabelHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LabelHLAPI.java
@@ -38,45 +38,33 @@ import java.util.List;
 import fr.lip6.move.pnml.framework.hlapi.HLAPIClass;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface LabelHLAPI extends HLAPIClass{
+public interface LabelHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public List<ToolInfo> getToolspecifics();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
 
-	
-	
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
 
+	// setters (including container setter if aviable)
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
+
 	public void addToolspecificsHLAPI(ToolInfoHLAPI unit);
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
-	
 
-	//equals method
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LineHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LineHLAPI.java
@@ -53,8 +53,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class LineHLAPI implements HLAPIClass{
+public class LineHLAPI implements HLAPIClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -62,245 +61,197 @@ public class LineHLAPI implements HLAPIClass{
 	private Line item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public LineHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, LineShapeHLAPI shape
-	
-		, java.lang.Integer width
-	
-		, LineStyleHLAPI style
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LineHLAPI(CSS2ColorHLAPI color
+
+			, LineShapeHLAPI shape
+
+			, java.lang.Integer width
+
+			, LineStyleHLAPI style) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(shape!=null)
-			item.setShape((LineShape)shape.getContainedItem());
-		
-	
- 		
-			if(width!=null){
-			
-				item.setWidth(width);
-			}
-		
-	
- 		
- 		if(style!=null)
-			item.setStyle((LineStyle)style.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLine();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (shape != null)
+			item.setShape((LineShape) shape.getContainedItem());
+
+		if (width != null) {
+
+			item.setWidth(width);
+		}
+
+		if (style != null)
+			item.setStyle((LineStyle) style.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LineHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, LineShapeHLAPI shape
-	
-		, java.lang.Integer width
-	
-		, LineStyleHLAPI style
-	
-		, NodeGraphicsHLAPI containerNodeGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LineHLAPI(CSS2ColorHLAPI color
+
+			, LineShapeHLAPI shape
+
+			, java.lang.Integer width
+
+			, LineStyleHLAPI style
+
+			, NodeGraphicsHLAPI containerNodeGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(shape!=null)
-			item.setShape((LineShape)shape.getContainedItem());
-		
-	
- 		
-			if(width!=null){
-			
-				item.setWidth(width);
-			}
-		
-	
- 		
- 		if(style!=null)
-			item.setStyle((LineStyle)style.getContainedItem());
-		
-	
- 		
- 		if(containerNodeGraphics!=null)
-			item.setContainerNodeGraphics((NodeGraphics)containerNodeGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLine();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (shape != null)
+			item.setShape((LineShape) shape.getContainedItem());
+
+		if (width != null) {
+
+			item.setWidth(width);
+		}
+
+		if (style != null)
+			item.setStyle((LineStyle) style.getContainedItem());
+
+		if (containerNodeGraphics != null)
+			item.setContainerNodeGraphics((NodeGraphics) containerNodeGraphics.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LineHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, LineShapeHLAPI shape
-	
-		, java.lang.Integer width
-	
-		, LineStyleHLAPI style
-	
-		, ArcGraphicsHLAPI containerArcGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LineHLAPI(CSS2ColorHLAPI color
+
+			, LineShapeHLAPI shape
+
+			, java.lang.Integer width
+
+			, LineStyleHLAPI style
+
+			, ArcGraphicsHLAPI containerArcGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(shape!=null)
-			item.setShape((LineShape)shape.getContainedItem());
-		
-	
- 		
-			if(width!=null){
-			
-				item.setWidth(width);
-			}
-		
-	
- 		
- 		if(style!=null)
-			item.setStyle((LineStyle)style.getContainedItem());
-		
-	
- 		
- 		if(containerArcGraphics!=null)
-			item.setContainerArcGraphics((ArcGraphics)containerArcGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLine();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (shape != null)
+			item.setShape((LineShape) shape.getContainedItem());
+
+		if (width != null) {
+
+			item.setWidth(width);
+		}
+
+		if (style != null)
+			item.setStyle((LineStyle) style.getContainedItem());
+
+		if (containerArcGraphics != null)
+			item.setContainerArcGraphics((ArcGraphics) containerArcGraphics.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LineHLAPI(
-		 CSS2ColorHLAPI color
-	
-		, LineShapeHLAPI shape
-	
-		, java.lang.Integer width
-	
-		, LineStyleHLAPI style
-	
-		, AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LineHLAPI(CSS2ColorHLAPI color
+
+			, LineShapeHLAPI shape
+
+			, java.lang.Integer width
+
+			, LineStyleHLAPI style
+
+			, AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(color!=null)
-			item.setColor((CSS2Color)color.getContainedItem());
-		
-	
- 		
- 		if(shape!=null)
-			item.setShape((LineShape)shape.getContainedItem());
-		
-	
- 		
-			if(width!=null){
-			
-				item.setWidth(width);
-			}
-		
-	
- 		
- 		if(style!=null)
-			item.setStyle((LineStyle)style.getContainedItem());
-		
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLine();
+		}
+
+		if (color != null)
+			item.setColor((CSS2Color) color.getContainedItem());
+
+		if (shape != null)
+			item.setShape((LineShape) shape.getContainedItem());
+
+		if (width != null) {
+
+			item.setWidth(width);
+		}
+
+		if (style != null)
+			item.setStyle((LineStyle) style.getContainedItem());
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LineHLAPI(NodeGraphicsHLAPI containerNodeGraphics) {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createLine();
+		}
 
+		if (containerNodeGraphics != null)
+			item.setContainerNodeGraphics((NodeGraphics) containerNodeGraphics.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LineHLAPI(
-		 NodeGraphicsHLAPI containerNodeGraphics
-	){//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(containerNodeGraphics!=null)
-			item.setContainerNodeGraphics((NodeGraphics)containerNodeGraphics.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LineHLAPI(
-		 ArcGraphicsHLAPI containerArcGraphics
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LineHLAPI(ArcGraphicsHLAPI containerArcGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(containerArcGraphics!=null)
-			item.setContainerArcGraphics((ArcGraphics)containerArcGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLine();
+		}
+
+		if (containerArcGraphics != null)
+			item.setContainerArcGraphics((ArcGraphics) containerArcGraphics.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LineHLAPI(
-		 AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LineHLAPI(AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLine();}
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLine();
+		}
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public LineHLAPI(Line lowLevelAPI){
+	public LineHLAPI(Line lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -308,256 +259,230 @@ public class LineHLAPI implements HLAPIClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public Line getContainedItem(){
+	public Line getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public CSS2Color getColor(){
+	public CSS2Color getColor() {
 		return item.getColor();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public LineShape getShape(){
+	public LineShape getShape() {
 		return item.getShape();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getWidth(){
+	public Integer getWidth() {
 		return item.getWidth();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getContainerNodeGraphics(){
+	public NodeGraphics getContainerNodeGraphics() {
 		return item.getContainerNodeGraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ArcGraphics getContainerArcGraphics(){
+	public ArcGraphics getContainerArcGraphics() {
 		return item.getContainerArcGraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getContainerAnnotationGraphics(){
+	public AnnotationGraphics getContainerAnnotationGraphics() {
 		return item.getContainerAnnotationGraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public LineStyle getStyle(){
+	public LineStyle getStyle() {
 		return item.getStyle();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getContainerNodeGraphicsHLAPI(){
-			if(item.getContainerNodeGraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getContainerNodeGraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ArcGraphicsHLAPI getContainerArcGraphicsHLAPI(){
-			if(item.getContainerArcGraphics() == null) return null;
-			return new ArcGraphicsHLAPI(item.getContainerArcGraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI(){
-			if(item.getContainerAnnotationGraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
-		}
-		
-	
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NodeGraphicsHLAPI getContainerNodeGraphicsHLAPI() {
+		if (item.getContainerNodeGraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getContainerNodeGraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ArcGraphicsHLAPI getContainerArcGraphicsHLAPI() {
+		if (item.getContainerArcGraphics() == null)
+			return null;
+		return new ArcGraphicsHLAPI(item.getContainerArcGraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI() {
+		if (item.getContainerAnnotationGraphics() == null)
+			return null;
+		return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Color
 	 */
 	public void setColorHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.CSS2Color elem) {
+
+		if (elem != null) {
+
 			item.setColor(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Shape
 	 */
 	public void setShapeHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape elem) {
+
+		if (elem != null) {
+
 			item.setShape(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Width
 	 */
 	public void setWidthHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setWidth(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Style
 	 */
 	public void setStyleHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle elem) {
+
+		if (elem != null) {
+
 			item.setStyle(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerNodeGraphics
 	 */
 	public void setContainerNodeGraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNodeGraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNodeGraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerArcGraphics
 	 */
 	public void setContainerArcGraphicsHLAPI(
-	
-	ArcGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerArcGraphics((ArcGraphics)elem.getContainedItem());
-	
+
+			ArcGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerArcGraphics((ArcGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAnnotationGraphics
 	 */
 	public void setContainerAnnotationGraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(LineHLAPI item){
+	// equals method
+	public boolean equals(LineHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LineShapeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LineShapeHLAPI.java
@@ -32,31 +32,33 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.LineShape;
-public enum LineShapeHLAPI{
-	LINE("line"),
-	CURVE("curve");
+
+public enum LineShapeHLAPI {
+	LINE("line"), CURVE("curve");
 
 	private final LineShape item;
 
 	private LineShapeHLAPI(String name) {
 		this.item = LineShape.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static LineShapeHLAPI get(int num) {
-	
-      if(num == 0){
-         return LINE;
-      }
-	
-      if(num == 1){
-         return CURVE;
-      }
-	
+
+		if (num == 0) {
+			return LINE;
+		}
+
+		if (num == 1) {
+			return CURVE;
+		}
+
 		return null;
 	}
 
@@ -64,5 +66,4 @@ public enum LineShapeHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LineStyleHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/LineStyleHLAPI.java
@@ -32,36 +32,37 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.LineStyle;
-public enum LineStyleHLAPI{
-	SOLID("SOLID"),
-	DASH("DASH"),
-	DOT("DOT");
+
+public enum LineStyleHLAPI {
+	SOLID("SOLID"), DASH("DASH"), DOT("DOT");
 
 	private final LineStyle item;
 
 	private LineStyleHLAPI(String name) {
 		this.item = LineStyle.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static LineStyleHLAPI get(int num) {
-	
-      if(num == 0){
-         return SOLID;
-      }
-	
-      if(num == 1){
-         return DASH;
-      }
-	
-      if(num == 2){
-         return DOT;
-      }
-	
+
+		if (num == 0) {
+			return SOLID;
+		}
+
+		if (num == 1) {
+			return DASH;
+		}
+
+		if (num == 2) {
+			return DOT;
+		}
+
 		return null;
 	}
 
@@ -69,5 +70,4 @@ public enum LineStyleHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/NameHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/NameHLAPI.java
@@ -53,8 +53,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class NameHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
+public class NameHLAPI implements HLAPIClass, LabelHLAPI, AnnotationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -62,175 +61,145 @@ public class NameHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	private Name item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NameHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NameHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createName();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createName();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NameHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, PetriNetHLAPI containerNamePetriNet
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NameHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, PetriNetHLAPI containerNamePetriNet) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createName();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(containerNamePetriNet!=null)
-			item.setContainerNamePetriNet((PetriNet)containerNamePetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createName();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (containerNamePetriNet != null)
+			item.setContainerNamePetriNet((PetriNet) containerNamePetriNet.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NameHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, PnObjectHLAPI containerNamePnObject
-	){//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createName();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(containerNamePnObject!=null)
-			item.setContainerNamePnObject((PnObject)containerNamePnObject.getContainedItem());
-		
-	
-	}
 
+	public NameHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, PnObjectHLAPI containerNamePnObject) {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createName();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (containerNamePnObject != null)
+			item.setContainerNamePnObject((PnObject) containerNamePnObject.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public NameHLAPI(
-		 java.lang.String text
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public NameHLAPI(java.lang.String text) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createName();}
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createName();
+		}
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NameHLAPI(java.lang.String text
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NameHLAPI(
-		 java.lang.String text
-	
-		, PetriNetHLAPI containerNamePetriNet
-	){//BEGIN CONSTRUCTOR BODY
+			, PetriNetHLAPI containerNamePetriNet) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createName();}
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(containerNamePetriNet!=null)
-			item.setContainerNamePetriNet((PetriNet)containerNamePetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createName();
+		}
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (containerNamePetriNet != null)
+			item.setContainerNamePetriNet((PetriNet) containerNamePetriNet.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NameHLAPI(
-		 java.lang.String text
-	
-		, PnObjectHLAPI containerNamePnObject
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NameHLAPI(java.lang.String text
+
+			, PnObjectHLAPI containerNamePnObject) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createName();}
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(containerNamePnObject!=null)
-			item.setContainerNamePnObject((PnObject)containerNamePnObject.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createName();
+		}
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (containerNamePnObject != null)
+			item.setContainerNamePnObject((PnObject) containerNamePnObject.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NameHLAPI(Name lowLevelAPI){
+	public NameHLAPI(Name lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -238,249 +207,228 @@ public class NameHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Name getContainedItem(){
+	public Name getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getAnnotationgraphics(){
+	public AnnotationGraphics getAnnotationgraphics() {
 		return item.getAnnotationgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getText(){
+	public String getText() {
 		return item.getText();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PetriNet getContainerNamePetriNet(){
+	public PetriNet getContainerNamePetriNet() {
 		return item.getContainerNamePetriNet();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PnObject getContainerNamePnObject(){
+	public PnObject getContainerNamePnObject() {
 		return item.getContainerNamePnObject();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI(){
-			if(item.getAnnotationgraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
-		}
-		
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PetriNetHLAPI getContainerNamePetriNetHLAPI(){
-			if(item.getContainerNamePetriNet() == null) return null;
-			return new PetriNetHLAPI(item.getContainerNamePetriNet());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public PnObjectHLAPI getContainerNamePnObjectHLAPI(){
-			if(item.getContainerNamePnObject() == null) return null;
-			PnObject object = item.getContainerNamePnObject();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Page)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)object);
-			}
-			
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI() {
+		if (item.getAnnotationgraphics() == null)
 			return null;
+		return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PetriNetHLAPI getContainerNamePetriNetHLAPI() {
+		if (item.getContainerNamePetriNet() == null)
+			return null;
+		return new PetriNetHLAPI(item.getContainerNamePetriNet());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PnObjectHLAPI getContainerNamePnObjectHLAPI() {
+		if (item.getContainerNamePnObject() == null)
+			return null;
+		PnObject object = item.getContainerNamePnObject();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Page) object);
 		}
-		
-	
-	
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
 	public void setAnnotationgraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setAnnotationgraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Text
 	 */
 	public void setTextHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setText(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerNamePetriNet
 	 */
 	public void setContainerNamePetriNetHLAPI(
-	
-	PetriNetHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamePetriNet((PetriNet)elem.getContainedItem());
-	
+
+			PetriNetHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamePetriNet((PetriNet) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamePnObject
 	 */
 	public void setContainerNamePnObjectHLAPI(
-	
-	PnObjectHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamePnObject((PnObject)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PnObjectHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamePnObject((PnObject) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NameHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(NameHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/NodeGraphicsHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/NodeGraphicsHLAPI.java
@@ -53,8 +53,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Page;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Position;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class NodeGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
+public class NodeGraphicsHLAPI implements HLAPIClass, GraphicsHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -62,175 +61,139 @@ public class NodeGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
 	private NodeGraphics item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NodeGraphicsHLAPI(
-		 PositionHLAPI position
-	
-		, DimensionHLAPI dimension
-	
-		, FillHLAPI fill
-	
-		, LineHLAPI line
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NodeGraphicsHLAPI(PositionHLAPI position
+
+			, DimensionHLAPI dimension
+
+			, FillHLAPI fill
+
+			, LineHLAPI line) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNodeGraphics();}
-	
- 		
- 		if(position!=null)
-			item.setPosition((Position)position.getContainedItem());
-		
-	
- 		
- 		if(dimension!=null)
-			item.setDimension((Dimension)dimension.getContainedItem());
-		
-	
- 		
- 		if(fill!=null)
-			item.setFill((Fill)fill.getContainedItem());
-		
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNodeGraphics();
+		}
+
+		if (position != null)
+			item.setPosition((Position) position.getContainedItem());
+
+		if (dimension != null)
+			item.setDimension((Dimension) dimension.getContainedItem());
+
+		if (fill != null)
+			item.setFill((Fill) fill.getContainedItem());
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NodeGraphicsHLAPI(
-		 PositionHLAPI position
-	
-		, DimensionHLAPI dimension
-	
-		, FillHLAPI fill
-	
-		, LineHLAPI line
-	
-		, NodeHLAPI containerNode
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NodeGraphicsHLAPI(PositionHLAPI position
+
+			, DimensionHLAPI dimension
+
+			, FillHLAPI fill
+
+			, LineHLAPI line
+
+			, NodeHLAPI containerNode) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNodeGraphics();}
-	
- 		
- 		if(position!=null)
-			item.setPosition((Position)position.getContainedItem());
-		
-	
- 		
- 		if(dimension!=null)
-			item.setDimension((Dimension)dimension.getContainedItem());
-		
-	
- 		
- 		if(fill!=null)
-			item.setFill((Fill)fill.getContainedItem());
-		
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
- 		
- 		if(containerNode!=null)
-			item.setContainerNode((Node)containerNode.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNodeGraphics();
+		}
+
+		if (position != null)
+			item.setPosition((Position) position.getContainedItem());
+
+		if (dimension != null)
+			item.setDimension((Dimension) dimension.getContainedItem());
+
+		if (fill != null)
+			item.setFill((Fill) fill.getContainedItem());
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
+		if (containerNode != null)
+			item.setContainerNode((Node) containerNode.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NodeGraphicsHLAPI(
-		 PositionHLAPI position
-	
-		, DimensionHLAPI dimension
-	
-		, FillHLAPI fill
-	
-		, LineHLAPI line
-	
-		, PageHLAPI containerPage
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NodeGraphicsHLAPI(PositionHLAPI position
+
+			, DimensionHLAPI dimension
+
+			, FillHLAPI fill
+
+			, LineHLAPI line
+
+			, PageHLAPI containerPage) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNodeGraphics();}
-	
- 		
- 		if(position!=null)
-			item.setPosition((Position)position.getContainedItem());
-		
-	
- 		
- 		if(dimension!=null)
-			item.setDimension((Dimension)dimension.getContainedItem());
-		
-	
- 		
- 		if(fill!=null)
-			item.setFill((Fill)fill.getContainedItem());
-		
-	
- 		
- 		if(line!=null)
-			item.setLine((Line)line.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNodeGraphics();
+		}
+
+		if (position != null)
+			item.setPosition((Position) position.getContainedItem());
+
+		if (dimension != null)
+			item.setDimension((Dimension) dimension.getContainedItem());
+
+		if (fill != null)
+			item.setFill((Fill) fill.getContainedItem());
+
+		if (line != null)
+			item.setLine((Line) line.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NodeGraphicsHLAPI(
-		 NodeHLAPI containerNode
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NodeGraphicsHLAPI(NodeHLAPI containerNode) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNodeGraphics();}
-	
- 		
- 		if(containerNode!=null)
-			item.setContainerNode((Node)containerNode.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNodeGraphics();
+		}
+
+		if (containerNode != null)
+			item.setContainerNode((Node) containerNode.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NodeGraphicsHLAPI(
-		 PageHLAPI containerPage
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NodeGraphicsHLAPI(PageHLAPI containerPage) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNodeGraphics();}
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNodeGraphics();
+		}
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NodeGraphicsHLAPI(NodeGraphics lowLevelAPI){
+	public NodeGraphicsHLAPI(NodeGraphics lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -238,291 +201,264 @@ public class NodeGraphicsHLAPI implements HLAPIClass,GraphicsHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public NodeGraphics getContainedItem(){
+	public NodeGraphics getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Position getPosition(){
+	public Position getPosition() {
 		return item.getPosition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Dimension getDimension(){
+	public Dimension getDimension() {
 		return item.getDimension();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Fill getFill(){
+	public Fill getFill() {
 		return item.getFill();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Line getLine(){
+	public Line getLine() {
 		return item.getLine();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Node getContainerNode(){
+	public Node getContainerNode() {
 		return item.getContainerNode();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PositionHLAPI getPositionHLAPI(){
-			if(item.getPosition() == null) return null;
-			return new PositionHLAPI(item.getPosition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DimensionHLAPI getDimensionHLAPI(){
-			if(item.getDimension() == null) return null;
-			return new DimensionHLAPI(item.getDimension());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public FillHLAPI getFillHLAPI(){
-			if(item.getFill() == null) return null;
-			return new FillHLAPI(item.getFill());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public LineHLAPI getLineHLAPI(){
-			if(item.getLine() == null) return null;
-			return new LineHLAPI(item.getLine());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public NodeHLAPI getContainerNodeHLAPI(){
-			if(item.getContainerNode() == null) return null;
-			Node object = item.getContainerNode();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PositionHLAPI getPositionHLAPI() {
+		if (item.getPosition() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
+		return new PositionHLAPI(item.getPosition());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public DimensionHLAPI getDimensionHLAPI() {
+		if (item.getDimension() == null)
+			return null;
+		return new DimensionHLAPI(item.getDimension());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public FillHLAPI getFillHLAPI() {
+		if (item.getFill() == null)
+			return null;
+		return new FillHLAPI(item.getFill());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public LineHLAPI getLineHLAPI() {
+		if (item.getLine() == null)
+			return null;
+		return new LineHLAPI(item.getLine());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeHLAPI getContainerNodeHLAPI() {
+		if (item.getContainerNode() == null)
+			return null;
+		Node object = item.getContainerNode();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerPage());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Position
 	 */
 	public void setPositionHLAPI(
-	
-	PositionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setPosition((Position)elem.getContainedItem());
-	
+
+			PositionHLAPI elem) {
+
+		if (elem != null)
+			item.setPosition((Position) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Dimension
 	 */
 	public void setDimensionHLAPI(
-	
-	DimensionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setDimension((Dimension)elem.getContainedItem());
-	
+
+			DimensionHLAPI elem) {
+
+		if (elem != null)
+			item.setDimension((Dimension) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Fill
 	 */
 	public void setFillHLAPI(
-	
-	FillHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setFill((Fill)elem.getContainedItem());
-	
+
+			FillHLAPI elem) {
+
+		if (elem != null)
+			item.setFill((Fill) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Line
 	 */
 	public void setLineHLAPI(
-	
-	LineHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setLine((Line)elem.getContainedItem());
-	
+
+			LineHLAPI elem) {
+
+		if (elem != null)
+			item.setLine((Line) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNode
 	 */
 	public void setContainerNodeHLAPI(
-	
-	NodeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNode((Node)elem.getContainedItem());
-	
+
+			NodeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNode((Node) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
+
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NodeGraphicsHLAPI item){
+	// equals method
+	public boolean equals(NodeGraphicsHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/NodeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/NodeHLAPI.java
@@ -44,160 +44,118 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Page;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface NodeHLAPI extends HLAPIClass,PnObjectHLAPI{
+public interface NodeHLAPI extends HLAPIClass, PnObjectHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public Name getName();
-	
+
 	/**
 	 *
 	 */
 	public List<ToolInfo> getToolspecifics();
-	
+
 	/**
 	 *
 	 */
 	public Page getContainerPage();
-	
+
 	/**
 	 *
 	 */
 	public List<Arc> getInArcs();
-	
+
 	/**
 	 *
 	 */
 	public List<Arc> getOutArcs();
-	
+
 	/**
 	 *
 	 */
 	public NodeGraphics getNodegraphics();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NameHLAPI getNameHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NameHLAPI getNameHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PageHLAPI getContainerPageHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	NameHLAPI elem);
-	
+	public void setNameHLAPI(NameHLAPI elem);
+
 	/**
 	 * set Nodegraphics
 	 */
-	public void setNodegraphicsHLAPI(
-	NodeGraphicsHLAPI elem);
-	
+	public void setNodegraphicsHLAPI(NodeGraphicsHLAPI elem);
+
 	/**
 	 * set ContainerPage
 	 */
-	public void setContainerPageHLAPI(
-	PageHLAPI elem);
-	
+	public void setContainerPageHLAPI(PageHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
 	public void addToolspecificsHLAPI(ToolInfoHLAPI unit);
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
-	
 
-	//equals method
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/OffsetHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/OffsetHLAPI.java
@@ -48,8 +48,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructureFactory;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class OffsetHLAPI implements HLAPIClass,CoordinateHLAPI{
+public class OffsetHLAPI implements HLAPIClass, CoordinateHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -57,77 +56,63 @@ public class OffsetHLAPI implements HLAPIClass,CoordinateHLAPI{
 	private Offset item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public OffsetHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OffsetHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOffset();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createOffset();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public OffsetHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	
-		, AnnotationGraphicsHLAPI containerAnnotationGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public OffsetHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y
+
+			, AnnotationGraphicsHLAPI containerAnnotationGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createOffset();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
- 		
- 		if(containerAnnotationGraphics!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)containerAnnotationGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createOffset();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
+		if (containerAnnotationGraphics != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) containerAnnotationGraphics.getContainedItem());
+
 	}
-
-
-
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public OffsetHLAPI(Offset lowLevelAPI){
+	public OffsetHLAPI(Offset lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -135,138 +120,124 @@ public class OffsetHLAPI implements HLAPIClass,CoordinateHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Offset getContainedItem(){
+	public Offset getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getX(){
+	public Integer getX() {
 		return item.getX();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getY(){
+	public Integer getY() {
 		return item.getY();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getContainerAnnotationGraphics(){
+	public AnnotationGraphics getContainerAnnotationGraphics() {
 		return item.getContainerAnnotationGraphics();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI(){
-			if(item.getContainerAnnotationGraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public AnnotationGraphicsHLAPI getContainerAnnotationGraphicsHLAPI() {
+		if (item.getContainerAnnotationGraphics() == null)
+			return null;
+		return new AnnotationGraphicsHLAPI(item.getContainerAnnotationGraphics());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set X
 	 */
 	public void setXHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setX(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Y
 	 */
 	public void setYHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setY(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerAnnotationGraphics
 	 */
 	public void setContainerAnnotationGraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAnnotationGraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAnnotationGraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(OffsetHLAPI item){
+	// equals method
+	public boolean equals(OffsetHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PNTypeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PNTypeHLAPI.java
@@ -32,8 +32,10 @@
  * $Id ggiffo, Thu Feb 11 16:30:27 CET 2016$
  */
 package fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi;
+
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType;
-public enum PNTypeHLAPI{
+
+public enum PNTypeHLAPI {
 	SYMNET("http://www.pnml.org/version-2009/grammar/symmetricnet"),
 	COREMODEL("http://www.pnml.org/version-2009/grammar/pnmlcoremodel"),
 	PTNET("http://www.pnml.org/version-2009/grammar/ptnet"),
@@ -45,33 +47,34 @@ public enum PNTypeHLAPI{
 	private PNTypeHLAPI(String name) {
 		this.item = PNType.get(name);
 	}
-	
+
 	/**
 	 * Return one HLAPI enum (used for tests).
+	 * 
 	 * @return one of the enum, null if the int is "out of bounds"
 	 */
 	public static PNTypeHLAPI get(int num) {
-	
-      if(num == 0){
-         return SYMNET;
-      }
-	
-      if(num == 1){
-         return COREMODEL;
-      }
-	
-      if(num == 2){
-         return PTNET;
-      }
-	
-      if(num == 3){
-         return HLPN;
-      }
-	
-      if(num == 4){
-         return PTHLPN;
-      }
-	
+
+		if (num == 0) {
+			return SYMNET;
+		}
+
+		if (num == 1) {
+			return COREMODEL;
+		}
+
+		if (num == 2) {
+			return PTNET;
+		}
+
+		if (num == 3) {
+			return HLPN;
+		}
+
+		if (num == 4) {
+			return PTHLPN;
+		}
+
 		return null;
 	}
 
@@ -79,5 +82,4 @@ public enum PNTypeHLAPI{
 		return item;
 	}
 
-	
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PageHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PageHLAPI.java
@@ -57,8 +57,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class PageHLAPI implements HLAPIClass,PnObjectHLAPI{
+public class PageHLAPI implements HLAPIClass, PnObjectHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -66,196 +65,163 @@ public class PageHLAPI implements HLAPIClass,PnObjectHLAPI{
 	private Page item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PageHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PageHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR
+																									// BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPage();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPage();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PageHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PageHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPage();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPage();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PageHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, PetriNetHLAPI containerPetriNet
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPage();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(containerPetriNet!=null)
-			item.setContainerPetriNet((PetriNet)containerPetriNet.getContainedItem());
-		
-	
-	}
 
+	public PageHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, PetriNetHLAPI containerPetriNet) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR
+																									// BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createPage();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (containerPetriNet != null)
+			item.setContainerPetriNet((PetriNet) containerPetriNet.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public PageHLAPI(
-		 java.lang.String id
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public PageHLAPI(java.lang.String id) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPage();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createPage();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PageHLAPI(java.lang.String id
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PageHLAPI(
-		 java.lang.String id
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPage();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPage();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PageHLAPI(
-		 java.lang.String id
-	
-		, PetriNetHLAPI containerPetriNet
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PageHLAPI(java.lang.String id
+
+			, PetriNetHLAPI containerPetriNet) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR
+																									// BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPage();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(containerPetriNet!=null)
-			item.setContainerPetriNet((PetriNet)containerPetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPage();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (containerPetriNet != null)
+			item.setContainerPetriNet((PetriNet) containerPetriNet.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PageHLAPI(Page lowLevelAPI){
+	public PageHLAPI(Page lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -263,482 +229,421 @@ public class PageHLAPI implements HLAPIClass,PnObjectHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Page getContainedItem(){
+	public Page getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<PnObject> getObjects(){
+	public List<PnObject> getObjects() {
 		return item.getObjects();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PetriNet getContainerPetriNet(){
+	public PetriNet getContainerPetriNet() {
 		return item.getContainerPetriNet();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getNodegraphics(){
+	public NodeGraphics getNodegraphics() {
 		return item.getNodegraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Declaration> getDeclaration(){
+	public List<Declaration> getDeclaration() {
 		return item.getDeclaration();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<PnObjectHLAPI> getObjectsHLAPI(){
-			java.util.List<PnObjectHLAPI> retour = new ArrayList<PnObjectHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Page)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PetriNetHLAPI getContainerPetriNetHLAPI(){
-			if(item.getContainerPetriNet() == null) return null;
-			return new PetriNetHLAPI(item.getContainerPetriNet());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI(){
-			if(item.getNodegraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getNodegraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<DeclarationHLAPI> getDeclarationHLAPI(){
-			java.util.List<DeclarationHLAPI> retour = new ArrayList<DeclarationHLAPI>();
-			for (Declaration elemnt : getDeclaration()) {
-				retour.add(new DeclarationHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PageHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI> getObjects_hlcorestructure_PageHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Page)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ArcHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI> getObjects_hlcorestructure_ArcHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PlaceHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI> getObjects_hlcorestructure_PlaceHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of RefTransitionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI> getObjects_hlcorestructure_RefTransitionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TransitionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI> getObjects_hlcorestructure_TransitionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of RefPlaceHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI> getObjects_hlcorestructure_RefPlaceHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI>();
-			for (PnObject elemnt : getObjects()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
-						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
+			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerPage());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<PnObjectHLAPI> getObjectsHLAPI() {
+		java.util.List<PnObjectHLAPI> retour = new ArrayList<PnObjectHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Page) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PetriNetHLAPI getContainerPetriNetHLAPI() {
+		if (item.getContainerPetriNet() == null)
+			return null;
+		return new PetriNetHLAPI(item.getContainerPetriNet());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI() {
+		if (item.getNodegraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getNodegraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<DeclarationHLAPI> getDeclarationHLAPI() {
+		java.util.List<DeclarationHLAPI> retour = new ArrayList<DeclarationHLAPI>();
+		for (Declaration elemnt : getDeclaration()) {
+			retour.add(new DeclarationHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PageHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI> getObjects_hlcorestructure_PageHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Page) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ArcHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI> getObjects_hlcorestructure_ArcHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PlaceHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI> getObjects_hlcorestructure_PlaceHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * RefTransitionHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI> getObjects_hlcorestructure_RefTransitionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * TransitionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI> getObjects_hlcorestructure_TransitionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of RefPlaceHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI> getObjects_hlcorestructure_RefPlaceHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI>();
+		for (PnObject elemnt : getObjects()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+						(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Nodegraphics
 	 */
 	public void setNodegraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setNodegraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setNodegraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
+
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPetriNet
 	 */
 	public void setContainerPetriNetHLAPI(
-	
-	PetriNetHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPetriNet((PetriNet)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	//Thread-safe insertion of objects in a Page
-	public synchronized void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PetriNetHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPetriNet((PetriNet) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
-	
-	//Thread-safe insertion of objects in a Page
-	public synchronized void addObjectsHLAPI(PnObjectHLAPI unit){
-	
-		item.getObjects().add((PnObject)unit.getContainedItem());
+	// setters/remover for lists.
+
+	// Thread-safe insertion of objects in a Page
+	public synchronized void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
 	}
 
-	public void removeObjectsHLAPI(PnObjectHLAPI unit){
-		item.getObjects().remove((PnObject)unit.getContainedItem());
-	}
-	
-	
-	//Thread-safe insertion of objects in a Page
-	public synchronized void addDeclarationHLAPI(DeclarationHLAPI unit){
-	
-		item.getDeclaration().add((Declaration)unit.getContainedItem());
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
 	}
 
-	public void removeDeclarationHLAPI(DeclarationHLAPI unit){
-		item.getDeclaration().remove((Declaration)unit.getContainedItem());
-	}
-	
+	// Thread-safe insertion of objects in a Page
+	public synchronized void addObjectsHLAPI(PnObjectHLAPI unit) {
 
-	//equals method
-	public boolean equals(PageHLAPI item){
+		item.getObjects().add((PnObject) unit.getContainedItem());
+	}
+
+	public void removeObjectsHLAPI(PnObjectHLAPI unit) {
+		item.getObjects().remove((PnObject) unit.getContainedItem());
+	}
+
+	// Thread-safe insertion of objects in a Page
+	public synchronized void addDeclarationHLAPI(DeclarationHLAPI unit) {
+
+		item.getDeclaration().add((Declaration) unit.getContainedItem());
+	}
+
+	public void removeDeclarationHLAPI(DeclarationHLAPI unit) {
+		item.getDeclaration().remove((Declaration) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PageHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PetriNetDocHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PetriNetDocHLAPI.java
@@ -50,8 +50,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class PetriNetDocHLAPI implements HLAPIRootClass{
+public class PetriNetDocHLAPI implements HLAPIRootClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -59,23 +58,21 @@ public class PetriNetDocHLAPI implements HLAPIRootClass{
 	private PetriNetDoc item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PetriNetDocHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public PetriNetDocHLAPI() {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPetriNetDoc();}
-	
+		synchronized (fact) {
+			item = fact.createPetriNetDoc();
+		}
+
 	}
-
-
-
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PetriNetDocHLAPI(PetriNetDoc lowLevelAPI){
+	public PetriNetDocHLAPI(PetriNetDoc lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -83,99 +80,86 @@ public class PetriNetDocHLAPI implements HLAPIRootClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public PetriNetDoc getContainedItem(){
+	public PetriNetDoc getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<PetriNet> getNets(){
+	public List<PetriNet> getNets() {
 		return item.getNets();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getXmlns(){
+	public String getXmlns() {
 		return item.getXmlns();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<PetriNetHLAPI> getNetsHLAPI(){
-			java.util.List<PetriNetHLAPI> retour = new ArrayList<PetriNetHLAPI>();
-			for (PetriNet elemnt : getNets()) {
-				retour.add(new PetriNetHLAPI(elemnt));
-			}
-			return retour;
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<PetriNetHLAPI> getNetsHLAPI() {
+		java.util.List<PetriNetHLAPI> retour = new ArrayList<PetriNetHLAPI>();
+		for (PetriNet elemnt : getNets()) {
+			retour.add(new PetriNetHLAPI(elemnt));
 		}
-	
-	
-	
-	
-
-	//Special getter for list of generics object, return only one object type.
-	
-	
-
-	//setters (including container setter if aviable)
-	
-	
-
-	//setters/remover for lists.
-	
-	
-	public void addNetsHLAPI(PetriNetHLAPI unit){
-	
-		item.getNets().add((PetriNet)unit.getContainedItem());
+		return retour;
 	}
 
-	public void removeNetsHLAPI(PetriNetHLAPI unit){
-		item.getNets().remove((PetriNet)unit.getContainedItem());
-	}
-	
+	// Special getter for list of generics object, return only one object type.
 
-	//equals method
-	public boolean equals(PetriNetDocHLAPI item){
+	// setters (including container setter if aviable)
+
+	// setters/remover for lists.
+
+	public void addNetsHLAPI(PetriNetHLAPI unit) {
+
+		item.getNets().add((PetriNet) unit.getContainedItem());
+	}
+
+	public void removeNetsHLAPI(PetriNetHLAPI unit) {
+		item.getNets().remove((PetriNet) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PetriNetDocHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PetriNetHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PetriNetHLAPI.java
@@ -57,8 +57,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class PetriNetHLAPI implements HLAPIClass{
+public class PetriNetHLAPI implements HLAPIClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -66,144 +65,120 @@ public class PetriNetHLAPI implements HLAPIClass{
 	private PetriNet item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PetriNetHLAPI(
-		 java.lang.String id
-	
-		, PNTypeHLAPI type
-	
-		, NameHLAPI name
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PetriNetHLAPI(java.lang.String id
+
+			, PNTypeHLAPI type
+
+			, NameHLAPI name) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPetriNet();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(type!=null)
-			item.setType((PNType)type.getContainedItem());
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPetriNet();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (type != null)
+			item.setType((PNType) type.getContainedItem());
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PetriNetHLAPI(
-		 java.lang.String id
-	
-		, PNTypeHLAPI type
-	
-		, NameHLAPI name
-	
-		, PetriNetDocHLAPI containerPetriNetDoc
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPetriNet();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(type!=null)
-			item.setType((PNType)type.getContainedItem());
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(containerPetriNetDoc!=null)
-			item.setContainerPetriNetDoc((PetriNetDoc)containerPetriNetDoc.getContainedItem());
-		
-	
-	}
 
+	public PetriNetHLAPI(java.lang.String id
+
+			, PNTypeHLAPI type
+
+			, NameHLAPI name
+
+			, PetriNetDocHLAPI containerPetriNetDoc) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createPetriNet();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (type != null)
+			item.setType((PNType) type.getContainedItem());
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (containerPetriNetDoc != null)
+			item.setContainerPetriNetDoc((PetriNetDoc) containerPetriNetDoc.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public PetriNetHLAPI(
-		 java.lang.String id
-	
-		, PNTypeHLAPI type
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public PetriNetHLAPI(java.lang.String id
+
+			, PNTypeHLAPI type) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPetriNet();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(type!=null)
-			item.setType((PNType)type.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPetriNet();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (type != null)
+			item.setType((PNType) type.getContainedItem());
+
 	}
 
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PetriNetHLAPI(
-		 java.lang.String id
-	
-		, PNTypeHLAPI type
-	
-		, PetriNetDocHLAPI containerPetriNetDoc
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PetriNetHLAPI(java.lang.String id
+
+			, PNTypeHLAPI type
+
+			, PetriNetDocHLAPI containerPetriNetDoc) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPetriNet();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(type!=null)
-			item.setType((PNType)type.getContainedItem());
-		
-	
- 		
- 		if(containerPetriNetDoc!=null)
-			item.setContainerPetriNetDoc((PetriNetDoc)containerPetriNetDoc.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPetriNet();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (type != null)
+			item.setType((PNType) type.getContainedItem());
+
+		if (containerPetriNetDoc != null)
+			item.setContainerPetriNetDoc((PetriNetDoc) containerPetriNetDoc.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PetriNetHLAPI(PetriNet lowLevelAPI){
+	public PetriNetHLAPI(PetriNet lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -211,283 +186,247 @@ public class PetriNetHLAPI implements HLAPIClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public PetriNet getContainedItem(){
+	public PetriNet getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PNType getType(){
+	public PNType getType() {
 		return item.getType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Page> getPages(){
+	public List<Page> getPages() {
 		return item.getPages();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PetriNetDoc getContainerPetriNetDoc(){
+	public PetriNetDoc getContainerPetriNetDoc() {
 		return item.getContainerPetriNetDoc();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Declaration> getDeclaration(){
+	public List<Declaration> getDeclaration() {
 		return item.getDeclaration();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<PageHLAPI> getPagesHLAPI(){
-			java.util.List<PageHLAPI> retour = new ArrayList<PageHLAPI>();
-			for (Page elemnt : getPages()) {
-				retour.add(new PageHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PetriNetDocHLAPI getContainerPetriNetDocHLAPI(){
-			if(item.getContainerPetriNetDoc() == null) return null;
-			return new PetriNetDocHLAPI(item.getContainerPetriNetDoc());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<DeclarationHLAPI> getDeclarationHLAPI(){
-			java.util.List<DeclarationHLAPI> retour = new ArrayList<DeclarationHLAPI>();
-			for (Declaration elemnt : getDeclaration()) {
-				retour.add(new DeclarationHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public java.util.List<PageHLAPI> getPagesHLAPI() {
+		java.util.List<PageHLAPI> retour = new ArrayList<PageHLAPI>();
+		for (Page elemnt : getPages()) {
+			retour.add(new PageHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
+			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PetriNetDocHLAPI getContainerPetriNetDocHLAPI() {
+		if (item.getContainerPetriNetDoc() == null)
+			return null;
+		return new PetriNetDocHLAPI(item.getContainerPetriNetDoc());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<DeclarationHLAPI> getDeclarationHLAPI() {
+		java.util.List<DeclarationHLAPI> retour = new ArrayList<DeclarationHLAPI>();
+		for (Declaration elemnt : getDeclaration()) {
+			retour.add(new DeclarationHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Type
 	 */
 	public void setTypeHLAPI(
-	
-	fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType elem){
-	
-	
-		if(elem!=null){
-		
+
+			fr.lip6.move.pnml.pthlpng.hlcorestructure.PNType elem) {
+
+		if (elem != null) {
+
 			item.setType(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPetriNetDoc
 	 */
 	public void setContainerPetriNetDocHLAPI(
-	
-	PetriNetDocHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPetriNetDoc((PetriNetDoc)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addPagesHLAPI(PageHLAPI unit){
-	
-		item.getPages().add((Page)unit.getContainedItem());
+			PetriNetDocHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPetriNetDoc((PetriNetDoc) elem.getContainedItem());
+
 	}
 
-	public void removePagesHLAPI(PageHLAPI unit){
-		item.getPages().remove((Page)unit.getContainedItem());
-	}
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+	// setters/remover for lists.
+
+	public void addPagesHLAPI(PageHLAPI unit) {
+
+		item.getPages().add((Page) unit.getContainedItem());
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
-	
-	public void addDeclarationHLAPI(DeclarationHLAPI unit){
-	
-		item.getDeclaration().add((Declaration)unit.getContainedItem());
+	public void removePagesHLAPI(PageHLAPI unit) {
+		item.getPages().remove((Page) unit.getContainedItem());
 	}
 
-	public void removeDeclarationHLAPI(DeclarationHLAPI unit){
-		item.getDeclaration().remove((Declaration)unit.getContainedItem());
-	}
-	
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
 
-	//equals method
-	public boolean equals(PetriNetHLAPI item){
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	public void addDeclarationHLAPI(DeclarationHLAPI unit) {
+
+		item.getDeclaration().add((Declaration) unit.getContainedItem());
+	}
+
+	public void removeDeclarationHLAPI(DeclarationHLAPI unit) {
+		item.getDeclaration().remove((Declaration) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PetriNetHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PlaceHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PlaceHLAPI.java
@@ -59,8 +59,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Type;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class PlaceHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,PlaceNodeHLAPI{
+public class PlaceHLAPI implements HLAPIClass, PnObjectHLAPI, NodeHLAPI, PlaceNodeHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -68,158 +67,127 @@ public class PlaceHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,PlaceNodeH
 	private Place item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PlaceHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, TypeHLAPI type
-	
-		, HLMarkingHLAPI hlinitialMarking
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PlaceHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, TypeHLAPI type
+
+			, HLMarkingHLAPI hlinitialMarking) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR
+																									// BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((Type)type.getContainedItem());
-		
-	
- 		
- 		if(hlinitialMarking!=null)
-			item.setHlinitialMarking((HLMarking)hlinitialMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (type != null)
+			item.setType((Type) type.getContainedItem());
+
+		if (hlinitialMarking != null)
+			item.setHlinitialMarking((HLMarking) hlinitialMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PlaceHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, TypeHLAPI type
-	
-		, HLMarkingHLAPI hlinitialMarking
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((Type)type.getContainedItem());
-		
-	
- 		
- 		if(hlinitialMarking!=null)
-			item.setHlinitialMarking((HLMarking)hlinitialMarking.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
-	}
 
+	public PlaceHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, TypeHLAPI type
+
+			, HLMarkingHLAPI hlinitialMarking
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (type != null)
+			item.setType((Type) type.getContainedItem());
+
+		if (hlinitialMarking != null)
+			item.setHlinitialMarking((HLMarking) hlinitialMarking.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public PlaceHLAPI(
-		 java.lang.String id
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public PlaceHLAPI(java.lang.String id) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
 	}
 
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PlaceHLAPI(
-		 java.lang.String id
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PlaceHLAPI(java.lang.String id
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PlaceHLAPI(Place lowLevelAPI){
+	public PlaceHLAPI(Place lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -227,373 +195,324 @@ public class PlaceHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,PlaceNodeH
 	/**
 	 * Return encapsulated object
 	 */
-	public Place getContainedItem(){
+	public Place getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getInArcs(){
+	public List<Arc> getInArcs() {
 		return item.getInArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getOutArcs(){
+	public List<Arc> getOutArcs() {
 		return item.getOutArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getNodegraphics(){
+	public NodeGraphics getNodegraphics() {
 		return item.getNodegraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<RefPlace> getReferencingPlaces(){
+	public List<RefPlace> getReferencingPlaces() {
 		return item.getReferencingPlaces();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getType(){
+	public Type getType() {
 		return item.getType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getHlinitialMarking(){
+	public HLMarking getHlinitialMarking() {
 		return item.getHlinitialMarking();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getInArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getOutArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI(){
-			if(item.getNodegraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getNodegraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<RefPlaceHLAPI> getReferencingPlacesHLAPI(){
-			java.util.List<RefPlaceHLAPI> retour = new ArrayList<RefPlaceHLAPI>();
-			for (RefPlace elemnt : getReferencingPlaces()) {
-				retour.add(new RefPlaceHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getTypeHLAPI(){
-			if(item.getType() == null) return null;
-			return new TypeHLAPI(item.getType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getHlinitialMarkingHLAPI(){
-			if(item.getHlinitialMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getHlinitialMarking());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
+			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerPage());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getInArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getOutArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI() {
+		if (item.getNodegraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getNodegraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<RefPlaceHLAPI> getReferencingPlacesHLAPI() {
+		java.util.List<RefPlaceHLAPI> retour = new ArrayList<RefPlaceHLAPI>();
+		for (RefPlace elemnt : getReferencingPlaces()) {
+			retour.add(new RefPlaceHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getTypeHLAPI() {
+		if (item.getType() == null)
+			return null;
+		return new TypeHLAPI(item.getType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getHlinitialMarkingHLAPI() {
+		if (item.getHlinitialMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getHlinitialMarking());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Nodegraphics
 	 */
 	public void setNodegraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setNodegraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setNodegraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Type
 	 */
 	public void setTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set HlinitialMarking
 	 */
 	public void setHlinitialMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setHlinitialMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setHlinitialMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(PlaceHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PlaceHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PlaceNodeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PlaceNodeHLAPI.java
@@ -45,177 +45,130 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Page;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface PlaceNodeHLAPI extends HLAPIClass,PnObjectHLAPI,NodeHLAPI{
+public interface PlaceNodeHLAPI extends HLAPIClass, PnObjectHLAPI, NodeHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public Name getName();
-	
+
 	/**
 	 *
 	 */
 	public List<ToolInfo> getToolspecifics();
-	
+
 	/**
 	 *
 	 */
 	public Page getContainerPage();
-	
+
 	/**
 	 *
 	 */
 	public List<Arc> getInArcs();
-	
+
 	/**
 	 *
 	 */
 	public List<Arc> getOutArcs();
-	
+
 	/**
 	 *
 	 */
 	public NodeGraphics getNodegraphics();
-	
+
 	/**
 	 *
 	 */
 	public List<RefPlace> getReferencingPlaces();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NameHLAPI getNameHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<RefPlaceHLAPI> getReferencingPlacesHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NameHLAPI getNameHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PageHLAPI getContainerPageHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<RefPlaceHLAPI> getReferencingPlacesHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	NameHLAPI elem);
-	
+	public void setNameHLAPI(NameHLAPI elem);
+
 	/**
 	 * set Nodegraphics
 	 */
-	public void setNodegraphicsHLAPI(
-	NodeGraphicsHLAPI elem);
-	
+	public void setNodegraphicsHLAPI(NodeGraphicsHLAPI elem);
+
 	/**
 	 * set ContainerPage
 	 */
-	public void setContainerPageHLAPI(
-	PageHLAPI elem);
-	
+	public void setContainerPageHLAPI(PageHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
 	public void addToolspecificsHLAPI(ToolInfoHLAPI unit);
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
-	
 
-	//equals method
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PnObjectHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PnObjectHLAPI.java
@@ -42,103 +42,77 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Name;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Page;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface PnObjectHLAPI extends HLAPIClass{
+public interface PnObjectHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public Name getName();
-	
+
 	/**
 	 *
 	 */
 	public List<ToolInfo> getToolspecifics();
-	
+
 	/**
 	 *
 	 */
 	public Page getContainerPage();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NameHLAPI getNameHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NameHLAPI getNameHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PageHLAPI getContainerPageHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	NameHLAPI elem);
-	
+	public void setNameHLAPI(NameHLAPI elem);
+
 	/**
 	 * set ContainerPage
 	 */
-	public void setContainerPageHLAPI(
-	PageHLAPI elem);
-	
+	public void setContainerPageHLAPI(PageHLAPI elem);
 
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
 	public void addToolspecificsHLAPI(ToolInfoHLAPI unit);
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
-	
 
-	//equals method
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PositionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/PositionHLAPI.java
@@ -49,8 +49,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Position;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class PositionHLAPI implements HLAPIClass,CoordinateHLAPI{
+public class PositionHLAPI implements HLAPIClass, CoordinateHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -58,113 +57,93 @@ public class PositionHLAPI implements HLAPIClass,CoordinateHLAPI{
 	private Position item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PositionHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositionHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPosition();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createPosition();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositionHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	
-		, ArcGraphicsHLAPI containerArcGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositionHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y
+
+			, ArcGraphicsHLAPI containerArcGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPosition();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
- 		
- 		if(containerArcGraphics!=null)
-			item.setContainerArcGraphics((ArcGraphics)containerArcGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPosition();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
+		if (containerArcGraphics != null)
+			item.setContainerArcGraphics((ArcGraphics) containerArcGraphics.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositionHLAPI(
-		 java.lang.Integer x
-	
-		, java.lang.Integer y
-	
-		, NodeGraphicsHLAPI containerPNodeGraphics
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositionHLAPI(java.lang.Integer x
+
+			, java.lang.Integer y
+
+			, NodeGraphicsHLAPI containerPNodeGraphics) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPosition();}
-	
- 		
-			if(x!=null){
-			
-				item.setX(x);
-			}
-		
-	
- 		
-			if(y!=null){
-			
-				item.setY(y);
-			}
-		
-	
- 		
- 		if(containerPNodeGraphics!=null)
-			item.setContainerPNodeGraphics((NodeGraphics)containerPNodeGraphics.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPosition();
+		}
+
+		if (x != null) {
+
+			item.setX(x);
+		}
+
+		if (y != null) {
+
+			item.setY(y);
+		}
+
+		if (containerPNodeGraphics != null)
+			item.setContainerPNodeGraphics((NodeGraphics) containerPNodeGraphics.getContainedItem());
+
 	}
-
-
-
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PositionHLAPI(Position lowLevelAPI){
+	public PositionHLAPI(Position lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -172,174 +151,156 @@ public class PositionHLAPI implements HLAPIClass,CoordinateHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Position getContainedItem(){
+	public Position getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getX(){
+	public Integer getX() {
 		return item.getX();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Integer getY(){
+	public Integer getY() {
 		return item.getY();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ArcGraphics getContainerArcGraphics(){
+	public ArcGraphics getContainerArcGraphics() {
 		return item.getContainerArcGraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getContainerPNodeGraphics(){
+	public NodeGraphics getContainerPNodeGraphics() {
 		return item.getContainerPNodeGraphics();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ArcGraphicsHLAPI getContainerArcGraphicsHLAPI(){
-			if(item.getContainerArcGraphics() == null) return null;
-			return new ArcGraphicsHLAPI(item.getContainerArcGraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getContainerPNodeGraphicsHLAPI(){
-			if(item.getContainerPNodeGraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getContainerPNodeGraphics());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public ArcGraphicsHLAPI getContainerArcGraphicsHLAPI() {
+		if (item.getContainerArcGraphics() == null)
+			return null;
+		return new ArcGraphicsHLAPI(item.getContainerArcGraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeGraphicsHLAPI getContainerPNodeGraphicsHLAPI() {
+		if (item.getContainerPNodeGraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getContainerPNodeGraphics());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set X
 	 */
 	public void setXHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setX(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Y
 	 */
 	public void setYHLAPI(
-	
-	java.lang.Integer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Integer elem) {
+
+		if (elem != null) {
+
 			item.setY(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerArcGraphics
 	 */
 	public void setContainerArcGraphicsHLAPI(
-	
-	ArcGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerArcGraphics((ArcGraphics)elem.getContainedItem());
-	
+
+			ArcGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerArcGraphics((ArcGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPNodeGraphics
 	 */
 	public void setContainerPNodeGraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPNodeGraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPNodeGraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(PositionHLAPI item){
+	// equals method
+	public boolean equals(PositionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/RefPlaceHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/RefPlaceHLAPI.java
@@ -57,8 +57,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class RefPlaceHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,PlaceNodeHLAPI{
+public class RefPlaceHLAPI implements HLAPIClass, PnObjectHLAPI, NodeHLAPI, PlaceNodeHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -66,158 +65,126 @@ public class RefPlaceHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,PlaceNo
 	private RefPlace item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public RefPlaceHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, PlaceNodeHLAPI ref
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public RefPlaceHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, PlaceNodeHLAPI ref) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((PlaceNode)ref.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createRefPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (ref != null)
+			item.setRef((PlaceNode) ref.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public RefPlaceHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, PlaceNodeHLAPI ref
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((PlaceNode)ref.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
-	}
 
+	public RefPlaceHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, PlaceNodeHLAPI ref
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createRefPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (ref != null)
+			item.setRef((PlaceNode) ref.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public RefPlaceHLAPI(
-		 java.lang.String id
-	
-		, PlaceNodeHLAPI ref
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public RefPlaceHLAPI(java.lang.String id
+
+			, PlaceNodeHLAPI ref) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((PlaceNode)ref.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createRefPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (ref != null)
+			item.setRef((PlaceNode) ref.getContainedItem());
+
 	}
 
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public RefPlaceHLAPI(
-		 java.lang.String id
-	
-		, PlaceNodeHLAPI ref
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public RefPlaceHLAPI(java.lang.String id
+
+			, PlaceNodeHLAPI ref
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefPlace();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((PlaceNode)ref.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createRefPlace();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (ref != null)
+			item.setRef((PlaceNode) ref.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public RefPlaceHLAPI(RefPlace lowLevelAPI){
+	public RefPlaceHLAPI(RefPlace lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -225,348 +192,304 @@ public class RefPlaceHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,PlaceNo
 	/**
 	 * Return encapsulated object
 	 */
-	public RefPlace getContainedItem(){
+	public RefPlace getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getInArcs(){
+	public List<Arc> getInArcs() {
 		return item.getInArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getOutArcs(){
+	public List<Arc> getOutArcs() {
 		return item.getOutArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getNodegraphics(){
+	public NodeGraphics getNodegraphics() {
 		return item.getNodegraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<RefPlace> getReferencingPlaces(){
+	public List<RefPlace> getReferencingPlaces() {
 		return item.getReferencingPlaces();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PlaceNode getRef(){
+	public PlaceNode getRef() {
 		return item.getRef();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getInArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getOutArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI(){
-			if(item.getNodegraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getNodegraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<RefPlaceHLAPI> getReferencingPlacesHLAPI(){
-			java.util.List<RefPlaceHLAPI> retour = new ArrayList<RefPlaceHLAPI>();
-			for (RefPlace elemnt : getReferencingPlaces()) {
-				retour.add(new RefPlaceHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public PlaceNodeHLAPI getRefHLAPI(){
-			if(item.getRef() == null) return null;
-			PlaceNode object = item.getRef();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
 			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-		
-	
-	
+		return retour;
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerPage());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getInArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getOutArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI() {
+		if (item.getNodegraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getNodegraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<RefPlaceHLAPI> getReferencingPlacesHLAPI() {
+		java.util.List<RefPlaceHLAPI> retour = new ArrayList<RefPlaceHLAPI>();
+		for (RefPlace elemnt : getReferencingPlaces()) {
+			retour.add(new RefPlaceHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PlaceNodeHLAPI getRefHLAPI() {
+		if (item.getRef() == null)
+			return null;
+		PlaceNode object = item.getRef();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Nodegraphics
 	 */
 	public void setNodegraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setNodegraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setNodegraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Ref
 	 */
 	public void setRefHLAPI(
-	
-	PlaceNodeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setRef((PlaceNode)elem.getContainedItem());
-	
+
+			PlaceNodeHLAPI elem) {
+
+		if (elem != null)
+			item.setRef((PlaceNode) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(RefPlaceHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(RefPlaceHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/RefTransitionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/RefTransitionHLAPI.java
@@ -57,8 +57,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class RefTransitionHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,TransitionNodeHLAPI{
+public class RefTransitionHLAPI implements HLAPIClass, PnObjectHLAPI, NodeHLAPI, TransitionNodeHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -66,158 +65,126 @@ public class RefTransitionHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,Tr
 	private RefTransition item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public RefTransitionHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, TransitionNodeHLAPI ref
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public RefTransitionHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, TransitionNodeHLAPI ref) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((TransitionNode)ref.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createRefTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (ref != null)
+			item.setRef((TransitionNode) ref.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public RefTransitionHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, TransitionNodeHLAPI ref
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((TransitionNode)ref.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
-	}
 
+	public RefTransitionHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, TransitionNodeHLAPI ref
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createRefTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (ref != null)
+			item.setRef((TransitionNode) ref.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public RefTransitionHLAPI(
-		 java.lang.String id
-	
-		, TransitionNodeHLAPI ref
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public RefTransitionHLAPI(java.lang.String id
+
+			, TransitionNodeHLAPI ref) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((TransitionNode)ref.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createRefTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (ref != null)
+			item.setRef((TransitionNode) ref.getContainedItem());
+
 	}
 
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public RefTransitionHLAPI(
-		 java.lang.String id
-	
-		, TransitionNodeHLAPI ref
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public RefTransitionHLAPI(java.lang.String id
+
+			, TransitionNodeHLAPI ref
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createRefTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(ref!=null)
-			item.setRef((TransitionNode)ref.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createRefTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (ref != null)
+			item.setRef((TransitionNode) ref.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public RefTransitionHLAPI(RefTransition lowLevelAPI){
+	public RefTransitionHLAPI(RefTransition lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -225,348 +192,304 @@ public class RefTransitionHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,Tr
 	/**
 	 * Return encapsulated object
 	 */
-	public RefTransition getContainedItem(){
+	public RefTransition getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getInArcs(){
+	public List<Arc> getInArcs() {
 		return item.getInArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getOutArcs(){
+	public List<Arc> getOutArcs() {
 		return item.getOutArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getNodegraphics(){
+	public NodeGraphics getNodegraphics() {
 		return item.getNodegraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<RefTransition> getReferencingTransitions(){
+	public List<RefTransition> getReferencingTransitions() {
 		return item.getReferencingTransitions();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public TransitionNode getRef(){
+	public TransitionNode getRef() {
 		return item.getRef();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getInArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getOutArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI(){
-			if(item.getNodegraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getNodegraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<RefTransitionHLAPI> getReferencingTransitionsHLAPI(){
-			java.util.List<RefTransitionHLAPI> retour = new ArrayList<RefTransitionHLAPI>();
-			for (RefTransition elemnt : getReferencingTransitions()) {
-				retour.add(new RefTransitionHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public TransitionNodeHLAPI getRefHLAPI(){
-			if(item.getRef() == null) return null;
-			TransitionNode object = item.getRef();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
 			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-		
-	
-	
+		return retour;
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerPage());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getInArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getOutArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI() {
+		if (item.getNodegraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getNodegraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<RefTransitionHLAPI> getReferencingTransitionsHLAPI() {
+		java.util.List<RefTransitionHLAPI> retour = new ArrayList<RefTransitionHLAPI>();
+		for (RefTransition elemnt : getReferencingTransitions()) {
+			retour.add(new RefTransitionHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TransitionNodeHLAPI getRefHLAPI() {
+		if (item.getRef() == null)
+			return null;
+		TransitionNode object = item.getRef();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Nodegraphics
 	 */
 	public void setNodegraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setNodegraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setNodegraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Ref
 	 */
 	public void setRefHLAPI(
-	
-	TransitionNodeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setRef((TransitionNode)elem.getContainedItem());
-	
+
+			TransitionNodeHLAPI elem) {
+
+		if (elem != null)
+			item.setRef((TransitionNode) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(RefTransitionHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(RefTransitionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ToolInfoHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/ToolInfoHLAPI.java
@@ -52,8 +52,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class ToolInfoHLAPI implements HLAPIClass{
+public class ToolInfoHLAPI implements HLAPIClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -61,378 +60,306 @@ public class ToolInfoHLAPI implements HLAPIClass{
 	private ToolInfo item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, java.lang.StringBuffer formattedXMLBuffer
-	
-		, java.net.URI toolInfoGrammarURI
-	
-		, AnyObjectHLAPI toolInfoModel
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version
+
+			, java.lang.StringBuffer formattedXMLBuffer
+
+			, java.net.URI toolInfoGrammarURI
+
+			, AnyObjectHLAPI toolInfoModel) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
-			if(formattedXMLBuffer!=null){
-			
-				item.setFormattedXMLBuffer(formattedXMLBuffer);
-			}
-		
-	
- 		
-			if(toolInfoGrammarURI!=null){
-			
-				item.setToolInfoGrammarURI(toolInfoGrammarURI);
-			}
-		
-	
- 		
- 		if(toolInfoModel!=null)
-			item.setToolInfoModel((AnyObject)toolInfoModel.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (formattedXMLBuffer != null) {
+
+			item.setFormattedXMLBuffer(formattedXMLBuffer);
+		}
+
+		if (toolInfoGrammarURI != null) {
+
+			item.setToolInfoGrammarURI(toolInfoGrammarURI);
+		}
+
+		if (toolInfoModel != null)
+			item.setToolInfoModel((AnyObject) toolInfoModel.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, java.lang.StringBuffer formattedXMLBuffer
-	
-		, java.net.URI toolInfoGrammarURI
-	
-		, AnyObjectHLAPI toolInfoModel
-	
-		, PetriNetHLAPI containerPetriNet
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version
+
+			, java.lang.StringBuffer formattedXMLBuffer
+
+			, java.net.URI toolInfoGrammarURI
+
+			, AnyObjectHLAPI toolInfoModel
+
+			, PetriNetHLAPI containerPetriNet) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
-			if(formattedXMLBuffer!=null){
-			
-				item.setFormattedXMLBuffer(formattedXMLBuffer);
-			}
-		
-	
- 		
-			if(toolInfoGrammarURI!=null){
-			
-				item.setToolInfoGrammarURI(toolInfoGrammarURI);
-			}
-		
-	
- 		
- 		if(toolInfoModel!=null)
-			item.setToolInfoModel((AnyObject)toolInfoModel.getContainedItem());
-		
-	
- 		
- 		if(containerPetriNet!=null)
-			item.setContainerPetriNet((PetriNet)containerPetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (formattedXMLBuffer != null) {
+
+			item.setFormattedXMLBuffer(formattedXMLBuffer);
+		}
+
+		if (toolInfoGrammarURI != null) {
+
+			item.setToolInfoGrammarURI(toolInfoGrammarURI);
+		}
+
+		if (toolInfoModel != null)
+			item.setToolInfoModel((AnyObject) toolInfoModel.getContainedItem());
+
+		if (containerPetriNet != null)
+			item.setContainerPetriNet((PetriNet) containerPetriNet.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, java.lang.StringBuffer formattedXMLBuffer
-	
-		, java.net.URI toolInfoGrammarURI
-	
-		, AnyObjectHLAPI toolInfoModel
-	
-		, PnObjectHLAPI containerPnObject
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version
+
+			, java.lang.StringBuffer formattedXMLBuffer
+
+			, java.net.URI toolInfoGrammarURI
+
+			, AnyObjectHLAPI toolInfoModel
+
+			, PnObjectHLAPI containerPnObject) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
-			if(formattedXMLBuffer!=null){
-			
-				item.setFormattedXMLBuffer(formattedXMLBuffer);
-			}
-		
-	
- 		
-			if(toolInfoGrammarURI!=null){
-			
-				item.setToolInfoGrammarURI(toolInfoGrammarURI);
-			}
-		
-	
- 		
- 		if(toolInfoModel!=null)
-			item.setToolInfoModel((AnyObject)toolInfoModel.getContainedItem());
-		
-	
- 		
- 		if(containerPnObject!=null)
-			item.setContainerPnObject((PnObject)containerPnObject.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (formattedXMLBuffer != null) {
+
+			item.setFormattedXMLBuffer(formattedXMLBuffer);
+		}
+
+		if (toolInfoGrammarURI != null) {
+
+			item.setToolInfoGrammarURI(toolInfoGrammarURI);
+		}
+
+		if (toolInfoModel != null)
+			item.setToolInfoModel((AnyObject) toolInfoModel.getContainedItem());
+
+		if (containerPnObject != null)
+			item.setContainerPnObject((PnObject) containerPnObject.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, java.lang.StringBuffer formattedXMLBuffer
-	
-		, java.net.URI toolInfoGrammarURI
-	
-		, AnyObjectHLAPI toolInfoModel
-	
-		, LabelHLAPI containerLabel
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version
+
+			, java.lang.StringBuffer formattedXMLBuffer
+
+			, java.net.URI toolInfoGrammarURI
+
+			, AnyObjectHLAPI toolInfoModel
+
+			, LabelHLAPI containerLabel) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
-			if(formattedXMLBuffer!=null){
-			
-				item.setFormattedXMLBuffer(formattedXMLBuffer);
-			}
-		
-	
- 		
-			if(toolInfoGrammarURI!=null){
-			
-				item.setToolInfoGrammarURI(toolInfoGrammarURI);
-			}
-		
-	
- 		
- 		if(toolInfoModel!=null)
-			item.setToolInfoModel((AnyObject)toolInfoModel.getContainedItem());
-		
-	
- 		
- 		if(containerLabel!=null)
-			item.setContainerLabel((Label)containerLabel.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (formattedXMLBuffer != null) {
+
+			item.setFormattedXMLBuffer(formattedXMLBuffer);
+		}
+
+		if (toolInfoGrammarURI != null) {
+
+			item.setToolInfoGrammarURI(toolInfoGrammarURI);
+		}
+
+		if (toolInfoModel != null)
+			item.setToolInfoModel((AnyObject) toolInfoModel.getContainedItem());
+
+		if (containerLabel != null)
+			item.setContainerLabel((Label) containerLabel.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version) {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version
+
+			, PetriNetHLAPI containerPetriNet) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (containerPetriNet != null)
+			item.setContainerPetriNet((PetriNet) containerPetriNet.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ToolInfoHLAPI(java.lang.String tool
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, PetriNetHLAPI containerPetriNet
-	){//BEGIN CONSTRUCTOR BODY
+			, java.lang.String version
+
+			, PnObjectHLAPI containerPnObject) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
- 		if(containerPetriNet!=null)
-			item.setContainerPetriNet((PetriNet)containerPetriNet.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (containerPnObject != null)
+			item.setContainerPnObject((PnObject) containerPnObject.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, PnObjectHLAPI containerPnObject
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ToolInfoHLAPI(java.lang.String tool
+
+			, java.lang.String version
+
+			, LabelHLAPI containerLabel) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
- 		if(containerPnObject!=null)
-			item.setContainerPnObject((PnObject)containerPnObject.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createToolInfo();
+		}
+
+		if (tool != null) {
+
+			item.setTool(tool);
+		}
+
+		if (version != null) {
+
+			item.setVersion(version);
+		}
+
+		if (containerLabel != null)
+			item.setContainerLabel((Label) containerLabel.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ToolInfoHLAPI(
-		 java.lang.String tool
-	
-		, java.lang.String version
-	
-		, LabelHLAPI containerLabel
-	){//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createToolInfo();}
-	
- 		
-			if(tool!=null){
-			
-				item.setTool(tool);
-			}
-		
-	
- 		
-			if(version!=null){
-			
-				item.setVersion(version);
-			}
-		
-	
- 		
- 		if(containerLabel!=null)
-			item.setContainerLabel((Label)containerLabel.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ToolInfoHLAPI(ToolInfo lowLevelAPI){
+	public ToolInfoHLAPI(ToolInfo lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -440,340 +367,320 @@ public class ToolInfoHLAPI implements HLAPIClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public ToolInfo getContainedItem(){
+	public ToolInfo getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getTool(){
+	public String getTool() {
 		return item.getTool();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getVersion(){
+	public String getVersion() {
 		return item.getVersion();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public StringBuffer getFormattedXMLBuffer(){
+	public StringBuffer getFormattedXMLBuffer() {
 		return item.getFormattedXMLBuffer();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public URI getToolInfoGrammarURI(){
+	public URI getToolInfoGrammarURI() {
 		return item.getToolInfoGrammarURI();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PetriNet getContainerPetriNet(){
+	public PetriNet getContainerPetriNet() {
 		return item.getContainerPetriNet();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PnObject getContainerPnObject(){
+	public PnObject getContainerPnObject() {
 		return item.getContainerPnObject();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Label getContainerLabel(){
+	public Label getContainerLabel() {
 		return item.getContainerLabel();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnyObject getToolInfoModel(){
+	public AnyObject getToolInfoModel() {
 		return item.getToolInfoModel();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PetriNetHLAPI getContainerPetriNetHLAPI(){
-			if(item.getContainerPetriNet() == null) return null;
-			return new PetriNetHLAPI(item.getContainerPetriNet());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public PnObjectHLAPI getContainerPnObjectHLAPI(){
-			if(item.getContainerPnObject() == null) return null;
-			PnObject object = item.getContainerPnObject();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Page)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Place)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PetriNetHLAPI getContainerPetriNetHLAPI() {
+		if (item.getContainerPetriNet() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public LabelHLAPI getContainerLabelHLAPI(){
-			if(item.getContainerLabel() == null) return null;
-			Label object = item.getContainerLabel();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.NameHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Name)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TypeHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Type)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLMarkingHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ConditionHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLAnnotationHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.DeclarationHLAPI((fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration)object);
-			}
-			
+		return new PetriNetHLAPI(item.getContainerPetriNet());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PnObjectHLAPI getContainerPnObjectHLAPI() {
+		if (item.getContainerPnObject() == null)
 			return null;
+		PnObject object = item.getContainerPnObject();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PageHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Page) object);
 		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ArcHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.PlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Place) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefTransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.RefPlaceHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public LabelHLAPI getContainerLabelHLAPI() {
+		if (item.getContainerLabel() == null)
+			return null;
+		Label object = item.getContainerLabel();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.NameHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Name) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TypeHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Type) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLMarkingHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.ConditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.HLAnnotationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.DeclarationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Tool
 	 */
 	public void setToolHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setTool(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Version
 	 */
 	public void setVersionHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setVersion(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set FormattedXMLBuffer
 	 */
 	public void setFormattedXMLBufferHLAPI(
-	
-	java.lang.StringBuffer elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.StringBuffer elem) {
+
+		if (elem != null) {
+
 			item.setFormattedXMLBuffer(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ToolInfoGrammarURI
 	 */
 	public void setToolInfoGrammarURIHLAPI(
-	
-	java.net.URI elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.net.URI elem) {
+
+		if (elem != null) {
+
 			item.setToolInfoGrammarURI(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ToolInfoModel
 	 */
 	public void setToolInfoModelHLAPI(
-	
-	AnyObjectHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setToolInfoModel((AnyObject)elem.getContainedItem());
-	
+
+			AnyObjectHLAPI elem) {
+
+		if (elem != null)
+			item.setToolInfoModel((AnyObject) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPetriNet
 	 */
 	public void setContainerPetriNetHLAPI(
-	
-	PetriNetHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPetriNet((PetriNet)elem.getContainedItem());
-	
+
+			PetriNetHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPetriNet((PetriNet) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPnObject
 	 */
 	public void setContainerPnObjectHLAPI(
-	
-	PnObjectHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPnObject((PnObject)elem.getContainedItem());
-	
+
+			PnObjectHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPnObject((PnObject) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerLabel
 	 */
 	public void setContainerLabelHLAPI(
-	
-	LabelHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerLabel((Label)elem.getContainedItem());
-	
+
+			LabelHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerLabel((Label) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ToolInfoHLAPI item){
+	// equals method
+	public boolean equals(ToolInfoHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/TransitionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/TransitionHLAPI.java
@@ -58,8 +58,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl;
 
-
-public class TransitionHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,TransitionNodeHLAPI{
+public class TransitionHLAPI implements HLAPIClass, PnObjectHLAPI, NodeHLAPI, TransitionNodeHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -67,144 +66,117 @@ public class TransitionHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,Trans
 	private Transition item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public TransitionHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, ConditionHLAPI condition
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public TransitionHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, ConditionHLAPI condition) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(condition!=null)
-			item.setCondition((Condition)condition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (condition != null)
+			item.setCondition((Condition) condition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TransitionHLAPI(
-		 java.lang.String id
-	
-		, NameHLAPI name
-	
-		, NodeGraphicsHLAPI nodegraphics
-	
-		, ConditionHLAPI condition
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
-		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(name!=null)
-			item.setName((Name)name.getContainedItem());
-		
-	
- 		
- 		if(nodegraphics!=null)
-			item.setNodegraphics((NodeGraphics)nodegraphics.getContainedItem());
-		
-	
- 		
- 		if(condition!=null)
-			item.setCondition((Condition)condition.getContainedItem());
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
-	}
 
+	public TransitionHLAPI(java.lang.String id
+
+			, NameHLAPI name
+
+			, NodeGraphicsHLAPI nodegraphics
+
+			, ConditionHLAPI condition
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
+		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null)
+			item.setName((Name) name.getContainedItem());
+
+		if (nodegraphics != null)
+			item.setNodegraphics((NodeGraphics) nodegraphics.getContainedItem());
+
+		if (condition != null)
+			item.setCondition((Condition) condition.getContainedItem());
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public TransitionHLAPI(
-		 java.lang.String id
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public TransitionHLAPI(java.lang.String id) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR
+																									// BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
 	}
 
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TransitionHLAPI(
-		 java.lang.String id
-	
-		, PageHLAPI containerPage
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TransitionHLAPI(java.lang.String id
+
+			, PageHLAPI containerPage) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTransition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
- 		if(containerPage!=null)
-			item.setContainerPage((Page)containerPage.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTransition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (containerPage != null)
+			item.setContainerPage((Page) containerPage.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public TransitionHLAPI(Transition lowLevelAPI){
+	public TransitionHLAPI(Transition lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -212,337 +184,292 @@ public class TransitionHLAPI implements HLAPIClass,PnObjectHLAPI,NodeHLAPI,Trans
 	/**
 	 * Return encapsulated object
 	 */
-	public Transition getContainedItem(){
+	public Transition getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Name getName(){
+	public Name getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Page getContainerPage(){
+	public Page getContainerPage() {
 		return item.getContainerPage();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getInArcs(){
+	public List<Arc> getInArcs() {
 		return item.getInArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Arc> getOutArcs(){
+	public List<Arc> getOutArcs() {
 		return item.getOutArcs();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NodeGraphics getNodegraphics(){
+	public NodeGraphics getNodegraphics() {
 		return item.getNodegraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<RefTransition> getReferencingTransitions(){
+	public List<RefTransition> getReferencingTransitions() {
 		return item.getReferencingTransitions();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getCondition(){
+	public Condition getCondition() {
 		return item.getCondition();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NameHLAPI getNameHLAPI(){
-			if(item.getName() == null) return null;
-			return new NameHLAPI(item.getName());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI(){
-			if(item.getContainerPage() == null) return null;
-			return new PageHLAPI(item.getContainerPage());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getInArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI(){
-			java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
-			for (Arc elemnt : getOutArcs()) {
-				retour.add(new ArcHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI(){
-			if(item.getNodegraphics() == null) return null;
-			return new NodeGraphicsHLAPI(item.getNodegraphics());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<RefTransitionHLAPI> getReferencingTransitionsHLAPI(){
-			java.util.List<RefTransitionHLAPI> retour = new ArrayList<RefTransitionHLAPI>();
-			for (RefTransition elemnt : getReferencingTransitions()) {
-				retour.add(new RefTransitionHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getConditionHLAPI(){
-			if(item.getCondition() == null) return null;
-			return new ConditionHLAPI(item.getCondition());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public NameHLAPI getNameHLAPI() {
+		if (item.getName() == null)
+			return null;
+		return new NameHLAPI(item.getName());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PageHLAPI getContainerPageHLAPI() {
+		if (item.getContainerPage() == null)
+			return null;
+		return new PageHLAPI(item.getContainerPage());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getInArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI() {
+		java.util.List<ArcHLAPI> retour = new ArrayList<ArcHLAPI>();
+		for (Arc elemnt : getOutArcs()) {
+			retour.add(new ArcHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI() {
+		if (item.getNodegraphics() == null)
+			return null;
+		return new NodeGraphicsHLAPI(item.getNodegraphics());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<RefTransitionHLAPI> getReferencingTransitionsHLAPI() {
+		java.util.List<RefTransitionHLAPI> retour = new ArrayList<RefTransitionHLAPI>();
+		for (RefTransition elemnt : getReferencingTransitions()) {
+			retour.add(new RefTransitionHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getConditionHLAPI() {
+		if (item.getCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getCondition());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	NameHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setName((Name)elem.getContainedItem());
-	
+
+			NameHLAPI elem) {
+
+		if (elem != null)
+			item.setName((Name) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Nodegraphics
 	 */
 	public void setNodegraphicsHLAPI(
-	
-	NodeGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setNodegraphics((NodeGraphics)elem.getContainedItem());
-	
+
+			NodeGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setNodegraphics((NodeGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Condition
 	 */
 	public void setConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPage
 	 */
 	public void setContainerPageHLAPI(
-	
-	PageHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPage((Page)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PageHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPage((Page) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(TransitionHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(TransitionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/TransitionNodeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/TransitionNodeHLAPI.java
@@ -45,177 +45,130 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Page;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
-public interface TransitionNodeHLAPI extends HLAPIClass,PnObjectHLAPI,NodeHLAPI{
+public interface TransitionNodeHLAPI extends HLAPIClass, PnObjectHLAPI, NodeHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public Name getName();
-	
+
 	/**
 	 *
 	 */
 	public List<ToolInfo> getToolspecifics();
-	
+
 	/**
 	 *
 	 */
 	public Page getContainerPage();
-	
+
 	/**
 	 *
 	 */
 	public List<Arc> getInArcs();
-	
+
 	/**
 	 *
 	 */
 	public List<Arc> getOutArcs();
-	
+
 	/**
 	 *
 	 */
 	public NodeGraphics getNodegraphics();
-	
+
 	/**
 	 *
 	 */
 	public List<RefTransition> getReferencingTransitions();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NameHLAPI getNameHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PageHLAPI getContainerPageHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getInArcsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ArcHLAPI> getOutArcsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NodeGraphicsHLAPI getNodegraphicsHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<RefTransitionHLAPI> getReferencingTransitionsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NameHLAPI getNameHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PageHLAPI getContainerPageHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getInArcsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ArcHLAPI> getOutArcsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NodeGraphicsHLAPI getNodegraphicsHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<RefTransitionHLAPI> getReferencingTransitionsHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	NameHLAPI elem);
-	
+	public void setNameHLAPI(NameHLAPI elem);
+
 	/**
 	 * set Nodegraphics
 	 */
-	public void setNodegraphicsHLAPI(
-	NodeGraphicsHLAPI elem);
-	
+	public void setNodegraphicsHLAPI(NodeGraphicsHLAPI elem);
+
 	/**
 	 * set ContainerPage
 	 */
-	public void setContainerPageHLAPI(
-	PageHLAPI elem);
-	
+	public void setContainerPageHLAPI(PageHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
 	public void addToolspecificsHLAPI(ToolInfoHLAPI unit);
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
-	
 
-	//equals method
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/TypeHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/hlapi/TypeHLAPI.java
@@ -54,8 +54,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HlcorestructureFactoryImpl
 import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 
-
-public class TypeHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
+public class TypeHLAPI implements HLAPIClass, LabelHLAPI, AnnotationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -63,103 +62,83 @@ public class TypeHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	private Type item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public TypeHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, SortHLAPI structure
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TypeHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, SortHLAPI structure) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createType();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Sort)structure.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createType();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Sort) structure.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TypeHLAPI(
-		 AnnotationGraphicsHLAPI annotationgraphics
-	
-		, java.lang.String text
-	
-		, SortHLAPI structure
-	
-		, PlaceHLAPI containerPlace
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TypeHLAPI(AnnotationGraphicsHLAPI annotationgraphics
+
+			, java.lang.String text
+
+			, SortHLAPI structure
+
+			, PlaceHLAPI containerPlace) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createType();}
-	
- 		
- 		if(annotationgraphics!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)annotationgraphics.getContainedItem());
-		
-	
- 		
-			if(text!=null){
-			
-				item.setText(text);
-			}
-		
-	
- 		
- 		if(structure!=null)
-			item.setStructure((Sort)structure.getContainedItem());
-		
-	
- 		
- 		if(containerPlace!=null)
-			item.setContainerPlace((Place)containerPlace.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createType();
+		}
+
+		if (annotationgraphics != null)
+			item.setAnnotationgraphics((AnnotationGraphics) annotationgraphics.getContainedItem());
+
+		if (text != null) {
+
+			item.setText(text);
+		}
+
+		if (structure != null)
+			item.setStructure((Sort) structure.getContainedItem());
+
+		if (containerPlace != null)
+			item.setContainerPlace((Place) containerPlace.getContainedItem());
+
 	}
 
-
-
-	
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TypeHLAPI(
-		 PlaceHLAPI containerPlace
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TypeHLAPI(PlaceHLAPI containerPlace) {// BEGIN CONSTRUCTOR BODY
 		HlcorestructureFactory fact = HlcorestructureFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createType();}
-	
- 		
- 		if(containerPlace!=null)
-			item.setContainerPlace((Place)containerPlace.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createType();
+		}
+
+		if (containerPlace != null)
+			item.setContainerPlace((Place) containerPlace.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public TypeHLAPI(Type lowLevelAPI){
+	public TypeHLAPI(Type lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -167,257 +146,237 @@ public class TypeHLAPI implements HLAPIClass,LabelHLAPI,AnnotationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Type getContainedItem(){
+	public Type getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<ToolInfo> getToolspecifics(){
+	public List<ToolInfo> getToolspecifics() {
 		return item.getToolspecifics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public AnnotationGraphics getAnnotationgraphics(){
+	public AnnotationGraphics getAnnotationgraphics() {
 		return item.getAnnotationgraphics();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getText(){
+	public String getText() {
 		return item.getText();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getStructure(){
+	public Sort getStructure() {
 		return item.getStructure();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Place getContainerPlace(){
+	public Place getContainerPlace() {
 		return item.getContainerPlace();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI(){
-			java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
-			for (ToolInfo elemnt : getToolspecifics()) {
-				retour.add(new ToolInfoHLAPI(elemnt));
-			}
-			return retour;
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<ToolInfoHLAPI> getToolspecificsHLAPI() {
+		java.util.List<ToolInfoHLAPI> retour = new ArrayList<ToolInfoHLAPI>();
+		for (ToolInfo elemnt : getToolspecifics()) {
+			retour.add(new ToolInfoHLAPI(elemnt));
 		}
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI(){
-			if(item.getAnnotationgraphics() == null) return null;
-			return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
-		}
-		
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getStructureHLAPI(){
-			if(item.getStructure() == null) return null;
-			Sort object = item.getStructure();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AnnotationGraphicsHLAPI getAnnotationgraphicsHLAPI() {
+		if (item.getAnnotationgraphics() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PlaceHLAPI getContainerPlaceHLAPI(){
-			if(item.getContainerPlace() == null) return null;
-			return new PlaceHLAPI(item.getContainerPlace());
-		}
-		
-	
-	
+		return new AnnotationGraphicsHLAPI(item.getAnnotationgraphics());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getStructureHLAPI() {
+		if (item.getStructure() == null)
+			return null;
+		Sort object = item.getStructure();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PlaceHLAPI getContainerPlaceHLAPI() {
+		if (item.getContainerPlace() == null)
+			return null;
+		return new PlaceHLAPI(item.getContainerPlace());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Annotationgraphics
 	 */
 	public void setAnnotationgraphicsHLAPI(
-	
-	AnnotationGraphicsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setAnnotationgraphics((AnnotationGraphics)elem.getContainedItem());
-	
+
+			AnnotationGraphicsHLAPI elem) {
+
+		if (elem != null)
+			item.setAnnotationgraphics((AnnotationGraphics) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Text
 	 */
 	public void setTextHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setText(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Structure
 	 */
 	public void setStructureHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setStructure((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setStructure((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPlace
 	 */
 	public void setContainerPlaceHLAPI(
-	
-	PlaceHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPlace((Place)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addToolspecificsHLAPI(ToolInfoHLAPI unit){
-	
-		item.getToolspecifics().add((ToolInfo)unit.getContainedItem());
+			PlaceHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPlace((Place) elem.getContainedItem());
+
 	}
 
-	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit){
-		item.getToolspecifics().remove((ToolInfo)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(TypeHLAPI item){
+	public void addToolspecificsHLAPI(ToolInfoHLAPI unit) {
+
+		item.getToolspecifics().add((ToolInfo) unit.getContainedItem());
+	}
+
+	public void removeToolspecificsHLAPI(ToolInfoHLAPI unit) {
+		item.getToolspecifics().remove((ToolInfo) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(TypeHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AnnotationGraphicsImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AnnotationGraphicsImpl.java
@@ -66,17 +66,21 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Annotation Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Annotation Graphics</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getOffset <em>Offset</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getFill <em>Fill</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getLine <em>Line</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getFont <em>Font</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getContainerAnnotation <em>Container Annotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getOffset
+ * <em>Offset</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getFill
+ * <em>Fill</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getLine
+ * <em>Line</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getFont
+ * <em>Font</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationGraphicsImpl#getContainerAnnotation
+ * <em>Container Annotation</em>}</li>
  * </ul>
  * </p>
  *
@@ -84,9 +88,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGraphics {
 	/**
-	 * The cached value of the '{@link #getOffset() <em>Offset</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getOffset() <em>Offset</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getOffset()
 	 * @generated
 	 * @ordered
@@ -94,9 +98,9 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	protected Offset offset;
 
 	/**
-	 * The cached value of the '{@link #getFill() <em>Fill</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFill() <em>Fill</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFill()
 	 * @generated
 	 * @ordered
@@ -104,9 +108,9 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	protected Fill fill;
 
 	/**
-	 * The cached value of the '{@link #getLine() <em>Line</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getLine() <em>Line</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getLine()
 	 * @generated
 	 * @ordered
@@ -114,9 +118,9 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	protected Line line;
 
 	/**
-	 * The cached value of the '{@link #getFont() <em>Font</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFont() <em>Font</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFont()
 	 * @generated
 	 * @ordered
@@ -124,8 +128,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	protected Font font;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AnnotationGraphicsImpl() {
@@ -133,8 +137,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -143,8 +147,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,8 +157,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetOffset(Offset newOffset, NotificationChain msgs) {
@@ -172,8 +176,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -195,8 +199,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -205,8 +209,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetFill(Fill newFill, NotificationChain msgs) {
@@ -224,8 +228,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -247,8 +251,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -257,8 +261,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetLine(Line newLine, NotificationChain msgs) {
@@ -276,8 +280,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -299,8 +303,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -309,8 +313,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetFont(Font newFont, NotificationChain msgs) {
@@ -328,8 +332,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -351,8 +355,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -363,8 +367,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerAnnotation(Annotation newContainerAnnotation, NotificationChain msgs) {
@@ -374,14 +378,15 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerAnnotation(Annotation newContainerAnnotation) {
 		if (newContainerAnnotation != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.ANNOTATION_GRAPHICS__CONTAINER_ANNOTATION && newContainerAnnotation != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.ANNOTATION_GRAPHICS__CONTAINER_ANNOTATION
+						&& newContainerAnnotation != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerAnnotation))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -400,8 +405,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -409,23 +414,23 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 		switch (featureID) {
 		case HlcorestructurePackage.ANNOTATION_GRAPHICS__OFFSET:
 			if (offset != null)
-				msgs = ((InternalEObject) offset).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ANNOTATION_GRAPHICS__OFFSET, null, msgs);
+				msgs = ((InternalEObject) offset).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ANNOTATION_GRAPHICS__OFFSET, null, msgs);
 			return basicSetOffset((Offset) otherEnd, msgs);
 		case HlcorestructurePackage.ANNOTATION_GRAPHICS__FILL:
 			if (fill != null)
-				msgs = ((InternalEObject) fill).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ANNOTATION_GRAPHICS__FILL, null, msgs);
+				msgs = ((InternalEObject) fill).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ANNOTATION_GRAPHICS__FILL, null, msgs);
 			return basicSetFill((Fill) otherEnd, msgs);
 		case HlcorestructurePackage.ANNOTATION_GRAPHICS__LINE:
 			if (line != null)
-				msgs = ((InternalEObject) line).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ANNOTATION_GRAPHICS__LINE, null, msgs);
+				msgs = ((InternalEObject) line).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ANNOTATION_GRAPHICS__LINE, null, msgs);
 			return basicSetLine((Line) otherEnd, msgs);
 		case HlcorestructurePackage.ANNOTATION_GRAPHICS__FONT:
 			if (font != null)
-				msgs = ((InternalEObject) font).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ANNOTATION_GRAPHICS__FONT, null, msgs);
+				msgs = ((InternalEObject) font).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ANNOTATION_GRAPHICS__FONT, null, msgs);
 			return basicSetFont((Font) otherEnd, msgs);
 		case HlcorestructurePackage.ANNOTATION_GRAPHICS__CONTAINER_ANNOTATION:
 			if (eInternalContainer() != null)
@@ -436,8 +441,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -458,8 +463,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -473,8 +478,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -495,8 +500,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -522,8 +527,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -549,8 +554,8 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -575,10 +580,10 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -596,13 +601,13 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getOffset() != null) {
 
@@ -672,22 +677,22 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -701,7 +706,7 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 				item.setContainerAnnotationGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("fill")) {
 				Fill item;
@@ -711,7 +716,7 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 				item.setContainerAnnotationGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("line")) {
 				Line item;
@@ -721,7 +726,7 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 				item.setContainerAnnotationGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("font")) {
 				Font item;
@@ -731,7 +736,7 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 				item.setContainerAnnotationGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -742,10 +747,10 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -768,13 +773,13 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getOffset() != null) {
 
@@ -895,4 +900,4 @@ public class AnnotationGraphicsImpl extends GraphicsImpl implements AnnotationGr
 		return retour;
 
 	}
-} //AnnotationGraphicsImpl
+} // AnnotationGraphicsImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AnnotationImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AnnotationImpl.java
@@ -43,13 +43,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Annotation</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Annotation</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl#getAnnotationgraphics <em>Annotationgraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnnotationImpl#getAnnotationgraphics
+ * <em>Annotationgraphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -57,9 +57,10 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
  */
 public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	/**
-	 * The cached value of the '{@link #getAnnotationgraphics() <em>Annotationgraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
+	 * The cached value of the '{@link #getAnnotationgraphics()
+	 * <em>Annotationgraphics</em>}' containment reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @see #getAnnotationgraphics()
 	 * @generated
 	 * @ordered
@@ -67,8 +68,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	protected AnnotationGraphics annotationgraphics;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AnnotationImpl() {
@@ -76,8 +77,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -86,8 +87,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -96,16 +97,18 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetAnnotationgraphics(AnnotationGraphics newAnnotationgraphics, NotificationChain msgs) {
+	public NotificationChain basicSetAnnotationgraphics(AnnotationGraphics newAnnotationgraphics,
+			NotificationChain msgs) {
 		AnnotationGraphics oldAnnotationgraphics = annotationgraphics;
 		annotationgraphics = newAnnotationgraphics;
 		if (eNotificationRequired()) {
 			ENotificationImpl notification = new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS, oldAnnotationgraphics, newAnnotationgraphics);
+					HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS, oldAnnotationgraphics,
+					newAnnotationgraphics);
 			if (msgs == null)
 				msgs = notification;
 			else
@@ -115,8 +118,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -135,13 +138,13 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS, newAnnotationgraphics, newAnnotationgraphics));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS,
+					newAnnotationgraphics, newAnnotationgraphics));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -149,16 +152,16 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 		switch (featureID) {
 		case HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS:
 			if (annotationgraphics != null)
-				msgs = ((InternalEObject) annotationgraphics).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS, null, msgs);
+				msgs = ((InternalEObject) annotationgraphics).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ANNOTATION__ANNOTATIONGRAPHICS, null, msgs);
 			return basicSetAnnotationgraphics((AnnotationGraphics) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -171,8 +174,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -185,8 +188,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -200,8 +203,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -215,8 +218,8 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -230,4 +233,4 @@ public abstract class AnnotationImpl extends LabelImpl implements Annotation {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //AnnotationImpl
+} // AnnotationImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AnyObjectImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AnyObjectImpl.java
@@ -42,13 +42,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Any Object</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Any
+ * Object</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl#getContainerToolInfo <em>Container Tool Info</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.AnyObjectImpl#getContainerToolInfo
+ * <em>Container Tool Info</em>}</li>
  * </ul>
  * </p>
  *
@@ -56,8 +56,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
  */
 public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObject {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AnyObjectImpl() {
@@ -65,8 +65,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -75,8 +75,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -87,8 +87,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -103,8 +103,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -117,8 +117,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -132,8 +132,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,8 +146,8 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,4 +161,4 @@ public abstract class AnyObjectImpl extends MinimalEObjectImpl implements AnyObj
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //AnyObjectImpl
+} // AnyObjectImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ArcGraphicsImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ArcGraphicsImpl.java
@@ -68,15 +68,17 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Position;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Arc Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Arc
+ * Graphics</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl#getPositions <em>Positions</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl#getLine <em>Line</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl#getContainerArc <em>Container Arc</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl#getPositions
+ * <em>Positions</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl#getLine
+ * <em>Line</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcGraphicsImpl#getContainerArc
+ * <em>Container Arc</em>}</li>
  * </ul>
  * </p>
  *
@@ -84,9 +86,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	/**
-	 * The cached value of the '{@link #getPositions() <em>Positions</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPositions() <em>Positions</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getPositions()
 	 * @generated
 	 * @ordered
@@ -94,9 +96,9 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	protected EList<Position> positions;
 
 	/**
-	 * The cached value of the '{@link #getLine() <em>Line</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getLine() <em>Line</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getLine()
 	 * @generated
 	 * @ordered
@@ -104,8 +106,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	protected Line line;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ArcGraphicsImpl() {
@@ -113,8 +115,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -123,8 +125,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -138,8 +140,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +150,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetLine(Line newLine, NotificationChain msgs) {
@@ -167,8 +169,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -190,8 +192,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -202,25 +204,26 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerArc(Arc newContainerArc, NotificationChain msgs) {
-		msgs = eBasicSetContainer((InternalEObject) newContainerArc,
-				HlcorestructurePackage.ARC_GRAPHICS__CONTAINER_ARC, msgs);
+		msgs = eBasicSetContainer((InternalEObject) newContainerArc, HlcorestructurePackage.ARC_GRAPHICS__CONTAINER_ARC,
+				msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerArc(Arc newContainerArc) {
 		if (newContainerArc != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.ARC_GRAPHICS__CONTAINER_ARC && newContainerArc != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.ARC_GRAPHICS__CONTAINER_ARC
+						&& newContainerArc != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerArc))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -238,8 +241,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -250,8 +253,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getPositions()).basicAdd(otherEnd, msgs);
 		case HlcorestructurePackage.ARC_GRAPHICS__LINE:
 			if (line != null)
-				msgs = ((InternalEObject) line).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ARC_GRAPHICS__LINE, null, msgs);
+				msgs = ((InternalEObject) line).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ARC_GRAPHICS__LINE, null, msgs);
 			return basicSetLine((Line) otherEnd, msgs);
 		case HlcorestructurePackage.ARC_GRAPHICS__CONTAINER_ARC:
 			if (eInternalContainer() != null)
@@ -262,8 +265,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -280,8 +283,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -294,8 +297,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -312,8 +315,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -335,8 +338,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -356,8 +359,8 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -378,10 +381,10 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 2
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -399,13 +402,13 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPositions() != null) {
 
@@ -452,22 +455,22 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//2
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 2
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -481,7 +484,7 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 				item.setContainerArcGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("line")) {
 				Line item;
@@ -491,7 +494,7 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 				item.setContainerArcGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -502,10 +505,10 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 2
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -528,13 +531,13 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPositions() != null) {
 
@@ -636,4 +639,4 @@ public class ArcGraphicsImpl extends GraphicsImpl implements ArcGraphics {
 		return retour;
 
 	}
-} //ArcGraphicsImpl
+} // ArcGraphicsImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ArcImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ArcImpl.java
@@ -68,16 +68,19 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Arc</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Arc</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getSource <em>Source</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getTarget <em>Target</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getArcgraphics <em>Arcgraphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getHlinscription <em>Hlinscription</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getSource
+ * <em>Source</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getTarget
+ * <em>Target</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getArcgraphics
+ * <em>Arcgraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ArcImpl#getHlinscription
+ * <em>Hlinscription</em>}</li>
  * </ul>
  * </p>
  *
@@ -86,8 +89,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 public class ArcImpl extends PnObjectImpl implements Arc {
 	/**
 	 * The cached value of the '{@link #getSource() <em>Source</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSource()
 	 * @generated
 	 * @ordered
@@ -96,8 +99,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 
 	/**
 	 * The cached value of the '{@link #getTarget() <em>Target</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getTarget()
 	 * @generated
 	 * @ordered
@@ -105,9 +108,9 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	protected Node target;
 
 	/**
-	 * The cached value of the '{@link #getArcgraphics() <em>Arcgraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getArcgraphics() <em>Arcgraphics</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getArcgraphics()
 	 * @generated
 	 * @ordered
@@ -115,9 +118,9 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	protected ArcGraphics arcgraphics;
 
 	/**
-	 * The cached value of the '{@link #getHlinscription() <em>Hlinscription</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getHlinscription() <em>Hlinscription</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getHlinscription()
 	 * @generated
 	 * @ordered
@@ -125,8 +128,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	protected HLAnnotation hlinscription;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ArcImpl() {
@@ -134,8 +137,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -144,8 +147,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,8 +166,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public Node basicGetSource() {
@@ -172,8 +175,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetSource(Node newSource, NotificationChain msgs) {
@@ -191,8 +194,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -214,8 +217,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,8 +236,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public Node basicGetTarget() {
@@ -242,8 +245,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetTarget(Node newTarget, NotificationChain msgs) {
@@ -261,8 +264,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -270,11 +273,11 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		if (newTarget != target) {
 			NotificationChain msgs = null;
 			if (target != null)
-				msgs = ((InternalEObject) target).eInverseRemove(this, HlcorestructurePackage.NODE__IN_ARCS,
-						Node.class, msgs);
+				msgs = ((InternalEObject) target).eInverseRemove(this, HlcorestructurePackage.NODE__IN_ARCS, Node.class,
+						msgs);
 			if (newTarget != null)
-				msgs = ((InternalEObject) newTarget).eInverseAdd(this, HlcorestructurePackage.NODE__IN_ARCS,
-						Node.class, msgs);
+				msgs = ((InternalEObject) newTarget).eInverseAdd(this, HlcorestructurePackage.NODE__IN_ARCS, Node.class,
+						msgs);
 			msgs = basicSetTarget(newTarget, msgs);
 			if (msgs != null)
 				msgs.dispatch();
@@ -284,8 +287,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -294,8 +297,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetArcgraphics(ArcGraphics newArcgraphics, NotificationChain msgs) {
@@ -313,8 +316,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -336,8 +339,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -346,8 +349,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetHlinscription(HLAnnotation newHlinscription, NotificationChain msgs) {
@@ -365,8 +368,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -388,8 +391,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -402,26 +405,26 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 			return basicSetSource((Node) otherEnd, msgs);
 		case HlcorestructurePackage.ARC__TARGET:
 			if (target != null)
-				msgs = ((InternalEObject) target).eInverseRemove(this, HlcorestructurePackage.NODE__IN_ARCS,
-						Node.class, msgs);
+				msgs = ((InternalEObject) target).eInverseRemove(this, HlcorestructurePackage.NODE__IN_ARCS, Node.class,
+						msgs);
 			return basicSetTarget((Node) otherEnd, msgs);
 		case HlcorestructurePackage.ARC__ARCGRAPHICS:
 			if (arcgraphics != null)
-				msgs = ((InternalEObject) arcgraphics).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ARC__ARCGRAPHICS, null, msgs);
+				msgs = ((InternalEObject) arcgraphics).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ARC__ARCGRAPHICS, null, msgs);
 			return basicSetArcgraphics((ArcGraphics) otherEnd, msgs);
 		case HlcorestructurePackage.ARC__HLINSCRIPTION:
 			if (hlinscription != null)
-				msgs = ((InternalEObject) hlinscription).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.ARC__HLINSCRIPTION, null, msgs);
+				msgs = ((InternalEObject) hlinscription).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.ARC__HLINSCRIPTION, null, msgs);
 			return basicSetHlinscription((HLAnnotation) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -440,8 +443,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -464,8 +467,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -488,8 +491,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -512,8 +515,8 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -536,10 +539,10 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 2
-		//attributes 0
-		//sons 4
+		// id 1
+		// idref 2
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -557,7 +560,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -584,7 +587,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -655,16 +658,16 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//2
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 2
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -672,7 +675,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -687,9 +690,9 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -703,7 +706,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 				item.setContainerNamePnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -713,7 +716,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 				item.setContainerPnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				ArcGraphics item;
@@ -723,7 +726,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 				item.setContainerArc(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("hlinscription")) {
 				HLAnnotation item;
@@ -733,7 +736,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 				item.setContainerArc(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -752,10 +755,10 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 2
-		//attributes 0
-		//sons 4
+		// id 1
+		// idref 2
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -778,7 +781,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -805,7 +808,7 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -939,4 +942,4 @@ public class ArcImpl extends PnObjectImpl implements Arc {
 		return retour;
 
 	}
-} //ArcImpl
+} // ArcImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ArcImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ArcImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AttributeImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/AttributeImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Attribute</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Attribute</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
  */
 public abstract class AttributeImpl extends LabelImpl implements Attribute {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AttributeImpl() {
@@ -57,8 +56,8 @@ public abstract class AttributeImpl extends LabelImpl implements Attribute {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class AttributeImpl extends LabelImpl implements Attribute {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //AttributeImpl
+} // AttributeImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ConditionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ConditionImpl.java
@@ -71,14 +71,15 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Condition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Condition</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl#getContainerTransition <em>Container Transition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ConditionImpl#getContainerTransition
+ * <em>Container Transition</em>}</li>
  * </ul>
  * </p>
  *
@@ -86,9 +87,9 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
  */
 public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	/**
-	 * The cached value of the '{@link #getStructure() <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStructure() <em>Structure</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStructure()
 	 * @generated
 	 * @ordered
@@ -96,8 +97,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	protected Term structure;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ConditionImpl() {
@@ -105,8 +106,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -115,8 +116,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,8 +126,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetStructure(Term newStructure, NotificationChain msgs) {
@@ -144,8 +145,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -167,8 +168,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,8 +180,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerTransition(Transition newContainerTransition, NotificationChain msgs) {
@@ -190,14 +191,15 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerTransition(Transition newContainerTransition) {
 		if (newContainerTransition != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.CONDITION__CONTAINER_TRANSITION && newContainerTransition != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.CONDITION__CONTAINER_TRANSITION
+						&& newContainerTransition != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerTransition))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -216,8 +218,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -225,8 +227,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 		switch (featureID) {
 		case HlcorestructurePackage.CONDITION__STRUCTURE:
 			if (structure != null)
-				msgs = ((InternalEObject) structure).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.CONDITION__STRUCTURE, null, msgs);
+				msgs = ((InternalEObject) structure).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.CONDITION__STRUCTURE, null, msgs);
 			return basicSetStructure((Term) otherEnd, msgs);
 		case HlcorestructurePackage.CONDITION__CONTAINER_TRANSITION:
 			if (eInternalContainer() != null)
@@ -237,8 +239,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -253,8 +255,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -268,8 +270,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -284,8 +286,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -302,8 +304,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -320,8 +322,8 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -340,10 +342,10 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -361,13 +363,13 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -450,22 +452,22 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -479,7 +481,7 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 				item.setContainerLabel(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				AnnotationGraphics item;
@@ -489,7 +491,7 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 				item.setContainerAnnotation(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("text")) {
 				this.setText(new java.lang.String(type.getText()));
@@ -712,7 +714,7 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -723,10 +725,10 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -749,13 +751,13 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -897,4 +899,4 @@ public class ConditionImpl extends HLCoreAnnotationImpl implements Condition {
 		return retour;
 
 	}
-} //ConditionImpl
+} // ConditionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/CoordinateImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/CoordinateImpl.java
@@ -41,14 +41,15 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Coordinate</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Coordinate</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl#getX <em>X</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl#getY <em>Y</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl#getX
+ * <em>X</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.CoordinateImpl#getY
+ * <em>Y</em>}</li>
  * </ul>
  * </p>
  *
@@ -56,9 +57,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
  */
 public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coordinate {
 	/**
-	 * The default value of the '{@link #getX() <em>X</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getX() <em>X</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getX()
 	 * @generated
 	 * @ordered
@@ -66,9 +67,9 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	protected static final Integer X_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getX() <em>X</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getX() <em>X</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getX()
 	 * @generated
 	 * @ordered
@@ -76,9 +77,9 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	protected Integer x = X_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getY() <em>Y</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getY() <em>Y</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getY()
 	 * @generated
 	 * @ordered
@@ -86,9 +87,9 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	protected static final Integer Y_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getY() <em>Y</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getY() <em>Y</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getY()
 	 * @generated
 	 * @ordered
@@ -96,8 +97,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	protected Integer y = Y_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected CoordinateImpl() {
@@ -105,8 +106,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -115,8 +116,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,8 +126,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -138,8 +139,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +149,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,8 +162,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -177,8 +178,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -195,8 +196,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -213,8 +214,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -229,8 +230,8 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -249,4 +250,4 @@ public abstract class CoordinateImpl extends MinimalEObjectImpl implements Coord
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //CoordinateImpl
+} // CoordinateImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/DeclarationImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/DeclarationImpl.java
@@ -68,15 +68,17 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Declaration</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Declaration</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl#getContainerDeclarationPetriNet <em>Container Declaration Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl#getContainerDeclarationPage <em>Container Declaration Page</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl#getContainerDeclarationPetriNet
+ * <em>Container Declaration Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DeclarationImpl#getContainerDeclarationPage
+ * <em>Container Declaration Page</em>}</li>
  * </ul>
  * </p>
  *
@@ -84,9 +86,9 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
  */
 public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration {
 	/**
-	 * The cached value of the '{@link #getStructure() <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStructure() <em>Structure</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStructure()
 	 * @generated
 	 * @ordered
@@ -94,8 +96,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	protected Declarations structure;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DeclarationImpl() {
@@ -103,8 +105,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -113,8 +115,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -123,8 +125,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetStructure(Declarations newStructure, NotificationChain msgs) {
@@ -142,8 +144,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -165,8 +167,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -177,8 +179,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerDeclarationPetriNet(PetriNet newContainerDeclarationPetriNet,
@@ -189,14 +191,15 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerDeclarationPetriNet(PetriNet newContainerDeclarationPetriNet) {
 		if (newContainerDeclarationPetriNet != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PETRI_NET && newContainerDeclarationPetriNet != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PETRI_NET
+						&& newContainerDeclarationPetriNet != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerDeclarationPetriNet))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -215,8 +218,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -227,25 +230,27 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetContainerDeclarationPage(Page newContainerDeclarationPage, NotificationChain msgs) {
+	public NotificationChain basicSetContainerDeclarationPage(Page newContainerDeclarationPage,
+			NotificationChain msgs) {
 		msgs = eBasicSetContainer((InternalEObject) newContainerDeclarationPage,
 				HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PAGE, msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerDeclarationPage(Page newContainerDeclarationPage) {
 		if (newContainerDeclarationPage != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PAGE && newContainerDeclarationPage != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PAGE
+						&& newContainerDeclarationPage != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerDeclarationPage))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -264,8 +269,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -273,8 +278,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 		switch (featureID) {
 		case HlcorestructurePackage.DECLARATION__STRUCTURE:
 			if (structure != null)
-				msgs = ((InternalEObject) structure).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.DECLARATION__STRUCTURE, null, msgs);
+				msgs = ((InternalEObject) structure).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.DECLARATION__STRUCTURE, null, msgs);
 			return basicSetStructure((Declarations) otherEnd, msgs);
 		case HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PETRI_NET:
 			if (eInternalContainer() != null)
@@ -289,8 +294,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -307,8 +312,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -318,15 +323,15 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 			return eInternalContainer().eInverseRemove(this, HlcorestructurePackage.PETRI_NET__DECLARATION,
 					PetriNet.class, msgs);
 		case HlcorestructurePackage.DECLARATION__CONTAINER_DECLARATION_PAGE:
-			return eInternalContainer()
-					.eInverseRemove(this, HlcorestructurePackage.PAGE__DECLARATION, Page.class, msgs);
+			return eInternalContainer().eInverseRemove(this, HlcorestructurePackage.PAGE__DECLARATION, Page.class,
+					msgs);
 		}
 		return super.eBasicRemoveFromContainerFeature(msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -343,8 +348,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -364,8 +369,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -385,8 +390,8 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -407,10 +412,10 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -428,13 +433,13 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -517,22 +522,22 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -546,7 +551,7 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 				item.setContainerLabel(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				AnnotationGraphics item;
@@ -556,7 +561,7 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 				item.setContainerAnnotation(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("text")) {
 				this.setText(new java.lang.String(type.getText()));
@@ -581,7 +586,7 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -592,10 +597,10 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -618,13 +623,13 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -766,4 +771,4 @@ public class DeclarationImpl extends HLCoreAnnotationImpl implements Declaration
 		return retour;
 
 	}
-} //DeclarationImpl
+} // DeclarationImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/DimensionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/DimensionImpl.java
@@ -38,7 +38,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/DimensionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/DimensionImpl.java
@@ -63,13 +63,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Dimension</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Dimension</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl#getContainerDNodeGraphics <em>Container DNode Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.DimensionImpl#getContainerDNodeGraphics
+ * <em>Container DNode Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -77,8 +77,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class DimensionImpl extends CoordinateImpl implements Dimension {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DimensionImpl() {
@@ -86,8 +86,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -96,8 +96,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -108,8 +108,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerDNodeGraphics(NodeGraphics newContainerDNodeGraphics,
@@ -120,14 +120,15 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerDNodeGraphics(NodeGraphics newContainerDNodeGraphics) {
 		if (newContainerDNodeGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.DIMENSION__CONTAINER_DNODE_GRAPHICS && newContainerDNodeGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.DIMENSION__CONTAINER_DNODE_GRAPHICS
+						&& newContainerDNodeGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerDNodeGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -146,8 +147,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -162,8 +163,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -176,8 +177,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -191,8 +192,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -205,8 +206,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -220,8 +221,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -235,8 +236,8 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -253,10 +254,10 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -274,7 +275,7 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getX() != null) {
 			sb.append(" x");
@@ -293,7 +294,7 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -306,20 +307,20 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//2
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 2
+		// 0
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("x")) != null) {
 			try {
@@ -337,7 +338,7 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -346,10 +347,10 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -372,7 +373,7 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getX() != null) {
 			sb.append(" x");
@@ -391,7 +392,7 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -444,4 +445,4 @@ public class DimensionImpl extends CoordinateImpl implements Dimension {
 		return retour;
 
 	}
-} //DimensionImpl
+} // DimensionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FillImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FillImpl.java
@@ -39,7 +39,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FillImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FillImpl.java
@@ -68,18 +68,23 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Fill</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Fill</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getColor <em>Color</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getGradientcolor <em>Gradientcolor</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getGradientrotation <em>Gradientrotation</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getImage <em>Image</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getContainerNodeGraphics <em>Container Node Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getColor
+ * <em>Color</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getGradientcolor
+ * <em>Gradientcolor</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getGradientrotation
+ * <em>Gradientrotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getImage
+ * <em>Image</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getContainerNodeGraphics
+ * <em>Container Node Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FillImpl#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -87,9 +92,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class FillImpl extends MinimalEObjectImpl implements Fill {
 	/**
-	 * The default value of the '{@link #getColor() <em>Color</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getColor() <em>Color</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getColor()
 	 * @generated
 	 * @ordered
@@ -97,9 +102,9 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected static final CSS2Color COLOR_EDEFAULT = CSS2Color.BLACK;
 
 	/**
-	 * The cached value of the '{@link #getColor() <em>Color</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getColor() <em>Color</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getColor()
 	 * @generated
 	 * @ordered
@@ -107,9 +112,9 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected CSS2Color color = COLOR_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getGradientcolor() <em>Gradientcolor</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getGradientcolor() <em>Gradientcolor</em>}'
+	 * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getGradientcolor()
 	 * @generated
 	 * @ordered
@@ -117,9 +122,9 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected static final CSS2Color GRADIENTCOLOR_EDEFAULT = CSS2Color.BLACK;
 
 	/**
-	 * The cached value of the '{@link #getGradientcolor() <em>Gradientcolor</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getGradientcolor() <em>Gradientcolor</em>}'
+	 * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getGradientcolor()
 	 * @generated
 	 * @ordered
@@ -127,9 +132,10 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected CSS2Color gradientcolor = GRADIENTCOLOR_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getGradientrotation() <em>Gradientrotation</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getGradientrotation()
+	 * <em>Gradientrotation</em>}' attribute. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #getGradientrotation()
 	 * @generated
 	 * @ordered
@@ -137,9 +143,10 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected static final Gradient GRADIENTROTATION_EDEFAULT = Gradient.HORIZONTAL;
 
 	/**
-	 * The cached value of the '{@link #getGradientrotation() <em>Gradientrotation</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getGradientrotation()
+	 * <em>Gradientrotation</em>}' attribute. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #getGradientrotation()
 	 * @generated
 	 * @ordered
@@ -147,9 +154,9 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected Gradient gradientrotation = GRADIENTROTATION_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getImage() <em>Image</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getImage() <em>Image</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getImage()
 	 * @generated
 	 * @ordered
@@ -157,9 +164,9 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected static final URI IMAGE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getImage() <em>Image</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getImage() <em>Image</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getImage()
 	 * @generated
 	 * @ordered
@@ -167,8 +174,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	protected URI image = IMAGE_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected FillImpl() {
@@ -176,8 +183,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -186,8 +193,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -196,8 +203,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -209,8 +216,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -219,8 +226,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,8 +240,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -243,8 +250,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -257,8 +264,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -267,8 +274,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -280,8 +287,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -292,25 +299,27 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetContainerNodeGraphics(NodeGraphics newContainerNodeGraphics, NotificationChain msgs) {
+	public NotificationChain basicSetContainerNodeGraphics(NodeGraphics newContainerNodeGraphics,
+			NotificationChain msgs) {
 		msgs = eBasicSetContainer((InternalEObject) newContainerNodeGraphics,
 				HlcorestructurePackage.FILL__CONTAINER_NODE_GRAPHICS, msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNodeGraphics(NodeGraphics newContainerNodeGraphics) {
 		if (newContainerNodeGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.FILL__CONTAINER_NODE_GRAPHICS && newContainerNodeGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.FILL__CONTAINER_NODE_GRAPHICS
+						&& newContainerNodeGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNodeGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -328,8 +337,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -340,8 +349,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics,
@@ -352,14 +361,15 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics) {
 		if (newContainerAnnotationGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.FILL__CONTAINER_ANNOTATION_GRAPHICS && newContainerAnnotationGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.FILL__CONTAINER_ANNOTATION_GRAPHICS
+						&& newContainerAnnotationGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerAnnotationGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -378,8 +388,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -398,8 +408,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -414,8 +424,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -432,8 +442,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -456,8 +466,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -486,8 +496,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -516,8 +526,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -540,8 +550,8 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -567,10 +577,10 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 4
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 4
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -588,7 +598,7 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getColor() != null) {
 			sb.append(" color");
@@ -621,7 +631,7 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -634,20 +644,20 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//4
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 4
+		// 0
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("color")) != null) {
 			this.setColor(CSS2Color.get(locRoot.getAttributeValue(new QName("color"))));
@@ -669,7 +679,7 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -678,10 +688,10 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 4
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 4
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -704,7 +714,7 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getColor() != null) {
 			sb.append(" color");
@@ -737,7 +747,7 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -790,4 +800,4 @@ public class FillImpl extends MinimalEObjectImpl implements Fill {
 		return retour;
 
 	}
-} //FillImpl
+} // FillImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FontImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FontImpl.java
@@ -71,20 +71,27 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Font</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Font</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getAlign <em>Align</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getDecoration <em>Decoration</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getFamily <em>Family</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getRotation <em>Rotation</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getSize <em>Size</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getStyle <em>Style</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getWeight <em>Weight</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getAlign
+ * <em>Align</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getDecoration
+ * <em>Decoration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getFamily
+ * <em>Family</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getRotation
+ * <em>Rotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getSize
+ * <em>Size</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getStyle
+ * <em>Style</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getWeight
+ * <em>Weight</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.FontImpl#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -92,9 +99,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class FontImpl extends MinimalEObjectImpl implements Font {
 	/**
-	 * The default value of the '{@link #getAlign() <em>Align</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getAlign() <em>Align</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getAlign()
 	 * @generated
 	 * @ordered
@@ -102,9 +109,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected static final FontAlign ALIGN_EDEFAULT = FontAlign.LEFT;
 
 	/**
-	 * The cached value of the '{@link #getAlign() <em>Align</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getAlign() <em>Align</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getAlign()
 	 * @generated
 	 * @ordered
@@ -112,9 +119,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected FontAlign align = ALIGN_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getDecoration() <em>Decoration</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getDecoration() <em>Decoration</em>}'
+	 * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDecoration()
 	 * @generated
 	 * @ordered
@@ -122,9 +129,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected static final FontDecoration DECORATION_EDEFAULT = FontDecoration.UNDERLINE;
 
 	/**
-	 * The cached value of the '{@link #getDecoration() <em>Decoration</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDecoration() <em>Decoration</em>}'
+	 * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDecoration()
 	 * @generated
 	 * @ordered
@@ -133,8 +140,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 
 	/**
 	 * The default value of the '{@link #getFamily() <em>Family</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFamily()
 	 * @generated
 	 * @ordered
@@ -143,8 +150,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 
 	/**
 	 * The cached value of the '{@link #getFamily() <em>Family</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFamily()
 	 * @generated
 	 * @ordered
@@ -152,9 +159,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected CSS2FontFamily family = FAMILY_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getRotation() <em>Rotation</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getRotation() <em>Rotation</em>}'
+	 * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRotation()
 	 * @generated
 	 * @ordered
@@ -163,8 +170,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 
 	/**
 	 * The cached value of the '{@link #getRotation() <em>Rotation</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRotation()
 	 * @generated
 	 * @ordered
@@ -172,9 +179,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected BigDecimal rotation = ROTATION_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getSize() <em>Size</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getSize() <em>Size</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSize()
 	 * @generated
 	 * @ordered
@@ -182,9 +189,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected static final CSS2FontSize SIZE_EDEFAULT = CSS2FontSize.SMALL;
 
 	/**
-	 * The cached value of the '{@link #getSize() <em>Size</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSize() <em>Size</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSize()
 	 * @generated
 	 * @ordered
@@ -192,9 +199,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected CSS2FontSize size = SIZE_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getStyle() <em>Style</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getStyle() <em>Style</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStyle()
 	 * @generated
 	 * @ordered
@@ -202,9 +209,9 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected static final CSS2FontStyle STYLE_EDEFAULT = CSS2FontStyle.NORMAL;
 
 	/**
-	 * The cached value of the '{@link #getStyle() <em>Style</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStyle() <em>Style</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStyle()
 	 * @generated
 	 * @ordered
@@ -213,8 +220,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 
 	/**
 	 * The default value of the '{@link #getWeight() <em>Weight</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getWeight()
 	 * @generated
 	 * @ordered
@@ -223,8 +230,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 
 	/**
 	 * The cached value of the '{@link #getWeight() <em>Weight</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getWeight()
 	 * @generated
 	 * @ordered
@@ -232,8 +239,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	protected CSS2FontWeight weight = WEIGHT_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected FontImpl() {
@@ -241,8 +248,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -251,8 +258,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -261,8 +268,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -274,8 +281,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -284,8 +291,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -298,8 +305,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -308,8 +315,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -322,8 +329,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -332,8 +339,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -346,8 +353,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -356,8 +363,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -369,8 +376,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -379,8 +386,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -392,8 +399,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -402,8 +409,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -416,8 +423,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -428,8 +435,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics,
@@ -440,14 +447,15 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics) {
 		if (newContainerAnnotationGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.FONT__CONTAINER_ANNOTATION_GRAPHICS && newContainerAnnotationGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.FONT__CONTAINER_ANNOTATION_GRAPHICS
+						&& newContainerAnnotationGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerAnnotationGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -466,8 +474,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -482,8 +490,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -496,8 +504,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -511,8 +519,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -539,8 +547,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -575,8 +583,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -611,8 +619,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -639,8 +647,8 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -672,10 +680,10 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 7
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 7
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -693,7 +701,7 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getAlign() != null) {
 			sb.append(" align");
@@ -747,7 +755,7 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -760,20 +768,20 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//7
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 7
+		// 0
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("align")) != null) {
 			this.setAlign(FontAlign.get(locRoot.getAttributeValue(new QName("align"))));
@@ -807,7 +815,7 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 			this.setWeight(CSS2FontWeight.get(locRoot.getAttributeValue(new QName("weight"))));
 		}
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -816,10 +824,10 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 7
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 7
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -842,7 +850,7 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getAlign() != null) {
 			sb.append(" align");
@@ -896,7 +904,7 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -949,4 +957,4 @@ public class FontImpl extends MinimalEObjectImpl implements Font {
 		return retour;
 
 	}
-} //FontImpl
+} // FontImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FontImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/FontImpl.java
@@ -39,7 +39,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/GraphicsImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/GraphicsImpl.java
@@ -39,9 +39,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Graphics</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -49,8 +48,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
  */
 public abstract class GraphicsImpl extends MinimalEObjectImpl implements Graphics {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected GraphicsImpl() {
@@ -58,8 +57,8 @@ public abstract class GraphicsImpl extends MinimalEObjectImpl implements Graphic
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -69,4 +68,4 @@ public abstract class GraphicsImpl extends MinimalEObjectImpl implements Graphic
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //GraphicsImpl
+} // GraphicsImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HLAnnotationImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HLAnnotationImpl.java
@@ -71,14 +71,15 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>HL Annotation</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>HL
+ * Annotation</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl#getContainerArc <em>Container Arc</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLAnnotationImpl#getContainerArc
+ * <em>Container Arc</em>}</li>
  * </ul>
  * </p>
  *
@@ -86,9 +87,9 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
  */
 public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotation {
 	/**
-	 * The cached value of the '{@link #getStructure() <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStructure() <em>Structure</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStructure()
 	 * @generated
 	 * @ordered
@@ -96,8 +97,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	protected Term structure;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected HLAnnotationImpl() {
@@ -105,8 +106,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -115,8 +116,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,8 +126,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetStructure(Term newStructure, NotificationChain msgs) {
@@ -144,8 +145,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -167,8 +168,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,8 +180,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerArc(Arc newContainerArc, NotificationChain msgs) {
@@ -190,14 +191,15 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerArc(Arc newContainerArc) {
 		if (newContainerArc != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.HL_ANNOTATION__CONTAINER_ARC && newContainerArc != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.HL_ANNOTATION__CONTAINER_ARC
+						&& newContainerArc != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerArc))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -215,8 +217,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -224,8 +226,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 		switch (featureID) {
 		case HlcorestructurePackage.HL_ANNOTATION__STRUCTURE:
 			if (structure != null)
-				msgs = ((InternalEObject) structure).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.HL_ANNOTATION__STRUCTURE, null, msgs);
+				msgs = ((InternalEObject) structure).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.HL_ANNOTATION__STRUCTURE, null, msgs);
 			return basicSetStructure((Term) otherEnd, msgs);
 		case HlcorestructurePackage.HL_ANNOTATION__CONTAINER_ARC:
 			if (eInternalContainer() != null)
@@ -236,8 +238,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -252,23 +254,23 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
 		switch (eContainerFeatureID()) {
 		case HlcorestructurePackage.HL_ANNOTATION__CONTAINER_ARC:
-			return eInternalContainer()
-					.eInverseRemove(this, HlcorestructurePackage.ARC__HLINSCRIPTION, Arc.class, msgs);
+			return eInternalContainer().eInverseRemove(this, HlcorestructurePackage.ARC__HLINSCRIPTION, Arc.class,
+					msgs);
 		}
 		return super.eBasicRemoveFromContainerFeature(msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -283,8 +285,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -301,8 +303,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -319,8 +321,8 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -339,10 +341,10 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -360,13 +362,13 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -449,22 +451,22 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -478,7 +480,7 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 				item.setContainerLabel(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				AnnotationGraphics item;
@@ -488,7 +490,7 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 				item.setContainerAnnotation(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("text")) {
 				this.setText(new java.lang.String(type.getText()));
@@ -711,7 +713,7 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -722,10 +724,10 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -748,13 +750,13 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -896,4 +898,4 @@ public class HLAnnotationImpl extends HLCoreAnnotationImpl implements HLAnnotati
 		return retour;
 
 	}
-} //HLAnnotationImpl
+} // HLAnnotationImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HLCoreAnnotationImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HLCoreAnnotationImpl.java
@@ -40,13 +40,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>HL Core Annotation</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>HL Core
+ * Annotation</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl#getText <em>Text</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLCoreAnnotationImpl#getText
+ * <em>Text</em>}</li>
  * </ul>
  * </p>
  *
@@ -54,9 +54,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage;
  */
 public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLCoreAnnotation {
 	/**
-	 * The default value of the '{@link #getText() <em>Text</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getText() <em>Text</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getText()
 	 * @generated
 	 * @ordered
@@ -64,9 +64,9 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	protected static final String TEXT_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getText() <em>Text</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getText() <em>Text</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getText()
 	 * @generated
 	 * @ordered
@@ -74,8 +74,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	protected String text = TEXT_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected HLCoreAnnotationImpl() {
@@ -83,8 +83,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -93,8 +93,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -103,8 +103,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -117,8 +117,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -131,8 +131,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -146,8 +146,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,8 +161,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -175,8 +175,8 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -193,4 +193,4 @@ public abstract class HLCoreAnnotationImpl extends AnnotationImpl implements HLC
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //HLCoreAnnotationImpl
+} // HLCoreAnnotationImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HLMarkingImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HLMarkingImpl.java
@@ -71,14 +71,15 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>HL Marking</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>HL
+ * Marking</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl#getContainerPlace <em>Container Place</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.HLMarkingImpl#getContainerPlace
+ * <em>Container Place</em>}</li>
  * </ul>
  * </p>
  *
@@ -86,9 +87,9 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
  */
 public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	/**
-	 * The cached value of the '{@link #getStructure() <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStructure() <em>Structure</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStructure()
 	 * @generated
 	 * @ordered
@@ -96,8 +97,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	protected Term structure;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected HLMarkingImpl() {
@@ -105,8 +106,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -115,8 +116,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,8 +126,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetStructure(Term newStructure, NotificationChain msgs) {
@@ -144,8 +145,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -167,8 +168,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,8 +180,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPlace(Place newContainerPlace, NotificationChain msgs) {
@@ -190,14 +191,15 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPlace(Place newContainerPlace) {
 		if (newContainerPlace != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.HL_MARKING__CONTAINER_PLACE && newContainerPlace != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.HL_MARKING__CONTAINER_PLACE
+						&& newContainerPlace != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPlace))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -215,8 +217,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -224,8 +226,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 		switch (featureID) {
 		case HlcorestructurePackage.HL_MARKING__STRUCTURE:
 			if (structure != null)
-				msgs = ((InternalEObject) structure).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.HL_MARKING__STRUCTURE, null, msgs);
+				msgs = ((InternalEObject) structure).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.HL_MARKING__STRUCTURE, null, msgs);
 			return basicSetStructure((Term) otherEnd, msgs);
 		case HlcorestructurePackage.HL_MARKING__CONTAINER_PLACE:
 			if (eInternalContainer() != null)
@@ -236,8 +238,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -252,8 +254,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -267,8 +269,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -283,8 +285,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -301,8 +303,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -319,8 +321,8 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -339,10 +341,10 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -360,13 +362,13 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -449,22 +451,22 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -478,7 +480,7 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 				item.setContainerLabel(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				AnnotationGraphics item;
@@ -488,7 +490,7 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 				item.setContainerAnnotation(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("text")) {
 				this.setText(new java.lang.String(type.getText()));
@@ -711,7 +713,7 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -722,10 +724,10 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -748,13 +750,13 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -896,4 +898,4 @@ public class HLMarkingImpl extends HLCoreAnnotationImpl implements HLMarking {
 		return retour;
 
 	}
-} //HLMarkingImpl
+} // HLMarkingImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HlcorestructureFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HlcorestructureFactoryImpl.java
@@ -79,16 +79,16 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Type;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class HlcorestructureFactoryImpl extends EFactoryImpl implements HlcorestructureFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static HlcorestructureFactory init() {
@@ -105,9 +105,9 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public HlcorestructureFactoryImpl() {
@@ -115,8 +115,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -176,8 +176,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -215,8 +215,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -254,8 +254,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -265,8 +265,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -276,8 +276,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -287,8 +287,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -298,8 +298,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -309,8 +309,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -320,8 +320,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -331,8 +331,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -342,8 +342,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -353,8 +353,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -364,8 +364,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -375,8 +375,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -386,8 +386,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -397,8 +397,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -408,8 +408,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -419,8 +419,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -430,8 +430,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -441,8 +441,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -452,8 +452,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -463,8 +463,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -474,8 +474,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -485,8 +485,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -496,8 +496,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -507,8 +507,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -518,21 +518,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public PNType createPNTypeFromString(EDataType eDataType, String initialValue) {
 		PNType result = PNType.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertPNTypeToString(EDataType eDataType, Object instanceValue) {
@@ -540,21 +540,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public CSS2Color createCSS2ColorFromString(EDataType eDataType, String initialValue) {
 		CSS2Color result = CSS2Color.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertCSS2ColorToString(EDataType eDataType, Object instanceValue) {
@@ -562,21 +562,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public Gradient createGradientFromString(EDataType eDataType, String initialValue) {
 		Gradient result = Gradient.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertGradientToString(EDataType eDataType, Object instanceValue) {
@@ -584,21 +584,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public LineShape createLineShapeFromString(EDataType eDataType, String initialValue) {
 		LineShape result = LineShape.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertLineShapeToString(EDataType eDataType, Object instanceValue) {
@@ -606,21 +606,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public FontAlign createFontAlignFromString(EDataType eDataType, String initialValue) {
 		FontAlign result = FontAlign.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertFontAlignToString(EDataType eDataType, Object instanceValue) {
@@ -628,21 +628,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public FontDecoration createFontDecorationFromString(EDataType eDataType, String initialValue) {
 		FontDecoration result = FontDecoration.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertFontDecorationToString(EDataType eDataType, Object instanceValue) {
@@ -650,21 +650,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public CSS2FontFamily createCSS2FontFamilyFromString(EDataType eDataType, String initialValue) {
 		CSS2FontFamily result = CSS2FontFamily.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertCSS2FontFamilyToString(EDataType eDataType, Object instanceValue) {
@@ -672,21 +672,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public CSS2FontSize createCSS2FontSizeFromString(EDataType eDataType, String initialValue) {
 		CSS2FontSize result = CSS2FontSize.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertCSS2FontSizeToString(EDataType eDataType, Object instanceValue) {
@@ -694,21 +694,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public CSS2FontStyle createCSS2FontStyleFromString(EDataType eDataType, String initialValue) {
 		CSS2FontStyle result = CSS2FontStyle.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertCSS2FontStyleToString(EDataType eDataType, Object instanceValue) {
@@ -716,21 +716,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public CSS2FontWeight createCSS2FontWeightFromString(EDataType eDataType, String initialValue) {
 		CSS2FontWeight result = CSS2FontWeight.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertCSS2FontWeightToString(EDataType eDataType, Object instanceValue) {
@@ -738,21 +738,21 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public LineStyle createLineStyleFromString(EDataType eDataType, String initialValue) {
 		LineStyle result = LineStyle.get(initialValue);
 		if (result == null)
-			throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '"
-					+ eDataType.getName() + "'");
+			throw new IllegalArgumentException(
+					"The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
 		return result;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertLineStyleToString(EDataType eDataType, Object instanceValue) {
@@ -760,8 +760,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public URI createURIFromString(EDataType eDataType, String initialValue) {
@@ -769,8 +769,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertURIToString(EDataType eDataType, Object instanceValue) {
@@ -778,8 +778,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public StringBuffer createLongStringFromString(EDataType eDataType, String initialValue) {
@@ -787,8 +787,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public String convertLongStringToString(EDataType eDataType, Object instanceValue) {
@@ -796,8 +796,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -806,8 +806,8 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -816,4 +816,4 @@ public class HlcorestructureFactoryImpl extends EFactoryImpl implements Hlcorest
 		return HlcorestructurePackage.eINSTANCE;
 	}
 
-} //HlcorestructureFactoryImpl
+} // HlcorestructureFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HlcorestructurePackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/HlcorestructurePackageImpl.java
@@ -103,358 +103,358 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class HlcorestructurePackageImpl extends EPackageImpl implements HlcorestructurePackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass petriNetDocEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass petriNetEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass pageEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass pnObjectEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass nameEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass toolInfoEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass labelEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass nodeGraphicsEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass graphicsEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass coordinateEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass positionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass offsetEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass dimensionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass annotationGraphicsEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass fillEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass lineEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass arcGraphicsEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass arcEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass nodeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass fontEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass placeNodeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass transitionNodeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass placeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass refTransitionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass transitionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass refPlaceEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass attributeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass annotationEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass anyObjectEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass hlCoreAnnotationEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass typeEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass hlMarkingEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass conditionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass hlAnnotationEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass declarationEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum pnTypeEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum css2ColorEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum gradientEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum lineShapeEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum fontAlignEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum fontDecorationEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum css2FontFamilyEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum css2FontSizeEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum css2FontStyleEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum css2FontWeightEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EEnum lineStyleEEnum = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EDataType uriEDataType = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EDataType longStringEDataType = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage#eNS_URI
 	 * @see #init()
@@ -465,19 +465,22 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link HlcorestructurePackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link HlcorestructurePackage#eINSTANCE}
+	 * when that field is accessed. Clients should not invoke it directly. Instead,
+	 * they should simply access that field to obtain the package. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -490,28 +493,35 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		// Obtain or create and register package
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
 				.get(eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
-				: new HlcorestructurePackageImpl());
+						: new HlcorestructurePackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
 		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) : BooleansPackage.eINSTANCE);
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(DotsPackage.eNS_URI) : DotsPackage.eINSTANCE);
+				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI)
+						: BooleansPackage.eINSTANCE);
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI)
+						: DotsPackage.eINSTANCE);
 		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) : IntegersPackage.eINSTANCE);
+				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI)
+						: IntegersPackage.eINSTANCE);
 		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) : MultisetsPackage.eINSTANCE);
+				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI)
+						: MultisetsPackage.eINSTANCE);
 		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) : PartitionsPackage.eINSTANCE);
+				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI)
+						: PartitionsPackage.eINSTANCE);
 		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) : TermsPackage.eINSTANCE);
+				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI)
+						: TermsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theHlcorestructurePackage.createPackageContents();
@@ -548,8 +558,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -558,8 +568,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -568,8 +578,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -578,8 +588,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -588,8 +598,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -598,8 +608,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -608,8 +618,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -618,8 +628,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -628,8 +638,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -638,8 +648,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -648,8 +658,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -658,8 +668,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -668,8 +678,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -678,8 +688,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -688,8 +698,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -698,8 +708,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -708,8 +718,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -718,8 +728,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -728,8 +738,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -738,8 +748,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -748,8 +758,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -758,8 +768,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -768,8 +778,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -778,8 +788,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -788,8 +798,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -798,8 +808,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -808,8 +818,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -818,8 +828,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -828,8 +838,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -838,8 +848,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -848,8 +858,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -858,8 +868,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -868,8 +878,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -878,8 +888,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -888,8 +898,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -898,8 +908,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -908,8 +918,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -918,8 +928,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -928,8 +938,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -938,8 +948,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -948,8 +958,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -958,8 +968,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -968,8 +978,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -978,8 +988,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -988,8 +998,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -998,8 +1008,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1008,8 +1018,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1018,8 +1028,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1028,8 +1038,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1038,8 +1048,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1048,8 +1058,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1058,8 +1068,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1068,8 +1078,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1078,8 +1088,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1088,8 +1098,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1098,8 +1108,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1108,8 +1118,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1118,8 +1128,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1128,8 +1138,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1138,8 +1148,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1148,8 +1158,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1158,8 +1168,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1168,8 +1178,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1178,8 +1188,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1188,8 +1198,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1198,8 +1208,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1208,8 +1218,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1218,8 +1228,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1228,8 +1238,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1238,8 +1248,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1248,8 +1258,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1258,8 +1268,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1268,8 +1278,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1278,8 +1288,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1288,8 +1298,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1298,8 +1308,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1308,8 +1318,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1318,8 +1328,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1328,8 +1338,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1338,8 +1348,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1348,8 +1358,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1358,8 +1368,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1368,8 +1378,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1378,8 +1388,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1388,8 +1398,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1398,8 +1408,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1408,8 +1418,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1418,8 +1428,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1428,8 +1438,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1438,8 +1448,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1448,8 +1458,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1458,8 +1468,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1468,8 +1478,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1478,8 +1488,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1488,8 +1498,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1498,8 +1508,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1508,8 +1518,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1518,8 +1528,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1528,8 +1538,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1538,8 +1548,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1548,8 +1558,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1558,8 +1568,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1568,8 +1578,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1578,8 +1588,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1588,8 +1598,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1598,8 +1608,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1608,8 +1618,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1618,8 +1628,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1628,8 +1638,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1638,8 +1648,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1648,8 +1658,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1658,8 +1668,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1668,8 +1678,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1678,8 +1688,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1688,8 +1698,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1698,8 +1708,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1708,8 +1718,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1718,8 +1728,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1728,8 +1738,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1738,8 +1748,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1748,8 +1758,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1758,8 +1768,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1768,8 +1778,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1778,8 +1788,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1788,8 +1798,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1798,8 +1808,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1808,8 +1818,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1818,8 +1828,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1828,8 +1838,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1838,8 +1848,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1848,8 +1858,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1858,8 +1868,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1868,8 +1878,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1878,8 +1888,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1888,8 +1898,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1898,8 +1908,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1908,8 +1918,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1918,8 +1928,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1928,8 +1938,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1938,8 +1948,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1948,8 +1958,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1958,8 +1968,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1968,8 +1978,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1978,8 +1988,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1988,8 +1998,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -1998,8 +2008,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -2008,8 +2018,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -2018,17 +2028,17 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -2224,17 +2234,17 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -2283,14 +2293,15 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		// Initialize classes and features; add operations and parameters
 		initEClass(petriNetDocEClass, PetriNetDoc.class, "PetriNetDoc", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getPetriNetDoc_Nets(), this.getPetriNet(), this.getPetriNet_ContainerPetriNetDoc(), "nets",
-				null, 1, -1, PetriNetDoc.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
-				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getPetriNetDoc_Nets(), this.getPetriNet(), this.getPetriNet_ContainerPetriNetDoc(), "nets", null,
+				1, -1, PetriNetDoc.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getPetriNetDoc_Xmlns(), ecorePackage.getEString(), "xmlns",
 				"http://www.pnml.org/version-2009/grammar/pnml", 0, 1, PetriNetDoc.class, !IS_TRANSIENT, !IS_VOLATILE,
 				!IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(petriNetEClass, PetriNet.class, "PetriNet", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(petriNetEClass, PetriNet.class, "PetriNet", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getPetriNet_Id(), ecorePackage.getEString(), "id", "", 1, 1, PetriNet.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getPetriNet_Type(), this.getPNType(), "type",
@@ -2336,8 +2347,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEReference(getPnObject_Toolspecifics(), this.getToolInfo(), this.getToolInfo_ContainerPnObject(),
 				"toolspecifics", null, 0, -1, PnObject.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getPnObject_ContainerPage(), this.getPage(), this.getPage_Objects(), "containerPage", null, 0,
-				1, PnObject.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+		initEReference(getPnObject_ContainerPage(), this.getPage(), this.getPage_Objects(), "containerPage", null, 0, 1,
+				PnObject.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, !IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
 		initEClass(nameEClass, Name.class, "Name", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -2350,11 +2361,13 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 				"containerNamePnObject", null, 0, 1, Name.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(toolInfoEClass, ToolInfo.class, "ToolInfo", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEAttribute(getToolInfo_Tool(), ecorePackage.getEString(), "tool", null, 1, 1, ToolInfo.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEClass(toolInfoEClass, ToolInfo.class, "ToolInfo", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getToolInfo_Tool(), ecorePackage.getEString(), "tool", null, 1, 1, ToolInfo.class, !IS_TRANSIENT,
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getToolInfo_Version(), ecorePackage.getEString(), "version", null, 1, 1, ToolInfo.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEAttribute(getToolInfo_FormattedXMLBuffer(), this.getLongString(), "formattedXMLBuffer", null, 0, 1,
 				ToolInfo.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE,
 				!IS_DERIVED, !IS_ORDERED);
@@ -2375,9 +2388,9 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(labelEClass, Label.class, "Label", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getLabel_Toolspecifics(), this.getToolInfo(), this.getToolInfo_ContainerLabel(),
-				"toolspecifics", null, 0, -1, Label.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
-				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+		initEReference(getLabel_Toolspecifics(), this.getToolInfo(), this.getToolInfo_ContainerLabel(), "toolspecifics",
+				null, 0, -1, Label.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
 		initEClass(nodeGraphicsEClass, NodeGraphics.class, "NodeGraphics", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -2387,11 +2400,11 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEReference(getNodeGraphics_Dimension(), this.getDimension(), this.getDimension_ContainerDNodeGraphics(),
 				"dimension", null, 0, 1, NodeGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getNodeGraphics_Fill(), this.getFill(), this.getFill_ContainerNodeGraphics(), "fill", null, 0,
-				1, NodeGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+		initEReference(getNodeGraphics_Fill(), this.getFill(), this.getFill_ContainerNodeGraphics(), "fill", null, 0, 1,
+				NodeGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getNodeGraphics_Line(), this.getLine(), this.getLine_ContainerNodeGraphics(), "line", null, 0,
-				1, NodeGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+		initEReference(getNodeGraphics_Line(), this.getLine(), this.getLine_ContainerNodeGraphics(), "line", null, 0, 1,
+				NodeGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getNodeGraphics_ContainerNode(), this.getNode(), this.getNode_Nodegraphics(), "containerNode",
 				null, 0, 1, NodeGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
@@ -2405,11 +2418,14 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEClass(coordinateEClass, Coordinate.class, "Coordinate", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getCoordinate_X(), ecorePackage.getEIntegerObject(), "x", null, 1, 1, Coordinate.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEAttribute(getCoordinate_Y(), ecorePackage.getEIntegerObject(), "y", null, 1, 1, Coordinate.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 
-		initEClass(positionEClass, Position.class, "Position", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(positionEClass, Position.class, "Position", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getPosition_ContainerArcGraphics(), this.getArcGraphics(), this.getArcGraphics_Positions(),
 				"containerArcGraphics", null, 0, 1, Position.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
@@ -2434,14 +2450,14 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEReference(getAnnotationGraphics_Offset(), this.getOffset(), this.getOffset_ContainerAnnotationGraphics(),
 				"offset", null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getAnnotationGraphics_Fill(), this.getFill(), this.getFill_ContainerAnnotationGraphics(),
-				"fill", null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+		initEReference(getAnnotationGraphics_Fill(), this.getFill(), this.getFill_ContainerAnnotationGraphics(), "fill",
+				null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getAnnotationGraphics_Line(), this.getLine(), this.getLine_ContainerAnnotationGraphics(),
-				"line", null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+		initEReference(getAnnotationGraphics_Line(), this.getLine(), this.getLine_ContainerAnnotationGraphics(), "line",
+				null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getAnnotationGraphics_Font(), this.getFont(), this.getFont_ContainerAnnotationGraphics(),
-				"font", null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+		initEReference(getAnnotationGraphics_Font(), this.getFont(), this.getFont_ContainerAnnotationGraphics(), "font",
+				null, 0, 1, AnnotationGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getAnnotationGraphics_ContainerAnnotation(), this.getAnnotation(),
 				this.getAnnotation_Annotationgraphics(), "containerAnnotation", null, 0, 1, AnnotationGraphics.class,
@@ -2452,18 +2468,20 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEAttribute(getFill_Color(), this.getCSS2Color(), "color", "BLACK", 0, 1, Fill.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getFill_Gradientcolor(), this.getCSS2Color(), "gradientcolor", "BLACK", 0, 1, Fill.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEAttribute(getFill_Gradientrotation(), this.getGradient(), "gradientrotation", null, 0, 1, Fill.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEAttribute(getFill_Image(), this.getURI(), "image", null, 0, 1, Fill.class, !IS_TRANSIENT, !IS_VOLATILE,
 				IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getFill_ContainerNodeGraphics(), this.getNodeGraphics(), this.getNodeGraphics_Fill(),
 				"containerNodeGraphics", null, 0, 1, Fill.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getFill_ContainerAnnotationGraphics(), this.getAnnotationGraphics(),
-				this.getAnnotationGraphics_Fill(), "containerAnnotationGraphics", null, 0, 1, Fill.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
-				IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				this.getAnnotationGraphics_Fill(), "containerAnnotationGraphics", null, 0, 1, Fill.class, !IS_TRANSIENT,
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 
 		initEClass(lineEClass, Line.class, "Line", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getLine_Color(), this.getCSS2Color(), "color", "BLACK", 0, 1, Line.class, !IS_TRANSIENT,
@@ -2471,7 +2489,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEAttribute(getLine_Shape(), this.getLineShape(), "shape", "line", 0, 1, Line.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getLine_Width(), ecorePackage.getEIntegerObject(), "width", null, 0, 1, Line.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEReference(getLine_ContainerNodeGraphics(), this.getNodeGraphics(), this.getNodeGraphics_Line(),
 				"containerNodeGraphics", null, 0, 1, Line.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
@@ -2479,9 +2498,9 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 				"containerArcGraphics", null, 0, 1, Line.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getLine_ContainerAnnotationGraphics(), this.getAnnotationGraphics(),
-				this.getAnnotationGraphics_Line(), "containerAnnotationGraphics", null, 0, 1, Line.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
-				IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				this.getAnnotationGraphics_Line(), "containerAnnotationGraphics", null, 0, 1, Line.class, !IS_TRANSIENT,
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEAttribute(getLine_Style(), this.getLineStyle(), "style", null, 0, 1, Line.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
@@ -2493,9 +2512,9 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEReference(getArcGraphics_Line(), this.getLine(), this.getLine_ContainerArcGraphics(), "line", null, 0, 1,
 				ArcGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEReference(getArcGraphics_ContainerArc(), this.getArc(), this.getArc_Arcgraphics(), "containerArc", null,
-				0, 1, ArcGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getArcGraphics_ContainerArc(), this.getArc(), this.getArc_Arcgraphics(), "containerArc", null, 0,
+				1, ArcGraphics.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(arcEClass, Arc.class, "Arc", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getArc_Source(), this.getNode(), this.getNode_OutArcs(), "source", null, 1, 1, Arc.class,
@@ -2526,11 +2545,13 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEAttribute(getFont_Align(), this.getFontAlign(), "align", "LEFT", 0, 1, Font.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getFont_Decoration(), this.getFontDecoration(), "decoration", "UNDERLINE", 0, 1, Font.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
-		initEAttribute(getFont_Family(), this.getCSS2FontFamily(), "family", "VERDANA", 0, 1, Font.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
+		initEAttribute(getFont_Family(), this.getCSS2FontFamily(), "family", "VERDANA", 0, 1, Font.class, !IS_TRANSIENT,
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getFont_Rotation(), ecorePackage.getEBigDecimal(), "rotation", null, 0, 1, Font.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 		initEAttribute(getFont_Size(), this.getCSS2FontSize(), "size", "SMALL", 0, 1, Font.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEAttribute(getFont_Style(), this.getCSS2FontStyle(), "style", "NORMAL", 0, 1, Font.class, !IS_TRANSIENT,
@@ -2538,9 +2559,9 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		initEAttribute(getFont_Weight(), this.getCSS2FontWeight(), "weight", null, 0, 1, Font.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getFont_ContainerAnnotationGraphics(), this.getAnnotationGraphics(),
-				this.getAnnotationGraphics_Font(), "containerAnnotationGraphics", null, 0, 1, Font.class,
-				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
-				IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
+				this.getAnnotationGraphics_Font(), "containerAnnotationGraphics", null, 0, 1, Font.class, !IS_TRANSIENT,
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 
 		initEClass(placeNodeEClass, PlaceNode.class, "PlaceNode", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -2550,10 +2571,9 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 
 		initEClass(transitionNodeEClass, TransitionNode.class, "TransitionNode", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getTransitionNode_ReferencingTransitions(), this.getRefTransition(),
-				this.getRefTransition_Ref(), "referencingTransitions", null, 0, -1, TransitionNode.class,
-				!IS_TRANSIENT, !IS_VOLATILE, !IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
-				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTransitionNode_ReferencingTransitions(), this.getRefTransition(), this.getRefTransition_Ref(),
+				"referencingTransitions", null, 0, -1, TransitionNode.class, !IS_TRANSIENT, !IS_VOLATILE,
+				!IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(placeEClass, Place.class, "Place", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getPlace_Type(), this.getType(), this.getType_ContainerPlace(), "type", null, 0, 1, Place.class,
@@ -2576,9 +2596,10 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 				"condition", null, 0, 1, Transition.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(refPlaceEClass, RefPlace.class, "RefPlace", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getRefPlace_Ref(), this.getPlaceNode(), this.getPlaceNode_ReferencingPlaces(), "ref", null, 1,
-				1, RefPlace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
+		initEClass(refPlaceEClass, RefPlace.class, "RefPlace", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
+		initEReference(getRefPlace_Ref(), this.getPlaceNode(), this.getPlaceNode_ReferencingPlaces(), "ref", null, 1, 1,
+				RefPlace.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
 		initEClass(attributeEClass, Attribute.class, "Attribute", IS_ABSTRACT, !IS_INTERFACE,
@@ -2637,8 +2658,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 				theTermsPackage.getTerm_ContainerHLAnnotation(), "structure", null, 0, 1, HLAnnotation.class,
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getHLAnnotation_ContainerArc(), this.getArc(), this.getArc_Hlinscription(), "containerArc",
-				null, 0, 1, HLAnnotation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
+		initEReference(getHLAnnotation_ContainerArc(), this.getArc(), this.getArc_Hlinscription(), "containerArc", null,
+				0, 1, HLAnnotation.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(declarationEClass, Declaration.class, "Declaration", !IS_ABSTRACT, !IS_INTERFACE,
@@ -2755,9 +2776,9 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -2784,8 +2805,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		addAnnotation(lineShapeEEnum, source, new String[] {});
 		addAnnotation(arcGraphicsEClass, source, new String[] {});
 		addAnnotation(arcEClass, source, new String[] {});
-		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL", new String[] { "samePageSourceTarget",
-				"self.source.containerPage = self.target.containerPage" });
+		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL",
+				new String[] { "samePageSourceTarget", "self.source.containerPage = self.target.containerPage" });
 		addAnnotation(nodeEClass, source, new String[] {});
 		addAnnotation(fontEClass, source, new String[] {});
 		addAnnotation(fontAlignEEnum, source, new String[] {});
@@ -2812,8 +2833,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -2860,8 +2881,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		addAnnotation(fillEClass, source, new String[] { "tag", "fill", "kind", "son" });
 		addAnnotation(getFill_Color(), source, new String[] { "tag", "color", "kind", "attribute" });
 		addAnnotation(getFill_Gradientcolor(), source, new String[] { "tag", "gradient-color", "kind", "attribute" });
-		addAnnotation(getFill_Gradientrotation(), source, new String[] { "tag", "gradient-rotation", "kind",
-				"attribute" });
+		addAnnotation(getFill_Gradientrotation(), source,
+				new String[] { "tag", "gradient-rotation", "kind", "attribute" });
 		addAnnotation(getFill_Image(), source, new String[] { "tag", "image", "kind", "attribute" });
 		addAnnotation(lineEClass, source, new String[] { "tag", "line", "kind", "son" });
 		addAnnotation(getLine_Color(), source, new String[] { "tag", "color", "kind", "attribute" });
@@ -2871,8 +2892,8 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		addAnnotation(arcGraphicsEClass, source, new String[] { "tag", "graphics", "kind", "son" });
 		addAnnotation(getArcGraphics_Positions(), source, new String[] { "kind", "follow" });
 		addAnnotation(getArcGraphics_Line(), source, new String[] { "kind", "follow" });
-		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL", new String[] { "samePageSourceTarget",
-				"self.source.containerPage = self.target.containerPage" });
+		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL",
+				new String[] { "samePageSourceTarget", "self.source.containerPage = self.target.containerPage" });
 		addAnnotation(arcEClass, source, new String[] { "tag", "arc", "kind", "son" });
 		addAnnotation(getArc_Source(), source, new String[] { "kind", "idref", "tag", "source" });
 		addAnnotation(getArc_Target(), source, new String[] { "kind", "idref", "tag", "target" });
@@ -2899,67 +2920,62 @@ public class HlcorestructurePackageImpl extends EPackageImpl implements Hlcorest
 		addAnnotation(getAnnotation_Annotationgraphics(), source, new String[] { "kind", "follow" });
 		addAnnotation(getHLCoreAnnotation_Text(), source, new String[] { "tag", "text", "kind", "son" });
 		addAnnotation(typeEClass, source, new String[] { "tag", "type", "kind", "son" });
-		addAnnotation(getType_Structure(), source, new String[] { "tag", "structure", "kind", "follow", "toBeFollowed",
-				"yes" });
+		addAnnotation(getType_Structure(), source,
+				new String[] { "tag", "structure", "kind", "follow", "toBeFollowed", "yes" });
 		addAnnotation(hlMarkingEClass, source, new String[] { "tag", "hlinitialMarking", "kind", "son" });
-		addAnnotation(getHLMarking_Structure(), source, new String[] { "tag", "structure", "kind", "follow",
-				"toBeFollowed", "yes" });
+		addAnnotation(getHLMarking_Structure(), source,
+				new String[] { "tag", "structure", "kind", "follow", "toBeFollowed", "yes" });
 		addAnnotation(conditionEClass, source, new String[] { "tag", "condition", "kind", "son" });
-		addAnnotation(getCondition_Structure(), source, new String[] { "tag", "structure", "kind", "follow",
-				"toBeFollowed", "yes" });
+		addAnnotation(getCondition_Structure(), source,
+				new String[] { "tag", "structure", "kind", "follow", "toBeFollowed", "yes" });
 		addAnnotation(hlAnnotationEClass, source, new String[] { "tag", "hlinscription", "kind", "son" });
-		addAnnotation(getHLAnnotation_Structure(), source, new String[] { "tag", "structure", "kind", "follow",
-				"toBeFollowed", "yes" });
+		addAnnotation(getHLAnnotation_Structure(), source,
+				new String[] { "tag", "structure", "kind", "follow", "toBeFollowed", "yes" });
 		addAnnotation(declarationEClass, source, new String[] { "tag", "declaration", "kind", "son" });
-		addAnnotation(getDeclaration_Structure(), source, new String[] { "tag", "structure", "kind", "follow",
-				"toBeFollowed", "yes" });
+		addAnnotation(getDeclaration_Structure(), source,
+				new String[] { "tag", "structure", "kind", "follow", "toBeFollowed", "yes" });
 	}
 
 	/**
-	 * Initializes the annotations for <b>redefines</b>.
-	 * <!-- begin-user-doc -->
+	 * Initializes the annotations for <b>redefines</b>. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createRedefinesAnnotations() {
 		String source = "redefines";
 		addAnnotation(getPetriNet_Name(), source, new String[] {});
 		addAnnotation(getPnObject_Name(), source, new String[] {});
-		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL", new String[] { "samePageSourceTarget",
-				"self.source.containerPage = self.target.containerPage" });
+		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL",
+				new String[] { "samePageSourceTarget", "self.source.containerPage = self.target.containerPage" });
 	}
 
 	/**
 	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createEcoreAnnotations() {
 		String source = "http://www.eclipse.org/emf/2002/Ecore";
-		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL", new String[] { "samePageSourceTarget",
-				"self.source.containerPage = self.target.containerPage" });
+		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL",
+				new String[] { "samePageSourceTarget", "self.source.containerPage = self.target.containerPage" });
 		addAnnotation(arcEClass, source, new String[] { "constraints", "samePageSourceTarget differentSourceTarget" });
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createOCLAnnotations() {
 		String source = "http://www.pnml.org/models/OCL";
-		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL", new String[] { "samePageSourceTarget",
-				"self.source.containerPage = self.target.containerPage" });
-		addAnnotation(
-				arcEClass,
-				source,
-				new String[] {
-						"samePageSourceTarget",
-						"self.source.containerPage = self.target.containerPage",
-						"differentSourceTarget",
-						"(self.source.oclIsKindOf(PlaceNode) and self.target.oclIsKindOf(TransitionNode)) or (self.source.oclIsKindOf(TransitionNode) and self.target.oclIsKindOf(PlaceNode))" });
+		addAnnotation(arcEClass, 1, "http://www.pnml.org/models/OCL",
+				new String[] { "samePageSourceTarget", "self.source.containerPage = self.target.containerPage" });
+		addAnnotation(arcEClass, source, new String[] { "samePageSourceTarget",
+				"self.source.containerPage = self.target.containerPage", "differentSourceTarget",
+				"(self.source.oclIsKindOf(PlaceNode) and self.target.oclIsKindOf(TransitionNode)) or (self.source.oclIsKindOf(TransitionNode) and self.target.oclIsKindOf(PlaceNode))" });
 	}
 
-} //HlcorestructurePackageImpl
+} // HlcorestructurePackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/LabelImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/LabelImpl.java
@@ -48,13 +48,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Label;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Label</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Label</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl#getToolspecifics <em>Toolspecifics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LabelImpl#getToolspecifics
+ * <em>Toolspecifics</em>}</li>
  * </ul>
  * </p>
  *
@@ -62,9 +62,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
  */
 public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	/**
-	 * The cached value of the '{@link #getToolspecifics() <em>Toolspecifics</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getToolspecifics() <em>Toolspecifics</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getToolspecifics()
 	 * @generated
 	 * @ordered
@@ -72,8 +72,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	protected EList<ToolInfo> toolspecifics;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected LabelImpl() {
@@ -81,8 +81,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -91,8 +91,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -105,8 +105,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -120,8 +120,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -134,8 +134,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +148,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -165,8 +165,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -180,8 +180,8 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -195,4 +195,4 @@ public abstract class LabelImpl extends MinimalEObjectImpl implements Label {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //LabelImpl
+} // LabelImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/LineImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/LineImpl.java
@@ -69,19 +69,25 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Line</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Line</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getColor <em>Color</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getShape <em>Shape</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getWidth <em>Width</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getContainerNodeGraphics <em>Container Node Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getContainerArcGraphics <em>Container Arc Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getStyle <em>Style</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getColor
+ * <em>Color</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getShape
+ * <em>Shape</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getWidth
+ * <em>Width</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getContainerNodeGraphics
+ * <em>Container Node Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getContainerArcGraphics
+ * <em>Container Arc Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.LineImpl#getStyle
+ * <em>Style</em>}</li>
  * </ul>
  * </p>
  *
@@ -89,9 +95,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class LineImpl extends MinimalEObjectImpl implements Line {
 	/**
-	 * The default value of the '{@link #getColor() <em>Color</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getColor() <em>Color</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getColor()
 	 * @generated
 	 * @ordered
@@ -99,9 +105,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected static final CSS2Color COLOR_EDEFAULT = CSS2Color.BLACK;
 
 	/**
-	 * The cached value of the '{@link #getColor() <em>Color</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getColor() <em>Color</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getColor()
 	 * @generated
 	 * @ordered
@@ -109,9 +115,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected CSS2Color color = COLOR_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getShape() <em>Shape</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getShape() <em>Shape</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getShape()
 	 * @generated
 	 * @ordered
@@ -119,9 +125,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected static final LineShape SHAPE_EDEFAULT = LineShape.LINE;
 
 	/**
-	 * The cached value of the '{@link #getShape() <em>Shape</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getShape() <em>Shape</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getShape()
 	 * @generated
 	 * @ordered
@@ -129,9 +135,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected LineShape shape = SHAPE_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getWidth() <em>Width</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getWidth() <em>Width</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getWidth()
 	 * @generated
 	 * @ordered
@@ -139,9 +145,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected static final Integer WIDTH_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getWidth() <em>Width</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getWidth()
 	 * @generated
 	 * @ordered
@@ -149,9 +155,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected Integer width = WIDTH_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getStyle() <em>Style</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getStyle() <em>Style</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStyle()
 	 * @generated
 	 * @ordered
@@ -159,9 +165,9 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected static final LineStyle STYLE_EDEFAULT = LineStyle.SOLID;
 
 	/**
-	 * The cached value of the '{@link #getStyle() <em>Style</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStyle() <em>Style</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStyle()
 	 * @generated
 	 * @ordered
@@ -169,8 +175,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	protected LineStyle style = STYLE_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected LineImpl() {
@@ -178,8 +184,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -188,8 +194,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -198,8 +204,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -211,8 +217,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -221,8 +227,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -234,8 +240,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -244,8 +250,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -257,8 +263,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -269,25 +275,27 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetContainerNodeGraphics(NodeGraphics newContainerNodeGraphics, NotificationChain msgs) {
+	public NotificationChain basicSetContainerNodeGraphics(NodeGraphics newContainerNodeGraphics,
+			NotificationChain msgs) {
 		msgs = eBasicSetContainer((InternalEObject) newContainerNodeGraphics,
 				HlcorestructurePackage.LINE__CONTAINER_NODE_GRAPHICS, msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNodeGraphics(NodeGraphics newContainerNodeGraphics) {
 		if (newContainerNodeGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.LINE__CONTAINER_NODE_GRAPHICS && newContainerNodeGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.LINE__CONTAINER_NODE_GRAPHICS
+						&& newContainerNodeGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNodeGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -305,8 +313,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -317,8 +325,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerArcGraphics(ArcGraphics newContainerArcGraphics, NotificationChain msgs) {
@@ -328,14 +336,15 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerArcGraphics(ArcGraphics newContainerArcGraphics) {
 		if (newContainerArcGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.LINE__CONTAINER_ARC_GRAPHICS && newContainerArcGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.LINE__CONTAINER_ARC_GRAPHICS
+						&& newContainerArcGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerArcGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -353,8 +362,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -365,8 +374,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics,
@@ -377,14 +386,15 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics) {
 		if (newContainerAnnotationGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.LINE__CONTAINER_ANNOTATION_GRAPHICS && newContainerAnnotationGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.LINE__CONTAINER_ANNOTATION_GRAPHICS
+						&& newContainerAnnotationGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerAnnotationGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -403,8 +413,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -413,8 +423,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -426,8 +436,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -450,8 +460,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -468,8 +478,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -489,8 +499,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -515,8 +525,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -548,8 +558,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -581,8 +591,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -607,8 +617,8 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -634,10 +644,10 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 4
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 4
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -655,7 +665,7 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getColor() != null) {
 			sb.append(" color");
@@ -688,7 +698,7 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -701,20 +711,20 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//4
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 4
+		// 0
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("color")) != null) {
 			this.setColor(CSS2Color.get(locRoot.getAttributeValue(new QName("color"))));
@@ -736,7 +746,7 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 			this.setStyle(LineStyle.get(locRoot.getAttributeValue(new QName("style"))));
 		}
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -745,10 +755,10 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 4
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 4
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -771,7 +781,7 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getColor() != null) {
 			sb.append(" color");
@@ -804,7 +814,7 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -857,4 +867,4 @@ public class LineImpl extends MinimalEObjectImpl implements Line {
 		return retour;
 
 	}
-} //LineImpl
+} // LineImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/LineImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/LineImpl.java
@@ -38,7 +38,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/NameImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/NameImpl.java
@@ -65,15 +65,17 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Name</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Name</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl#getText <em>Text</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl#getContainerNamePetriNet <em>Container Name Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl#getContainerNamePnObject <em>Container Name Pn Object</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl#getText
+ * <em>Text</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl#getContainerNamePetriNet
+ * <em>Container Name Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NameImpl#getContainerNamePnObject
+ * <em>Container Name Pn Object</em>}</li>
  * </ul>
  * </p>
  *
@@ -81,9 +83,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class NameImpl extends AnnotationImpl implements Name {
 	/**
-	 * The default value of the '{@link #getText() <em>Text</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getText() <em>Text</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getText()
 	 * @generated
 	 * @ordered
@@ -91,9 +93,9 @@ public class NameImpl extends AnnotationImpl implements Name {
 	protected static final String TEXT_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getText() <em>Text</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getText() <em>Text</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getText()
 	 * @generated
 	 * @ordered
@@ -101,8 +103,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	protected String text = TEXT_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NameImpl() {
@@ -110,8 +112,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -120,8 +122,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,8 +132,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -143,8 +145,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -155,8 +157,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNamePetriNet(PetriNet newContainerNamePetriNet, NotificationChain msgs) {
@@ -166,14 +168,15 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNamePetriNet(PetriNet newContainerNamePetriNet) {
 		if (newContainerNamePetriNet != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.NAME__CONTAINER_NAME_PETRI_NET && newContainerNamePetriNet != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.NAME__CONTAINER_NAME_PETRI_NET
+						&& newContainerNamePetriNet != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNamePetriNet))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -186,14 +189,13 @@ public class NameImpl extends AnnotationImpl implements Name {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.NAME__CONTAINER_NAME_PETRI_NET, newContainerNamePetriNet,
-					newContainerNamePetriNet));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.NAME__CONTAINER_NAME_PETRI_NET,
+					newContainerNamePetriNet, newContainerNamePetriNet));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -204,8 +206,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNamePnObject(PnObject newContainerNamePnObject, NotificationChain msgs) {
@@ -215,14 +217,15 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNamePnObject(PnObject newContainerNamePnObject) {
 		if (newContainerNamePnObject != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.NAME__CONTAINER_NAME_PN_OBJECT && newContainerNamePnObject != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.NAME__CONTAINER_NAME_PN_OBJECT
+						&& newContainerNamePnObject != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNamePnObject))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -235,14 +238,13 @@ public class NameImpl extends AnnotationImpl implements Name {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.NAME__CONTAINER_NAME_PN_OBJECT, newContainerNamePnObject,
-					newContainerNamePnObject));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.NAME__CONTAINER_NAME_PN_OBJECT,
+					newContainerNamePnObject, newContainerNamePnObject));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -261,8 +263,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -277,8 +279,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -295,8 +297,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -313,8 +315,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -334,8 +336,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -355,8 +357,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -373,8 +375,8 @@ public class NameImpl extends AnnotationImpl implements Name {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -394,10 +396,10 @@ public class NameImpl extends AnnotationImpl implements Name {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 3
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 3
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -415,13 +417,13 @@ public class NameImpl extends AnnotationImpl implements Name {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -484,22 +486,22 @@ public class NameImpl extends AnnotationImpl implements Name {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//3
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 3
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -513,7 +515,7 @@ public class NameImpl extends AnnotationImpl implements Name {
 				item.setContainerLabel(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				AnnotationGraphics item;
@@ -523,7 +525,7 @@ public class NameImpl extends AnnotationImpl implements Name {
 				item.setContainerAnnotation(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("text")) {
 				this.setText(new java.lang.String(type.getText()));
@@ -538,10 +540,10 @@ public class NameImpl extends AnnotationImpl implements Name {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 3
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 3
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -564,13 +566,13 @@ public class NameImpl extends AnnotationImpl implements Name {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -688,4 +690,4 @@ public class NameImpl extends AnnotationImpl implements Name {
 		return retour;
 
 	}
-} //NameImpl
+} // NameImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/NodeGraphicsImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/NodeGraphicsImpl.java
@@ -67,18 +67,23 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Position;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Node Graphics</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Node
+ * Graphics</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getPosition <em>Position</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getDimension <em>Dimension</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getFill <em>Fill</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getLine <em>Line</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getContainerNode <em>Container Node</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getContainerPage <em>Container Page</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getPosition
+ * <em>Position</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getDimension
+ * <em>Dimension</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getFill
+ * <em>Fill</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getLine
+ * <em>Line</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getContainerNode
+ * <em>Container Node</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeGraphicsImpl#getContainerPage
+ * <em>Container Page</em>}</li>
  * </ul>
  * </p>
  *
@@ -86,9 +91,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	/**
-	 * The cached value of the '{@link #getPosition() <em>Position</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPosition() <em>Position</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getPosition()
 	 * @generated
 	 * @ordered
@@ -96,9 +101,9 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	protected Position position;
 
 	/**
-	 * The cached value of the '{@link #getDimension() <em>Dimension</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDimension() <em>Dimension</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDimension()
 	 * @generated
 	 * @ordered
@@ -106,9 +111,9 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	protected Dimension dimension;
 
 	/**
-	 * The cached value of the '{@link #getFill() <em>Fill</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFill() <em>Fill</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFill()
 	 * @generated
 	 * @ordered
@@ -116,9 +121,9 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	protected Fill fill;
 
 	/**
-	 * The cached value of the '{@link #getLine() <em>Line</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getLine() <em>Line</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getLine()
 	 * @generated
 	 * @ordered
@@ -126,8 +131,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	protected Line line;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NodeGraphicsImpl() {
@@ -135,8 +140,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -145,8 +150,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -155,8 +160,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetPosition(Position newPosition, NotificationChain msgs) {
@@ -174,8 +179,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -197,8 +202,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -207,8 +212,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetDimension(Dimension newDimension, NotificationChain msgs) {
@@ -226,8 +231,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -249,8 +254,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,8 +264,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetFill(Fill newFill, NotificationChain msgs) {
@@ -278,8 +283,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -301,8 +306,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -311,8 +316,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetLine(Line newLine, NotificationChain msgs) {
@@ -330,8 +335,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -353,8 +358,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -365,8 +370,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNode(Node newContainerNode, NotificationChain msgs) {
@@ -376,22 +381,23 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNode(Node newContainerNode) {
 		if (newContainerNode != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.NODE_GRAPHICS__CONTAINER_NODE && newContainerNode != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.NODE_GRAPHICS__CONTAINER_NODE
+						&& newContainerNode != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNode))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
 			if (eInternalContainer() != null)
 				msgs = eBasicRemoveFromContainer(msgs);
 			if (newContainerNode != null)
-				msgs = ((InternalEObject) newContainerNode).eInverseAdd(this,
-						HlcorestructurePackage.NODE__NODEGRAPHICS, Node.class, msgs);
+				msgs = ((InternalEObject) newContainerNode).eInverseAdd(this, HlcorestructurePackage.NODE__NODEGRAPHICS,
+						Node.class, msgs);
 			msgs = basicSetContainerNode(newContainerNode, msgs);
 			if (msgs != null)
 				msgs.dispatch();
@@ -401,8 +407,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -413,8 +419,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPage(Page newContainerPage, NotificationChain msgs) {
@@ -424,22 +430,23 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPage(Page newContainerPage) {
 		if (newContainerPage != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.NODE_GRAPHICS__CONTAINER_PAGE && newContainerPage != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.NODE_GRAPHICS__CONTAINER_PAGE
+						&& newContainerPage != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPage))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
 			if (eInternalContainer() != null)
 				msgs = eBasicRemoveFromContainer(msgs);
 			if (newContainerPage != null)
-				msgs = ((InternalEObject) newContainerPage).eInverseAdd(this,
-						HlcorestructurePackage.PAGE__NODEGRAPHICS, Page.class, msgs);
+				msgs = ((InternalEObject) newContainerPage).eInverseAdd(this, HlcorestructurePackage.PAGE__NODEGRAPHICS,
+						Page.class, msgs);
 			msgs = basicSetContainerPage(newContainerPage, msgs);
 			if (msgs != null)
 				msgs.dispatch();
@@ -449,8 +456,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -458,23 +465,23 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 		switch (featureID) {
 		case HlcorestructurePackage.NODE_GRAPHICS__POSITION:
 			if (position != null)
-				msgs = ((InternalEObject) position).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.NODE_GRAPHICS__POSITION, null, msgs);
+				msgs = ((InternalEObject) position).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.NODE_GRAPHICS__POSITION, null, msgs);
 			return basicSetPosition((Position) otherEnd, msgs);
 		case HlcorestructurePackage.NODE_GRAPHICS__DIMENSION:
 			if (dimension != null)
-				msgs = ((InternalEObject) dimension).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.NODE_GRAPHICS__DIMENSION, null, msgs);
+				msgs = ((InternalEObject) dimension).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.NODE_GRAPHICS__DIMENSION, null, msgs);
 			return basicSetDimension((Dimension) otherEnd, msgs);
 		case HlcorestructurePackage.NODE_GRAPHICS__FILL:
 			if (fill != null)
-				msgs = ((InternalEObject) fill).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.NODE_GRAPHICS__FILL, null, msgs);
+				msgs = ((InternalEObject) fill).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.NODE_GRAPHICS__FILL, null, msgs);
 			return basicSetFill((Fill) otherEnd, msgs);
 		case HlcorestructurePackage.NODE_GRAPHICS__LINE:
 			if (line != null)
-				msgs = ((InternalEObject) line).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.NODE_GRAPHICS__LINE, null, msgs);
+				msgs = ((InternalEObject) line).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.NODE_GRAPHICS__LINE, null, msgs);
 			return basicSetLine((Line) otherEnd, msgs);
 		case HlcorestructurePackage.NODE_GRAPHICS__CONTAINER_NODE:
 			if (eInternalContainer() != null)
@@ -489,8 +496,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -513,8 +520,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -531,8 +538,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -555,8 +562,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -585,8 +592,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -615,8 +622,8 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -643,10 +650,10 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -664,13 +671,13 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPosition() != null) {
 
@@ -740,22 +747,22 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -769,7 +776,7 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 				item.setContainerPNodeGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dimension")) {
 				Dimension item;
@@ -779,7 +786,7 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 				item.setContainerDNodeGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("fill")) {
 				Fill item;
@@ -789,7 +796,7 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 				item.setContainerNodeGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("line")) {
 				Line item;
@@ -799,7 +806,7 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 				item.setContainerNodeGraphics(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -810,10 +817,10 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -836,13 +843,13 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPosition() != null) {
 
@@ -963,4 +970,4 @@ public class NodeGraphicsImpl extends GraphicsImpl implements NodeGraphics {
 		return retour;
 
 	}
-} //NodeGraphicsImpl
+} // NodeGraphicsImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/NodeImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/NodeImpl.java
@@ -49,15 +49,17 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Node;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Node</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Node</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl#getInArcs <em>In Arcs</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl#getOutArcs <em>Out Arcs</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl#getNodegraphics <em>Nodegraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl#getInArcs
+ * <em>In Arcs</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl#getOutArcs
+ * <em>Out Arcs</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.NodeImpl#getNodegraphics
+ * <em>Nodegraphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -65,9 +67,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics;
  */
 public abstract class NodeImpl extends PnObjectImpl implements Node {
 	/**
-	 * The cached value of the '{@link #getInArcs() <em>In Arcs</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getInArcs() <em>In Arcs</em>}' reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getInArcs()
 	 * @generated
 	 * @ordered
@@ -75,9 +77,9 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	protected EList<Arc> inArcs;
 
 	/**
-	 * The cached value of the '{@link #getOutArcs() <em>Out Arcs</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getOutArcs() <em>Out Arcs</em>}' reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getOutArcs()
 	 * @generated
 	 * @ordered
@@ -85,9 +87,9 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	protected EList<Arc> outArcs;
 
 	/**
-	 * The cached value of the '{@link #getNodegraphics() <em>Nodegraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getNodegraphics() <em>Nodegraphics</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getNodegraphics()
 	 * @generated
 	 * @ordered
@@ -95,8 +97,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	protected NodeGraphics nodegraphics;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NodeImpl() {
@@ -104,8 +106,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -114,8 +116,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,8 +130,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -142,8 +144,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -152,8 +154,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetNodegraphics(NodeGraphics newNodegraphics, NotificationChain msgs) {
@@ -171,8 +173,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -194,8 +196,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -208,16 +210,16 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getOutArcs()).basicAdd(otherEnd, msgs);
 		case HlcorestructurePackage.NODE__NODEGRAPHICS:
 			if (nodegraphics != null)
-				msgs = ((InternalEObject) nodegraphics).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.NODE__NODEGRAPHICS, null, msgs);
+				msgs = ((InternalEObject) nodegraphics).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.NODE__NODEGRAPHICS, null, msgs);
 			return basicSetNodegraphics((NodeGraphics) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -234,8 +236,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -252,8 +254,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -267,8 +269,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -282,8 +284,8 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -301,4 +303,4 @@ public abstract class NodeImpl extends PnObjectImpl implements Node {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //NodeImpl
+} // NodeImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/OffsetImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/OffsetImpl.java
@@ -63,13 +63,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Offset</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Offset</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl#getContainerAnnotationGraphics <em>Container Annotation Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.OffsetImpl#getContainerAnnotationGraphics
+ * <em>Container Annotation Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -77,8 +77,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class OffsetImpl extends CoordinateImpl implements Offset {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected OffsetImpl() {
@@ -86,8 +86,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -96,8 +96,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -108,8 +108,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics,
@@ -120,14 +120,15 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerAnnotationGraphics(AnnotationGraphics newContainerAnnotationGraphics) {
 		if (newContainerAnnotationGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.OFFSET__CONTAINER_ANNOTATION_GRAPHICS && newContainerAnnotationGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.OFFSET__CONTAINER_ANNOTATION_GRAPHICS
+						&& newContainerAnnotationGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerAnnotationGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -146,8 +147,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -162,8 +163,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -176,8 +177,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -191,8 +192,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -205,8 +206,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -220,8 +221,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -235,8 +236,8 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -253,10 +254,10 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -274,7 +275,7 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getX() != null) {
 			sb.append(" x");
@@ -293,7 +294,7 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -306,20 +307,20 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//2
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 2
+		// 0
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("x")) != null) {
 			try {
@@ -337,7 +338,7 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -346,10 +347,10 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -372,7 +373,7 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getX() != null) {
 			sb.append(" x");
@@ -391,7 +392,7 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -444,4 +445,4 @@ public class OffsetImpl extends CoordinateImpl implements Offset {
 		return retour;
 
 	}
-} //OffsetImpl
+} // OffsetImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/OffsetImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/OffsetImpl.java
@@ -38,7 +38,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PageImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PageImpl.java
@@ -78,16 +78,19 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Page</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Page</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getObjects <em>Objects</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getContainerPetriNet <em>Container Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getNodegraphics <em>Nodegraphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getObjects
+ * <em>Objects</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getContainerPetriNet
+ * <em>Container Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getNodegraphics
+ * <em>Nodegraphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PageImpl#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -95,9 +98,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class PageImpl extends PnObjectImpl implements Page {
 	/**
-	 * The cached value of the '{@link #getObjects() <em>Objects</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getObjects() <em>Objects</em>}' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getObjects()
 	 * @generated
 	 * @ordered
@@ -105,9 +108,9 @@ public class PageImpl extends PnObjectImpl implements Page {
 	protected EList<PnObject> objects;
 
 	/**
-	 * The cached value of the '{@link #getNodegraphics() <em>Nodegraphics</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getNodegraphics() <em>Nodegraphics</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getNodegraphics()
 	 * @generated
 	 * @ordered
@@ -115,9 +118,9 @@ public class PageImpl extends PnObjectImpl implements Page {
 	protected NodeGraphics nodegraphics;
 
 	/**
-	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDeclaration()
 	 * @generated
 	 * @ordered
@@ -125,8 +128,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	protected EList<Declaration> declaration;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PageImpl() {
@@ -134,8 +137,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -144,8 +147,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -158,8 +161,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -170,8 +173,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPetriNet(PetriNet newContainerPetriNet, NotificationChain msgs) {
@@ -181,14 +184,15 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPetriNet(PetriNet newContainerPetriNet) {
 		if (newContainerPetriNet != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.PAGE__CONTAINER_PETRI_NET && newContainerPetriNet != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.PAGE__CONTAINER_PETRI_NET
+						&& newContainerPetriNet != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPetriNet))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -206,8 +210,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -216,8 +220,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetNodegraphics(NodeGraphics newNodegraphics, NotificationChain msgs) {
@@ -235,8 +239,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -258,8 +262,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -273,8 +277,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -289,8 +293,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 			return basicSetContainerPetriNet((PetriNet) otherEnd, msgs);
 		case HlcorestructurePackage.PAGE__NODEGRAPHICS:
 			if (nodegraphics != null)
-				msgs = ((InternalEObject) nodegraphics).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.PAGE__NODEGRAPHICS, null, msgs);
+				msgs = ((InternalEObject) nodegraphics).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.PAGE__NODEGRAPHICS, null, msgs);
 			return basicSetNodegraphics((NodeGraphics) otherEnd, msgs);
 		case HlcorestructurePackage.PAGE__DECLARATION:
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getDeclaration()).basicAdd(otherEnd, msgs);
@@ -299,8 +303,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -319,8 +323,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -334,8 +338,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -354,8 +358,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -381,8 +385,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -405,8 +409,8 @@ public class PageImpl extends PnObjectImpl implements Page {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -429,10 +433,10 @@ public class PageImpl extends PnObjectImpl implements Page {
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 0
-		//sons 5
+		// id 1
+		// idref 0
+		// attributes 0
+		// sons 5
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -450,7 +454,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -463,7 +467,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -548,16 +552,16 @@ public class PageImpl extends PnObjectImpl implements Page {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//0
-		//5
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 0
+		// 5
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -565,11 +569,11 @@ public class PageImpl extends PnObjectImpl implements Page {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -583,7 +587,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerNamePnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -593,7 +597,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("page")) {
 				Page item;
@@ -603,7 +607,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("arc")) {
 				Arc item;
@@ -613,7 +617,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("place")) {
 				Place item;
@@ -623,7 +627,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("referenceTransition")) {
 				RefTransition item;
@@ -633,7 +637,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("transition")) {
 				Transition item;
@@ -643,7 +647,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("referencePlace")) {
 				RefPlace item;
@@ -653,7 +657,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				NodeGraphics item;
@@ -663,7 +667,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("declaration")) {
 				Declaration item;
@@ -673,7 +677,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 				item.setContainerDeclarationPage(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -684,10 +688,10 @@ public class PageImpl extends PnObjectImpl implements Page {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 0
-		//sons 5
+		// id 1
+		// idref 0
+		// attributes 0
+		// sons 5
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -710,7 +714,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -723,7 +727,7 @@ public class PageImpl extends PnObjectImpl implements Page {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -899,4 +903,4 @@ public class PageImpl extends PnObjectImpl implements Page {
 		return retour;
 
 	}
-} //PageImpl
+} // PageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PetriNetDocImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PetriNetDocImpl.java
@@ -64,14 +64,15 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Petri Net Doc</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Petri
+ * Net Doc</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl#getNets <em>Nets</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl#getXmlns <em>Xmlns</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl#getNets
+ * <em>Nets</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetDocImpl#getXmlns
+ * <em>Xmlns</em>}</li>
  * </ul>
  * </p>
  *
@@ -79,9 +80,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	/**
-	 * The cached value of the '{@link #getNets() <em>Nets</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getNets() <em>Nets</em>}' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getNets()
 	 * @generated
 	 * @ordered
@@ -89,9 +90,9 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	protected EList<PetriNet> nets;
 
 	/**
-	 * The default value of the '{@link #getXmlns() <em>Xmlns</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getXmlns() <em>Xmlns</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getXmlns()
 	 * @generated
 	 * @ordered
@@ -99,9 +100,9 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	protected static final String XMLNS_EDEFAULT = "http://www.pnml.org/version-2009/grammar/pnml";
 
 	/**
-	 * The cached value of the '{@link #getXmlns() <em>Xmlns</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getXmlns() <em>Xmlns</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getXmlns()
 	 * @generated
 	 * @ordered
@@ -109,8 +110,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	protected String xmlns = XMLNS_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PetriNetDocImpl() {
@@ -118,8 +119,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,8 +129,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -143,8 +144,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,8 +154,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -168,8 +169,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -182,8 +183,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -198,8 +199,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -215,8 +216,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -230,8 +231,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -246,8 +247,8 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -267,10 +268,10 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -288,7 +289,7 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getXmlns() != null) {
 			sb.append(" xmlns");
@@ -301,7 +302,7 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getNets() != null) {
 
@@ -336,22 +337,22 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//1
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 1
+		// 1
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -365,7 +366,7 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 				item.setContainerPetriNetDoc(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -376,10 +377,10 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -402,7 +403,7 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getXmlns() != null) {
 			sb.append(" xmlns");
@@ -415,7 +416,7 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getNets() != null) {
 
@@ -501,4 +502,4 @@ public class PetriNetDocImpl extends MinimalEObjectImpl implements PetriNetDoc {
 		return retour;
 
 	}
-} //PetriNetDocImpl
+} // PetriNetDocImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PetriNetImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PetriNetImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PetriNetImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PetriNetImpl.java
@@ -74,19 +74,25 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Petri Net</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Petri
+ * Net</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getId <em>Id</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getType <em>Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getPages <em>Pages</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getName <em>Name</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getToolspecifics <em>Toolspecifics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getContainerPetriNetDoc <em>Container Petri Net Doc</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getId
+ * <em>Id</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getType
+ * <em>Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getPages
+ * <em>Pages</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getName
+ * <em>Name</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getToolspecifics
+ * <em>Toolspecifics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getContainerPetriNetDoc
+ * <em>Container Petri Net Doc</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PetriNetImpl#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -94,9 +100,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	/**
-	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getId()
 	 * @generated
 	 * @ordered
@@ -104,9 +110,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected static final String ID_EDEFAULT = "";
 
 	/**
-	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getId()
 	 * @generated
 	 * @ordered
@@ -114,9 +120,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected String id = ID_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -124,9 +130,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected static final PNType TYPE_EDEFAULT = PNType.PTHLPN;
 
 	/**
-	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -134,9 +140,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected PNType type = TYPE_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getPages() <em>Pages</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPages() <em>Pages</em>}' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getPages()
 	 * @generated
 	 * @ordered
@@ -144,9 +150,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected EList<Page> pages;
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -154,9 +160,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected Name name;
 
 	/**
-	 * The cached value of the '{@link #getToolspecifics() <em>Toolspecifics</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getToolspecifics() <em>Toolspecifics</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getToolspecifics()
 	 * @generated
 	 * @ordered
@@ -164,9 +170,9 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected EList<ToolInfo> toolspecifics;
 
 	/**
-	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDeclaration()
 	 * @generated
 	 * @ordered
@@ -174,8 +180,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	protected EList<Declaration> declaration;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PetriNetImpl() {
@@ -183,8 +189,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -193,8 +199,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -203,8 +209,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -216,8 +222,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -226,8 +232,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -235,12 +241,13 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 		PNType oldType = type;
 		type = newType == null ? TYPE_EDEFAULT : newType;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.PETRI_NET__TYPE, oldType, type));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.PETRI_NET__TYPE, oldType,
+					type));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -253,8 +260,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -263,8 +270,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetName(Name newName, NotificationChain msgs) {
@@ -282,8 +289,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -305,8 +312,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -320,8 +327,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -332,8 +339,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPetriNetDoc(PetriNetDoc newContainerPetriNetDoc, NotificationChain msgs) {
@@ -343,14 +350,15 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPetriNetDoc(PetriNetDoc newContainerPetriNetDoc) {
 		if (newContainerPetriNetDoc != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.PETRI_NET__CONTAINER_PETRI_NET_DOC && newContainerPetriNetDoc != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.PETRI_NET__CONTAINER_PETRI_NET_DOC
+						&& newContainerPetriNetDoc != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPetriNetDoc))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -369,8 +377,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -384,8 +392,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -396,8 +404,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getPages()).basicAdd(otherEnd, msgs);
 		case HlcorestructurePackage.PETRI_NET__NAME:
 			if (name != null)
-				msgs = ((InternalEObject) name).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.PETRI_NET__NAME, null, msgs);
+				msgs = ((InternalEObject) name).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.PETRI_NET__NAME, null, msgs);
 			return basicSetName((Name) otherEnd, msgs);
 		case HlcorestructurePackage.PETRI_NET__TOOLSPECIFICS:
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getToolspecifics()).basicAdd(otherEnd, msgs);
@@ -412,8 +420,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -434,8 +442,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -449,8 +457,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -475,8 +483,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -512,8 +520,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -545,8 +553,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -571,8 +579,8 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -594,10 +602,10 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 4
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -615,7 +623,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -635,7 +643,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPages() != null) {
 
@@ -708,16 +716,16 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//1
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 1
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -725,15 +733,15 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("type")) != null) {
 			this.setType(PNType.get(locRoot.getAttributeValue(new QName("type"))));
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -747,7 +755,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 				item.setContainerPetriNet(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("name")) {
 				Name item;
@@ -757,7 +765,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 				item.setContainerNamePetriNet(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -767,7 +775,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 				item.setContainerPetriNet(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("declaration")) {
 				Declaration item;
@@ -777,7 +785,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 				item.setContainerDeclarationPetriNet(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -788,10 +796,10 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 4
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -814,7 +822,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -834,7 +842,7 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPages() != null) {
 
@@ -994,4 +1002,4 @@ public class PetriNetImpl extends MinimalEObjectImpl implements PetriNet {
 		return retour;
 
 	}
-} //PetriNetImpl
+} // PetriNetImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PlaceImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PlaceImpl.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PlaceImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PlaceImpl.java
@@ -67,14 +67,15 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Type;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Place</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Place</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl#getType <em>Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl#getHlinitialMarking <em>Hlinitial Marking</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl#getType
+ * <em>Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceImpl#getHlinitialMarking
+ * <em>Hlinitial Marking</em>}</li>
  * </ul>
  * </p>
  *
@@ -82,9 +83,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class PlaceImpl extends PlaceNodeImpl implements Place {
 	/**
-	 * The cached value of the '{@link #getType() <em>Type</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getType() <em>Type</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -92,9 +93,10 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	protected Type type;
 
 	/**
-	 * The cached value of the '{@link #getHlinitialMarking() <em>Hlinitial Marking</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getHlinitialMarking() <em>Hlinitial
+	 * Marking</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see #getHlinitialMarking()
 	 * @generated
 	 * @ordered
@@ -102,8 +104,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	protected HLMarking hlinitialMarking;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PlaceImpl() {
@@ -111,8 +113,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -121,8 +123,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -131,8 +133,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetType(Type newType, NotificationChain msgs) {
@@ -150,8 +152,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -168,12 +170,13 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.PLACE__TYPE, newType, newType));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.PLACE__TYPE, newType,
+					newType));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -182,8 +185,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetHlinitialMarking(HLMarking newHlinitialMarking, NotificationChain msgs) {
@@ -201,8 +204,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -224,8 +227,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,21 +236,21 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		switch (featureID) {
 		case HlcorestructurePackage.PLACE__TYPE:
 			if (type != null)
-				msgs = ((InternalEObject) type).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.PLACE__TYPE, null, msgs);
+				msgs = ((InternalEObject) type).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.PLACE__TYPE, null, msgs);
 			return basicSetType((Type) otherEnd, msgs);
 		case HlcorestructurePackage.PLACE__HLINITIAL_MARKING:
 			if (hlinitialMarking != null)
-				msgs = ((InternalEObject) hlinitialMarking).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.PLACE__HLINITIAL_MARKING, null, msgs);
+				msgs = ((InternalEObject) hlinitialMarking).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.PLACE__HLINITIAL_MARKING, null, msgs);
 			return basicSetHlinitialMarking((HLMarking) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -262,8 +265,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -278,8 +281,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -296,8 +299,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -314,8 +317,8 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -329,24 +332,25 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingPlaces) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingPlaces) seems not to have any ToPNML associated
+	// tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 0
-		//sons 5
+		// id 1
+		// idref 0
+		// attributes 0
+		// sons 5
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -364,7 +368,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -377,7 +381,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -460,16 +464,16 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//0
-		//5
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 0
+		// 5
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -477,11 +481,11 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -495,7 +499,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 				item.setContainerNamePnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -505,7 +509,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 				item.setContainerPnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				NodeGraphics item;
@@ -515,7 +519,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 				item.setContainerNode(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("type")) {
 				Type item;
@@ -525,7 +529,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 				item.setContainerPlace(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("hlinitialMarking")) {
 				HLMarking item;
@@ -535,30 +539,31 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 				item.setContainerPlace(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingPlaces) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingPlaces) seems not to have any ToPNML associated
+	// tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 0
-		//sons 5
+		// id 1
+		// idref 0
+		// attributes 0
+		// sons 5
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -581,7 +586,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -594,7 +599,7 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -744,4 +749,4 @@ public class PlaceImpl extends PlaceNodeImpl implements Place {
 		return retour;
 
 	}
-} //PlaceImpl
+} // PlaceImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PlaceNodeImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PlaceNodeImpl.java
@@ -46,13 +46,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Place Node</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Place
+ * Node</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl#getReferencingPlaces <em>Referencing Places</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PlaceNodeImpl#getReferencingPlaces
+ * <em>Referencing Places</em>}</li>
  * </ul>
  * </p>
  *
@@ -60,9 +60,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace;
  */
 public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	/**
-	 * The cached value of the '{@link #getReferencingPlaces() <em>Referencing Places</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getReferencingPlaces() <em>Referencing
+	 * Places</em>}' reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getReferencingPlaces()
 	 * @generated
 	 * @ordered
@@ -70,8 +70,8 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	protected EList<RefPlace> referencingPlaces;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PlaceNodeImpl() {
@@ -79,8 +79,8 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,8 +89,8 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -103,8 +103,8 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -112,15 +112,15 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	public NotificationChain eInverseAdd(InternalEObject otherEnd, int featureID, NotificationChain msgs) {
 		switch (featureID) {
 		case HlcorestructurePackage.PLACE_NODE__REFERENCING_PLACES:
-			return ((InternalEList<InternalEObject>) (InternalEList<?>) getReferencingPlaces())
-					.basicAdd(otherEnd, msgs);
+			return ((InternalEList<InternalEObject>) (InternalEList<?>) getReferencingPlaces()).basicAdd(otherEnd,
+					msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -133,8 +133,8 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -147,8 +147,8 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -162,4 +162,4 @@ public abstract class PlaceNodeImpl extends NodeImpl implements PlaceNode {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //PlaceNodeImpl
+} // PlaceNodeImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PnObjectImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PnObjectImpl.java
@@ -53,16 +53,19 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Pn Object</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Pn
+ * Object</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getId <em>Id</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getName <em>Name</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getToolspecifics <em>Toolspecifics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getContainerPage <em>Container Page</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getId
+ * <em>Id</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getName
+ * <em>Name</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getToolspecifics
+ * <em>Toolspecifics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PnObjectImpl#getContainerPage
+ * <em>Container Page</em>}</li>
  * </ul>
  * </p>
  *
@@ -70,9 +73,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
  */
 public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObject {
 	/**
-	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getId()
 	 * @generated
 	 * @ordered
@@ -80,9 +83,9 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	protected static final String ID_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getId()
 	 * @generated
 	 * @ordered
@@ -90,9 +93,9 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	protected String id = ID_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -100,9 +103,9 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	protected Name name;
 
 	/**
-	 * The cached value of the '{@link #getToolspecifics() <em>Toolspecifics</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getToolspecifics() <em>Toolspecifics</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getToolspecifics()
 	 * @generated
 	 * @ordered
@@ -110,8 +113,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	protected EList<ToolInfo> toolspecifics;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PnObjectImpl() {
@@ -119,8 +122,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +132,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -139,8 +142,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -152,8 +155,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -162,8 +165,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetName(Name newName, NotificationChain msgs) {
@@ -181,8 +184,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -204,8 +207,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -219,8 +222,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -231,8 +234,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPage(Page newContainerPage, NotificationChain msgs) {
@@ -242,14 +245,15 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPage(Page newContainerPage) {
 		if (newContainerPage != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.PN_OBJECT__CONTAINER_PAGE && newContainerPage != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.PN_OBJECT__CONTAINER_PAGE
+						&& newContainerPage != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPage))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -267,8 +271,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -277,8 +281,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 		switch (featureID) {
 		case HlcorestructurePackage.PN_OBJECT__NAME:
 			if (name != null)
-				msgs = ((InternalEObject) name).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.PN_OBJECT__NAME, null, msgs);
+				msgs = ((InternalEObject) name).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.PN_OBJECT__NAME, null, msgs);
 			return basicSetName((Name) otherEnd, msgs);
 		case HlcorestructurePackage.PN_OBJECT__TOOLSPECIFICS:
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getToolspecifics()).basicAdd(otherEnd, msgs);
@@ -291,8 +295,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -309,8 +313,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -323,8 +327,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -343,8 +347,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -369,8 +373,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -393,8 +397,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -413,8 +417,8 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -431,4 +435,4 @@ public abstract class PnObjectImpl extends MinimalEObjectImpl implements PnObjec
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //PnObjectImpl
+} // PnObjectImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PositionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PositionImpl.java
@@ -64,14 +64,15 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Position;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Position</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Position</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl#getContainerArcGraphics <em>Container Arc Graphics</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl#getContainerPNodeGraphics <em>Container PNode Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl#getContainerArcGraphics
+ * <em>Container Arc Graphics</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.PositionImpl#getContainerPNodeGraphics
+ * <em>Container PNode Graphics</em>}</li>
  * </ul>
  * </p>
  *
@@ -79,8 +80,8 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class PositionImpl extends CoordinateImpl implements Position {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PositionImpl() {
@@ -88,8 +89,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -98,8 +99,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -110,8 +111,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerArcGraphics(ArcGraphics newContainerArcGraphics, NotificationChain msgs) {
@@ -121,14 +122,15 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerArcGraphics(ArcGraphics newContainerArcGraphics) {
 		if (newContainerArcGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.POSITION__CONTAINER_ARC_GRAPHICS && newContainerArcGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.POSITION__CONTAINER_ARC_GRAPHICS
+						&& newContainerArcGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerArcGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -147,8 +149,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -159,8 +161,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPNodeGraphics(NodeGraphics newContainerPNodeGraphics,
@@ -171,14 +173,15 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPNodeGraphics(NodeGraphics newContainerPNodeGraphics) {
 		if (newContainerPNodeGraphics != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.POSITION__CONTAINER_PNODE_GRAPHICS && newContainerPNodeGraphics != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.POSITION__CONTAINER_PNODE_GRAPHICS
+						&& newContainerPNodeGraphics != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPNodeGraphics))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -197,8 +200,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -217,8 +220,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,8 +236,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -251,8 +254,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -267,8 +270,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -285,8 +288,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -303,8 +306,8 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -323,10 +326,10 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -344,7 +347,7 @@ public class PositionImpl extends CoordinateImpl implements Position {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getX() != null) {
 			sb.append(" x");
@@ -363,7 +366,7 @@ public class PositionImpl extends CoordinateImpl implements Position {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -376,20 +379,20 @@ public class PositionImpl extends CoordinateImpl implements Position {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//2
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 2
+		// 0
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("x")) != null) {
 			try {
@@ -407,7 +410,7 @@ public class PositionImpl extends CoordinateImpl implements Position {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -416,10 +419,10 @@ public class PositionImpl extends CoordinateImpl implements Position {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -442,7 +445,7 @@ public class PositionImpl extends CoordinateImpl implements Position {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getX() != null) {
 			sb.append(" x");
@@ -461,7 +464,7 @@ public class PositionImpl extends CoordinateImpl implements Position {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -514,4 +517,4 @@ public class PositionImpl extends CoordinateImpl implements Position {
 		return retour;
 
 	}
-} //PositionImpl
+} // PositionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PositionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/PositionImpl.java
@@ -38,7 +38,6 @@ import java.nio.charset.Charset;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefPlaceImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefPlaceImpl.java
@@ -67,13 +67,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Ref Place</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Ref
+ * Place</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl#getRef <em>Ref</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefPlaceImpl#getRef
+ * <em>Ref</em>}</li>
  * </ul>
  * </p>
  *
@@ -81,9 +81,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	/**
-	 * The cached value of the '{@link #getRef() <em>Ref</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getRef() <em>Ref</em>}' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRef()
 	 * @generated
 	 * @ordered
@@ -91,8 +91,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	protected PlaceNode ref;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected RefPlaceImpl() {
@@ -100,8 +100,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -110,8 +110,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +129,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public PlaceNode basicGetRef() {
@@ -138,8 +138,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetRef(PlaceNode newRef, NotificationChain msgs) {
@@ -157,8 +157,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -175,12 +175,13 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.REF_PLACE__REF, newRef, newRef));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.REF_PLACE__REF, newRef,
+					newRef));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -196,8 +197,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -210,8 +211,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -226,8 +227,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -241,8 +242,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -256,8 +257,8 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -269,24 +270,25 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingPlaces) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingPlaces) seems not to have any ToPNML associated
+	// tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 1
-		//attributes 0
-		//sons 3
+		// id 1
+		// idref 1
+		// attributes 0
+		// sons 3
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -304,7 +306,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -324,7 +326,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -383,16 +385,16 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//1
-		//0
-		//3
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 1
+		// 0
+		// 3
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -400,7 +402,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -410,9 +412,9 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -426,7 +428,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 				item.setContainerNamePnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -436,7 +438,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 				item.setContainerPnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				NodeGraphics item;
@@ -446,7 +448,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 				item.setContainerNode(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -458,24 +460,25 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingPlaces) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingPlaces) seems not to have any ToPNML associated
+	// tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 1
-		//attributes 0
-		//sons 3
+		// id 1
+		// idref 1
+		// attributes 0
+		// sons 3
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -498,7 +501,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -518,7 +521,7 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -636,4 +639,4 @@ public class RefPlaceImpl extends PlaceNodeImpl implements RefPlace {
 		return retour;
 
 	}
-} //RefPlaceImpl
+} // RefPlaceImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefPlaceImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefPlaceImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefTransitionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefTransitionImpl.java
@@ -67,13 +67,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Ref Transition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Ref
+ * Transition</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl#getRef <em>Ref</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.RefTransitionImpl#getRef
+ * <em>Ref</em>}</li>
  * </ul>
  * </p>
  *
@@ -81,9 +81,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class RefTransitionImpl extends TransitionNodeImpl implements RefTransition {
 	/**
-	 * The cached value of the '{@link #getRef() <em>Ref</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getRef() <em>Ref</em>}' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRef()
 	 * @generated
 	 * @ordered
@@ -91,8 +91,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	protected TransitionNode ref;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected RefTransitionImpl() {
@@ -100,8 +100,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -110,8 +110,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +129,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public TransitionNode basicGetRef() {
@@ -138,8 +138,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetRef(TransitionNode newRef, NotificationChain msgs) {
@@ -157,8 +157,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -180,8 +180,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -197,8 +197,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -211,8 +211,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -227,8 +227,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -242,8 +242,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -257,8 +257,8 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -270,24 +270,25 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingTransitions) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingTransitions) seems not to have any ToPNML
+	// associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 1
-		//attributes 0
-		//sons 3
+		// id 1
+		// idref 1
+		// attributes 0
+		// sons 3
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -305,7 +306,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -325,7 +326,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -384,16 +385,16 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//1
-		//0
-		//3
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 1
+		// 0
+		// 3
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -401,7 +402,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -411,9 +412,9 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -427,7 +428,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 				item.setContainerNamePnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -437,7 +438,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 				item.setContainerPnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				NodeGraphics item;
@@ -447,7 +448,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 				item.setContainerNode(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -459,24 +460,25 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingTransitions) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingTransitions) seems not to have any ToPNML
+	// associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 1
-		//attributes 0
-		//sons 3
+		// id 1
+		// idref 1
+		// attributes 0
+		// sons 3
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -499,7 +501,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -519,7 +521,7 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -637,4 +639,4 @@ public class RefTransitionImpl extends TransitionNodeImpl implements RefTransiti
 		return retour;
 
 	}
-} //RefTransitionImpl
+} // RefTransitionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefTransitionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/RefTransitionImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ToolInfoImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ToolInfoImpl.java
@@ -69,20 +69,27 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Tool Info</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Tool
+ * Info</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getTool <em>Tool</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getVersion <em>Version</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getFormattedXMLBuffer <em>Formatted XML Buffer</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getToolInfoGrammarURI <em>Tool Info Grammar URI</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getContainerPetriNet <em>Container Petri Net</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getContainerPnObject <em>Container Pn Object</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getContainerLabel <em>Container Label</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getToolInfoModel <em>Tool Info Model</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getTool
+ * <em>Tool</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getVersion
+ * <em>Version</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getFormattedXMLBuffer
+ * <em>Formatted XML Buffer</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getToolInfoGrammarURI
+ * <em>Tool Info Grammar URI</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getContainerPetriNet
+ * <em>Container Petri Net</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getContainerPnObject
+ * <em>Container Pn Object</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getContainerLabel
+ * <em>Container Label</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.ToolInfoImpl#getToolInfoModel
+ * <em>Tool Info Model</em>}</li>
  * </ul>
  * </p>
  *
@@ -90,9 +97,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	/**
-	 * The default value of the '{@link #getTool() <em>Tool</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getTool() <em>Tool</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getTool()
 	 * @generated
 	 * @ordered
@@ -100,9 +107,9 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected static final String TOOL_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getTool() <em>Tool</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getTool() <em>Tool</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getTool()
 	 * @generated
 	 * @ordered
@@ -111,8 +118,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 
 	/**
 	 * The default value of the '{@link #getVersion() <em>Version</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getVersion()
 	 * @generated
 	 * @ordered
@@ -121,8 +128,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 
 	/**
 	 * The cached value of the '{@link #getVersion() <em>Version</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getVersion()
 	 * @generated
 	 * @ordered
@@ -130,9 +137,9 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected String version = VERSION_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getFormattedXMLBuffer() <em>Formatted XML Buffer</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getFormattedXMLBuffer() <em>Formatted XML
+	 * Buffer</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFormattedXMLBuffer()
 	 * @generated
 	 * @ordered
@@ -140,9 +147,9 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected static final StringBuffer FORMATTED_XML_BUFFER_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getFormattedXMLBuffer() <em>Formatted XML Buffer</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getFormattedXMLBuffer() <em>Formatted XML
+	 * Buffer</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getFormattedXMLBuffer()
 	 * @generated
 	 * @ordered
@@ -150,9 +157,9 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected StringBuffer formattedXMLBuffer = FORMATTED_XML_BUFFER_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getToolInfoGrammarURI() <em>Tool Info Grammar URI</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getToolInfoGrammarURI() <em>Tool Info
+	 * Grammar URI</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getToolInfoGrammarURI()
 	 * @generated
 	 * @ordered
@@ -160,9 +167,9 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected static final URI TOOL_INFO_GRAMMAR_URI_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getToolInfoGrammarURI() <em>Tool Info Grammar URI</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getToolInfoGrammarURI() <em>Tool Info
+	 * Grammar URI</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getToolInfoGrammarURI()
 	 * @generated
 	 * @ordered
@@ -170,9 +177,10 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected URI toolInfoGrammarURI = TOOL_INFO_GRAMMAR_URI_EDEFAULT;
 
 	/**
-	 * The cached value of the '{@link #getToolInfoModel() <em>Tool Info Model</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getToolInfoModel() <em>Tool Info
+	 * Model</em>}' containment reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see #getToolInfoModel()
 	 * @generated
 	 * @ordered
@@ -180,8 +188,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	protected AnyObject toolInfoModel;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ToolInfoImpl() {
@@ -189,8 +197,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -199,8 +207,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -209,8 +217,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -218,12 +226,13 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		String oldTool = tool;
 		tool = newTool;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.TOOL_INFO__TOOL, oldTool, tool));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.TOOL_INFO__TOOL, oldTool,
+					tool));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -232,8 +241,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -241,13 +250,13 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		String oldVersion = version;
 		version = newVersion;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.TOOL_INFO__VERSION,
-					oldVersion, version));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.TOOL_INFO__VERSION, oldVersion,
+					version));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -256,8 +265,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -270,8 +279,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -280,8 +289,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -290,12 +299,13 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		toolInfoGrammarURI = newToolInfoGrammarURI;
 		if (eNotificationRequired())
 			eNotify(new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.TOOL_INFO__TOOL_INFO_GRAMMAR_URI, oldToolInfoGrammarURI, toolInfoGrammarURI));
+					HlcorestructurePackage.TOOL_INFO__TOOL_INFO_GRAMMAR_URI, oldToolInfoGrammarURI,
+					toolInfoGrammarURI));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -306,8 +316,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPetriNet(PetriNet newContainerPetriNet, NotificationChain msgs) {
@@ -317,14 +327,15 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPetriNet(PetriNet newContainerPetriNet) {
 		if (newContainerPetriNet != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.TOOL_INFO__CONTAINER_PETRI_NET && newContainerPetriNet != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.TOOL_INFO__CONTAINER_PETRI_NET
+						&& newContainerPetriNet != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPetriNet))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -337,13 +348,13 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.TOOL_INFO__CONTAINER_PETRI_NET, newContainerPetriNet, newContainerPetriNet));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.TOOL_INFO__CONTAINER_PETRI_NET,
+					newContainerPetriNet, newContainerPetriNet));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -354,8 +365,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPnObject(PnObject newContainerPnObject, NotificationChain msgs) {
@@ -365,14 +376,15 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPnObject(PnObject newContainerPnObject) {
 		if (newContainerPnObject != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.TOOL_INFO__CONTAINER_PN_OBJECT && newContainerPnObject != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.TOOL_INFO__CONTAINER_PN_OBJECT
+						&& newContainerPnObject != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPnObject))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -385,13 +397,13 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET,
-					HlcorestructurePackage.TOOL_INFO__CONTAINER_PN_OBJECT, newContainerPnObject, newContainerPnObject));
+			eNotify(new ENotificationImpl(this, Notification.SET, HlcorestructurePackage.TOOL_INFO__CONTAINER_PN_OBJECT,
+					newContainerPnObject, newContainerPnObject));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -402,8 +414,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerLabel(Label newContainerLabel, NotificationChain msgs) {
@@ -413,14 +425,15 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerLabel(Label newContainerLabel) {
 		if (newContainerLabel != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.TOOL_INFO__CONTAINER_LABEL && newContainerLabel != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.TOOL_INFO__CONTAINER_LABEL
+						&& newContainerLabel != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerLabel))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -438,8 +451,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -448,8 +461,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetToolInfoModel(AnyObject newToolInfoModel, NotificationChain msgs) {
@@ -467,8 +480,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -490,8 +503,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -511,16 +524,16 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 			return basicSetContainerLabel((Label) otherEnd, msgs);
 		case HlcorestructurePackage.TOOL_INFO__TOOL_INFO_MODEL:
 			if (toolInfoModel != null)
-				msgs = ((InternalEObject) toolInfoModel).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.TOOL_INFO__TOOL_INFO_MODEL, null, msgs);
+				msgs = ((InternalEObject) toolInfoModel).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.TOOL_INFO__TOOL_INFO_MODEL, null, msgs);
 			return basicSetToolInfoModel((AnyObject) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -539,8 +552,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -560,8 +573,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -588,8 +601,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -624,8 +637,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -660,8 +673,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -672,8 +685,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		case HlcorestructurePackage.TOOL_INFO__VERSION:
 			return VERSION_EDEFAULT == null ? version != null : !VERSION_EDEFAULT.equals(version);
 		case HlcorestructurePackage.TOOL_INFO__FORMATTED_XML_BUFFER:
-			return FORMATTED_XML_BUFFER_EDEFAULT == null ? formattedXMLBuffer != null : !FORMATTED_XML_BUFFER_EDEFAULT
-					.equals(formattedXMLBuffer);
+			return FORMATTED_XML_BUFFER_EDEFAULT == null ? formattedXMLBuffer != null
+					: !FORMATTED_XML_BUFFER_EDEFAULT.equals(formattedXMLBuffer);
 		case HlcorestructurePackage.TOOL_INFO__TOOL_INFO_GRAMMAR_URI:
 			return TOOL_INFO_GRAMMAR_URI_EDEFAULT == null ? toolInfoGrammarURI != null
 					: !TOOL_INFO_GRAMMAR_URI_EDEFAULT.equals(toolInfoGrammarURI);
@@ -690,8 +703,8 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -712,21 +725,23 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		return result.toString();
 	}
 
-	//TODO this element (toolInfoGrammarURI) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (toolInfoGrammarURI) seems not to have any ToPNML
+	// associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (toolInfoModel) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (toolInfoModel) seems not to have any ToPNML associated
+	// tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -744,7 +759,7 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getTool() != null) {
 			sb.append(" tool");
@@ -764,7 +779,7 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getFormattedXMLBuffer() != null) {
 
@@ -794,20 +809,20 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//2
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 2
+		// 1
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("tool")) != null) {
 			try {
@@ -825,14 +840,15 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
 			OMElement type = (OMElement) iterator.next();
 
-			//Any Elements
-			//all sub element of <toolspecific> will be serialized in a java.lang.StringBuffer
+			// Any Elements
+			// all sub element of <toolspecific> will be serialized in a
+			// java.lang.StringBuffer
 			StringBuffer sb = new StringBuffer();
 			sb.append(locRoot.toString());
 			this.setFormattedXMLBuffer(new java.lang.StringBuffer(sb.toString()));
@@ -841,21 +857,23 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 
 	}
 
-	//TODO this element (toolInfoGrammarURI) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (toolInfoGrammarURI) seems not to have any ToPNML
+	// associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (toolInfoModel) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (toolInfoModel) seems not to have any ToPNML associated
+	// tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 2
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 2
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -878,7 +896,7 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getTool() != null) {
 			sb.append(" tool");
@@ -898,7 +916,7 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getFormattedXMLBuffer() != null) {
 
@@ -967,4 +985,4 @@ public class ToolInfoImpl extends MinimalEObjectImpl implements ToolInfo {
 		return retour;
 
 	}
-} //ToolInfoImpl
+} // ToolInfoImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ToolInfoImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/ToolInfoImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TransitionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TransitionImpl.java
@@ -66,13 +66,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Transition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Transition</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl#getCondition <em>Condition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionImpl#getCondition
+ * <em>Condition</em>}</li>
  * </ul>
  * </p>
  *
@@ -80,9 +80,9 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.util.HlcorestructureValidator;
  */
 public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	/**
-	 * The cached value of the '{@link #getCondition() <em>Condition</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getCondition() <em>Condition</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getCondition()
 	 * @generated
 	 * @ordered
@@ -90,8 +90,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	protected Condition condition;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TransitionImpl() {
@@ -99,8 +99,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -109,8 +109,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,8 +119,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetCondition(Condition newCondition, NotificationChain msgs) {
@@ -138,8 +138,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,8 +161,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -170,16 +170,16 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		switch (featureID) {
 		case HlcorestructurePackage.TRANSITION__CONDITION:
 			if (condition != null)
-				msgs = ((InternalEObject) condition).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.TRANSITION__CONDITION, null, msgs);
+				msgs = ((InternalEObject) condition).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.TRANSITION__CONDITION, null, msgs);
 			return basicSetCondition((Condition) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -192,8 +192,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -206,8 +206,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -221,8 +221,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -236,8 +236,8 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -249,24 +249,25 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingTransitions) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingTransitions) seems not to have any ToPNML
+	// associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 1
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -284,7 +285,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -297,7 +298,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -368,16 +369,16 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -385,11 +386,11 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -403,7 +404,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 				item.setContainerNamePnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("toolspecific")) {
 				ToolInfo item;
@@ -413,7 +414,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 				item.setContainerPnObject(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				NodeGraphics item;
@@ -423,7 +424,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 				item.setContainerNode(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("condition")) {
 				Condition item;
@@ -433,30 +434,31 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 				item.setContainerTransition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
 	}
 
-	//TODO this element (InArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (InArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (OutArcs) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (OutArcs) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (referencingTransitions) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (referencingTransitions) seems not to have any ToPNML
+	// associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 1
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -479,7 +481,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -492,7 +494,7 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getName() != null) {
 
@@ -626,4 +628,4 @@ public class TransitionImpl extends TransitionNodeImpl implements Transition {
 		return retour;
 
 	}
-} //TransitionImpl
+} // TransitionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TransitionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TransitionImpl.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TransitionNodeImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TransitionNodeImpl.java
@@ -46,13 +46,13 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Transition Node</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Transition Node</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl#getReferencingTransitions <em>Referencing Transitions</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TransitionNodeImpl#getReferencingTransitions
+ * <em>Referencing Transitions</em>}</li>
  * </ul>
  * </p>
  *
@@ -60,9 +60,10 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
  */
 public abstract class TransitionNodeImpl extends NodeImpl implements TransitionNode {
 	/**
-	 * The cached value of the '{@link #getReferencingTransitions() <em>Referencing Transitions</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getReferencingTransitions() <em>Referencing
+	 * Transitions</em>}' reference list. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see #getReferencingTransitions()
 	 * @generated
 	 * @ordered
@@ -70,8 +71,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	protected EList<RefTransition> referencingTransitions;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TransitionNodeImpl() {
@@ -79,8 +80,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,8 +90,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -104,8 +105,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -120,8 +121,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -134,8 +135,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +149,8 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,4 +164,4 @@ public abstract class TransitionNodeImpl extends NodeImpl implements TransitionN
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //TransitionNodeImpl
+} // TransitionNodeImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TypeImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/impl/TypeImpl.java
@@ -69,14 +69,15 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Type</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Type</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl#getStructure <em>Structure</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl#getContainerPlace <em>Container Place</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl#getStructure
+ * <em>Structure</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.impl.TypeImpl#getContainerPlace
+ * <em>Container Place</em>}</li>
  * </ul>
  * </p>
  *
@@ -84,9 +85,9 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
  */
 public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	/**
-	 * The cached value of the '{@link #getStructure() <em>Structure</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getStructure() <em>Structure</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getStructure()
 	 * @generated
 	 * @ordered
@@ -94,8 +95,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	protected Sort structure;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TypeImpl() {
@@ -103,8 +104,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -113,8 +114,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -123,8 +124,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetStructure(Sort newStructure, NotificationChain msgs) {
@@ -142,8 +143,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -151,11 +152,11 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 		if (newStructure != structure) {
 			NotificationChain msgs = null;
 			if (structure != null)
-				msgs = ((InternalEObject) structure).eInverseRemove(this, TermsPackage.SORT__CONTAINER_TYPE,
-						Sort.class, msgs);
+				msgs = ((InternalEObject) structure).eInverseRemove(this, TermsPackage.SORT__CONTAINER_TYPE, Sort.class,
+						msgs);
 			if (newStructure != null)
-				msgs = ((InternalEObject) newStructure).eInverseAdd(this, TermsPackage.SORT__CONTAINER_TYPE,
-						Sort.class, msgs);
+				msgs = ((InternalEObject) newStructure).eInverseAdd(this, TermsPackage.SORT__CONTAINER_TYPE, Sort.class,
+						msgs);
 			msgs = basicSetStructure(newStructure, msgs);
 			if (msgs != null)
 				msgs.dispatch();
@@ -165,8 +166,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -177,8 +178,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPlace(Place newContainerPlace, NotificationChain msgs) {
@@ -188,14 +189,15 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPlace(Place newContainerPlace) {
 		if (newContainerPlace != eInternalContainer()
-				|| (eContainerFeatureID() != HlcorestructurePackage.TYPE__CONTAINER_PLACE && newContainerPlace != null)) {
+				|| (eContainerFeatureID() != HlcorestructurePackage.TYPE__CONTAINER_PLACE
+						&& newContainerPlace != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPlace))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -213,8 +215,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -222,8 +224,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 		switch (featureID) {
 		case HlcorestructurePackage.TYPE__STRUCTURE:
 			if (structure != null)
-				msgs = ((InternalEObject) structure).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- HlcorestructurePackage.TYPE__STRUCTURE, null, msgs);
+				msgs = ((InternalEObject) structure).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - HlcorestructurePackage.TYPE__STRUCTURE, null, msgs);
 			return basicSetStructure((Sort) otherEnd, msgs);
 		case HlcorestructurePackage.TYPE__CONTAINER_PLACE:
 			if (eInternalContainer() != null)
@@ -234,8 +236,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -250,8 +252,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -264,8 +266,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -280,8 +282,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -298,8 +300,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -316,8 +318,8 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -336,10 +338,10 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -357,13 +359,13 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -446,22 +448,22 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//4
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 4
 		@SuppressWarnings("unused")
 		HlcorestructureFactory fact = HlcorestructureFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -475,7 +477,7 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 				item.setContainerLabel(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("graphics")) {
 				AnnotationGraphics item;
@@ -485,7 +487,7 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 				item.setContainerAnnotation(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("text")) {
 				this.setText(new java.lang.String(type.getText()));
@@ -546,7 +548,7 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -557,10 +559,10 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 4
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 4
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -583,13 +585,13 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getToolspecifics() != null) {
 
@@ -731,4 +733,4 @@ public class TypeImpl extends HLCoreAnnotationImpl implements Type {
 		return retour;
 
 	}
-} //TypeImpl
+} // TypeImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/tools/Tools.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/tools/Tools.java
@@ -39,99 +39,95 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionHLAPI;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.hlapi.TransitionNodeHLAPI;
 
 public class Tools {
-	 /**
-     * Test if a refplace is member of a circular cycle.
-     * @param rp the ref place to test
-     * @return true if there is no circular cycle, false either
-     */
-    public static boolean circularElement(RefPlaceHLAPI rp) {
+	/**
+	 * Test if a refplace is member of a circular cycle.
+	 * 
+	 * @param rp the ref place to test
+	 * @return true if there is no circular cycle, false either
+	 */
+	public static boolean circularElement(RefPlaceHLAPI rp) {
 
-        PlaceNodeHLAPI test = rp.getRefHLAPI();
+		PlaceNodeHLAPI test = rp.getRefHLAPI();
 
-        while (test != null) {
-            if (test.getClass().equals(PlaceHLAPI.class))
-                return true;
-            if (((RefPlaceHLAPI)test).equals(rp))
-                return false;
-            test = ((RefPlaceHLAPI) test).getRefHLAPI();
-        }
-        return false;
-    }
+		while (test != null) {
+			if (test.getClass().equals(PlaceHLAPI.class))
+				return true;
+			if (((RefPlaceHLAPI) test).equals(rp))
+				return false;
+			test = ((RefPlaceHLAPI) test).getRefHLAPI();
+		}
+		return false;
+	}
 
-    /**
-     * Test if a refplace is member of a circular cycle.
-     * @param rt the ref place to test
-     * @return true if there is no circular cycle, false either
-     */
-    public static boolean circularElement(RefTransitionHLAPI rt) {
+	/**
+	 * Test if a refplace is member of a circular cycle.
+	 * 
+	 * @param rt the ref place to test
+	 * @return true if there is no circular cycle, false either
+	 */
+	public static boolean circularElement(RefTransitionHLAPI rt) {
 
-        TransitionNodeHLAPI test = rt.getRefHLAPI();
+		TransitionNodeHLAPI test = rt.getRefHLAPI();
 
-        while (test != null) {
-            if (test.getClass().equals(TransitionHLAPI.class))
-                return true;
-            if (((RefTransitionHLAPI)test).equals(rt))
-                return false;
-            test = ((RefTransitionHLAPI) test).getRefHLAPI();
-        }
-        return false;
-    }
+		while (test != null) {
+			if (test.getClass().equals(TransitionHLAPI.class))
+				return true;
+			if (((RefTransitionHLAPI) test).equals(rt))
+				return false;
+			test = ((RefTransitionHLAPI) test).getRefHLAPI();
+		}
+		return false;
+	}
 
-    /**
-     * Fuse documents of two given workspace in one. All net of second document
-     * will now belong in first one.
-     *
-     * @param WsId1
-     *            id of first Document Workspace
-     * @param WsId2
-     *            id of second Document Workspace
-     * @throws InvalidIDException
-     *             if an unexisting workspace is given or if duplicated id
-     *             exists between the two workspaces
-     * @throws VoidRepositoryException
-     *             if Model repository has not been initializated.
-     * @throws OtherException
-     *             if a problem occure with classes
-     */
-    public static void fuseDocuments(String WsId1, String WsId2)
-            throws InvalidIDException, VoidRepositoryException, OtherException {
-        PetriNetDocHLAPI doc1;
-        PetriNetDocHLAPI doc2;
-        IdRepository idr1;
-        IdRepository idr2;
+	/**
+	 * Fuse documents of two given workspace in one. All net of second document will
+	 * now belong in first one.
+	 *
+	 * @param WsId1 id of first Document Workspace
+	 * @param WsId2 id of second Document Workspace
+	 * @throws InvalidIDException      if an unexisting workspace is given or if
+	 *                                 duplicated id exists between the two
+	 *                                 workspaces
+	 * @throws VoidRepositoryException if Model repository has not been
+	 *                                 initializated.
+	 * @throws OtherException          if a problem occure with classes
+	 */
+	public static void fuseDocuments(String WsId1, String WsId2)
+			throws InvalidIDException, VoidRepositoryException, OtherException {
+		PetriNetDocHLAPI doc1;
+		PetriNetDocHLAPI doc2;
+		IdRepository idr1;
+		IdRepository idr2;
 
-        ModelRepository mr = ModelRepository.getInstance();
-        mr.changeCurrentDocWorkspace(WsId1);
-        if (mr.getCurrentHLAPIRootClass() !=null && mr.getCurrentHLAPIRootClass().getClass().equals(
-                PetriNetDocHLAPI.class)) {
-            doc1 = (PetriNetDocHLAPI) mr.getCurrentHLAPIRootClass();
-            idr1 = mr.getCurrentIdRepository();
-        } else {
-            throw new OtherException(
-                    "The HLAPIRootClass is not of the expected type");
-        }
+		ModelRepository mr = ModelRepository.getInstance();
+		mr.changeCurrentDocWorkspace(WsId1);
+		if (mr.getCurrentHLAPIRootClass() != null
+				&& mr.getCurrentHLAPIRootClass().getClass().equals(PetriNetDocHLAPI.class)) {
+			doc1 = (PetriNetDocHLAPI) mr.getCurrentHLAPIRootClass();
+			idr1 = mr.getCurrentIdRepository();
+		} else {
+			throw new OtherException("The HLAPIRootClass is not of the expected type");
+		}
 
-        mr.changeCurrentDocWorkspace(WsId2);
-        if (mr.getCurrentHLAPIRootClass() !=null && mr.getCurrentHLAPIRootClass().getClass().equals(
-                PetriNetDocHLAPI.class)) {
-            doc2 = (PetriNetDocHLAPI) mr.getCurrentHLAPIRootClass();
-            idr2 = mr.getCurrentIdRepository();
-        } else {
-            throw new OtherException(
-                    "The HLAPIRootClass is not of the expected type");
-        }
+		mr.changeCurrentDocWorkspace(WsId2);
+		if (mr.getCurrentHLAPIRootClass() != null
+				&& mr.getCurrentHLAPIRootClass().getClass().equals(PetriNetDocHLAPI.class)) {
+			doc2 = (PetriNetDocHLAPI) mr.getCurrentHLAPIRootClass();
+			idr2 = mr.getCurrentIdRepository();
+		} else {
+			throw new OtherException("The HLAPIRootClass is not of the expected type");
+		}
 
-        mr.changeCurrentDocWorkspace(WsId1);
-        if (!idr1.isCompatible(idr2))
-            throw new InvalidIDException(
-                    "Common ids exists between the two workspaces");
+		mr.changeCurrentDocWorkspace(WsId1);
+		if (!idr1.isCompatible(idr2))
+			throw new InvalidIDException("Common ids exists between the two workspaces");
 
-        for (PetriNetHLAPI net : doc2.getNetsHLAPI()) {
-            doc1.addNetsHLAPI(net);
-        }
-        idr1.fuseWith(idr2);
-        mr.changeCurrentDocWorkspace(WsId2);
-        mr.destroyCurrentWorkspace();
-        mr.changeCurrentDocWorkspace(WsId1);
-    }
+		for (PetriNetHLAPI net : doc2.getNetsHLAPI()) {
+			doc1.addNetsHLAPI(net);
+		}
+		idr1.fuseWith(idr2);
+		mr.changeCurrentDocWorkspace(WsId2);
+		mr.destroyCurrentWorkspace();
+		mr.changeCurrentDocWorkspace(WsId1);
+	}
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/util/HlcorestructureAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/util/HlcorestructureAdapterFactory.java
@@ -74,26 +74,25 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Type;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage
  * @generated
  */
 public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static HlcorestructurePackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public HlcorestructureAdapterFactory() {
@@ -103,10 +102,11 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -122,9 +122,9 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected HlcorestructureSwitch<Adapter> modelSwitch = new HlcorestructureSwitch<Adapter>() {
@@ -310,9 +310,9 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -323,11 +323,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc <em>Petri Net Doc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc <em>Petri Net
+	 * Doc</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNetDoc
 	 * @generated
@@ -337,11 +338,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet <em>Petri Net</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet <em>Petri
+	 * Net</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PetriNet
 	 * @generated
@@ -351,11 +353,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page <em>Page</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Page <em>Page</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Page
 	 * @generated
@@ -365,11 +368,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject <em>Pn Object</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject <em>Pn
+	 * Object</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PnObject
 	 * @generated
@@ -379,11 +383,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Name <em>Name</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Name
 	 * @generated
@@ -393,11 +398,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo <em>Tool Info</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo <em>Tool
+	 * Info</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ToolInfo
 	 * @generated
@@ -407,11 +413,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label <em>Label</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Label <em>Label</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Label
 	 * @generated
@@ -421,11 +428,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics <em>Node Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics <em>Node
+	 * Graphics</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.NodeGraphics
 	 * @generated
@@ -435,11 +443,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics <em>Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics
+	 * <em>Graphics</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Graphics
 	 * @generated
@@ -449,11 +458,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate <em>Coordinate</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate
+	 * <em>Coordinate</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Coordinate
 	 * @generated
@@ -463,11 +473,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position <em>Position</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Position
+	 * <em>Position</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Position
 	 * @generated
@@ -477,11 +488,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset <em>Offset</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset <em>Offset</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Offset
 	 * @generated
@@ -491,11 +503,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension <em>Dimension</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension
+	 * <em>Dimension</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Dimension
 	 * @generated
@@ -505,11 +518,13 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics <em>Annotation Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics
+	 * <em>Annotation Graphics</em>}'. <!-- begin-user-doc --> This default
+	 * implementation returns null so that we can easily ignore cases; it's useful
+	 * to ignore a case when inheritance will catch all the cases anyway. <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnnotationGraphics
 	 * @generated
@@ -519,11 +534,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill <em>Fill</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill <em>Fill</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Fill
 	 * @generated
@@ -533,11 +549,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line <em>Line</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Line <em>Line</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Line
 	 * @generated
@@ -547,11 +564,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics <em>Arc Graphics</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics <em>Arc
+	 * Graphics</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.ArcGraphics
 	 * @generated
@@ -561,11 +579,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc <em>Arc</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc <em>Arc</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Arc
 	 * @generated
@@ -575,11 +594,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node <em>Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Node <em>Node</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Node
 	 * @generated
@@ -589,11 +609,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font <em>Font</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Font <em>Font</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Font
 	 * @generated
@@ -603,11 +624,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode <em>Place Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode <em>Place
+	 * Node</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.PlaceNode
 	 * @generated
@@ -617,11 +639,13 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode <em>Transition Node</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode
+	 * <em>Transition Node</em>}'. <!-- begin-user-doc --> This default
+	 * implementation returns null so that we can easily ignore cases; it's useful
+	 * to ignore a case when inheritance will catch all the cases anyway. <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode
 	 * @generated
@@ -631,11 +655,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place <em>Place</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Place <em>Place</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Place
 	 * @generated
@@ -645,11 +670,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition <em>Ref Transition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition <em>Ref
+	 * Transition</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefTransition
 	 * @generated
@@ -659,11 +685,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition <em>Transition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition
+	 * <em>Transition</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Transition
 	 * @generated
@@ -673,11 +700,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace <em>Ref Place</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace <em>Ref
+	 * Place</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.RefPlace
 	 * @generated
@@ -687,11 +715,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute <em>Attribute</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute
+	 * <em>Attribute</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Attribute
 	 * @generated
@@ -701,11 +730,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation <em>Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation
+	 * <em>Annotation</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Annotation
 	 * @generated
@@ -715,11 +745,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject <em>Any Object</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject <em>Any
+	 * Object</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.AnyObject
 	 * @generated
@@ -729,11 +760,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation <em>HL Core Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation <em>HL
+	 * Core Annotation</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLCoreAnnotation
 	 * @generated
@@ -743,11 +775,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type <em>Type</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Type
 	 * @generated
@@ -757,11 +790,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking <em>HL Marking</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking <em>HL
+	 * Marking</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking
 	 * @generated
@@ -771,11 +805,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition <em>Condition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition
+	 * <em>Condition</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition
 	 * @generated
@@ -785,11 +820,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation <em>HL Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation <em>HL
+	 * Annotation</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation
 	 * @generated
@@ -799,11 +835,12 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration
 	 * @generated
@@ -813,10 +850,9 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -824,4 +860,4 @@ public class HlcorestructureAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //HlcorestructureAdapterFactory
+} // HlcorestructureAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/util/HlcorestructureSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/util/HlcorestructureSwitch.java
@@ -73,31 +73,28 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Type;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage
  * @generated
  */
 public class HlcorestructureSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static HlcorestructurePackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public HlcorestructureSwitch() {
@@ -107,9 +104,9 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -120,9 +117,10 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -472,13 +470,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Petri Net Doc</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Petri
+	 * Net Doc</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Petri Net Doc</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Petri
+	 *         Net Doc</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -487,13 +485,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Petri Net</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Petri
+	 * Net</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Petri Net</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Petri
+	 *         Net</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -502,13 +500,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Page</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Page</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Page</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Page</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -517,13 +515,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Pn Object</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Pn
+	 * Object</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Pn Object</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Pn
+	 *         Object</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -532,13 +530,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Name</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Name</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Name</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Name</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -547,13 +545,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Tool Info</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Tool
+	 * Info</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Tool Info</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Tool
+	 *         Info</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -562,13 +560,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Label</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Label</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Label</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Label</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -577,13 +575,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Node Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Node
+	 * Graphics</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Node Graphics</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Node
+	 *         Graphics</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -592,13 +590,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Graphics</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Graphics</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Graphics</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -607,13 +606,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Coordinate</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Coordinate</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Coordinate</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Coordinate</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -622,13 +622,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Position</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Position</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Position</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Position</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -637,13 +638,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Offset</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Offset</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Offset</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Offset</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -652,13 +653,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Dimension</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Dimension</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Dimension</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Dimension</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -667,13 +669,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Annotation Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Annotation Graphics</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Annotation Graphics</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Annotation Graphics</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -682,13 +685,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Fill</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Fill</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Fill</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Fill</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -697,13 +700,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Line</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Line</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Line</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Line</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -712,13 +715,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Arc Graphics</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Arc
+	 * Graphics</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Arc Graphics</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Arc
+	 *         Graphics</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -727,13 +730,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Arc</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Arc</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Arc</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Arc</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -742,13 +745,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Node</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Node</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Node</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Node</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -757,13 +760,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Font</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Font</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Font</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Font</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -772,13 +775,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Place Node</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Place
+	 * Node</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Place Node</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Place
+	 *         Node</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -787,13 +790,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Transition Node</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Transition Node</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Transition Node</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Transition Node</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -802,13 +806,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Place</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Place</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Place</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Place</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -817,13 +821,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Ref Transition</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Ref
+	 * Transition</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Ref Transition</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Ref
+	 *         Transition</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -832,13 +836,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Transition</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Transition</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Transition</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Transition</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -847,13 +852,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Ref Place</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Ref
+	 * Place</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Ref Place</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Ref
+	 *         Place</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -862,13 +867,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Attribute</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Attribute</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Attribute</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Attribute</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -877,13 +883,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Annotation</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Annotation</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Annotation</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Annotation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -892,13 +899,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Any Object</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Any
+	 * Object</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Any Object</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Any
+	 *         Object</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -907,13 +914,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>HL Core Annotation</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>HL Core
+	 * Annotation</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>HL Core Annotation</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>HL Core
+	 *         Annotation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -922,13 +929,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Type</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Type</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Type</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Type</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -937,13 +944,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>HL Marking</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>HL
+	 * Marking</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>HL Marking</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>HL
+	 *         Marking</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -952,13 +959,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Condition</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Condition</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Condition</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Condition</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -967,13 +975,13 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>HL Annotation</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>HL
+	 * Annotation</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>HL Annotation</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>HL
+	 *         Annotation</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -982,13 +990,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Declaration</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Declaration</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Declaration</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Declaration</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -997,13 +1006,14 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -1012,4 +1022,4 @@ public class HlcorestructureSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //HlcorestructureSwitch
+} // HlcorestructureSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/util/HlcorestructureValidator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/hlcorestructure/util/HlcorestructureValidator.java
@@ -89,25 +89,25 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.TransitionNode;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Type;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Validator</b> for the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Validator</b> for the model. <!-- end-user-doc
+ * -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HlcorestructurePackage
  * @generated
  */
 public class HlcorestructureValidator extends EObjectValidator {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final HlcorestructureValidator INSTANCE = new HlcorestructureValidator();
 
 	/**
-	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource() source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode() codes} from this package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource()
+	 * source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode()
+	 * codes} from this package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.common.util.Diagnostic#getSource()
 	 * @see org.eclipse.emf.common.util.Diagnostic#getCode()
 	 * @generated
@@ -115,25 +115,27 @@ public class HlcorestructureValidator extends EObjectValidator {
 	public static final String DIAGNOSTIC_SOURCE = "fr.lip6.move.pnml.pthlpng.hlcorestructure";
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 0;
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
-	 * <!-- begin-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants in a derived class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static final int DIAGNOSTIC_CODE_COUNT = GENERATED_DIAGNOSTIC_CODE_COUNT;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public HlcorestructureValidator() {
@@ -141,9 +143,9 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the package of this validator switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package of this validator switch. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,12 +155,13 @@ public class HlcorestructureValidator extends EObjectValidator {
 
 	/**
 	 * Calls <code>validateXXX</code> for the corresponding classifier of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		switch (classifierID) {
 		case HlcorestructurePackage.PETRI_NET_DOC:
 			return validatePetriNetDoc((PetriNetDoc) value, diagnostics, context);
@@ -262,17 +265,18 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validatePetriNetDoc(PetriNetDoc petriNetDoc, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validatePetriNetDoc(PetriNetDoc petriNetDoc, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		return validate_EveryDefaultConstraint(petriNetDoc, diagnostics, context);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePetriNet(PetriNet petriNet, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -280,8 +284,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePage(Page page, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -289,8 +293,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePnObject(PnObject pnObject, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -298,8 +302,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateName(Name name, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -307,8 +311,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateToolInfo(ToolInfo toolInfo, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -316,8 +320,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLabel(Label label, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -325,8 +329,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNodeGraphics(NodeGraphics nodeGraphics, DiagnosticChain diagnostics,
@@ -335,8 +339,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateGraphics(Graphics graphics, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -344,8 +348,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCoordinate(Coordinate coordinate, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -353,8 +357,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePosition(Position position, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -362,8 +366,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateOffset(Offset offset, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -371,8 +375,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateDimension(Dimension dimension, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -380,8 +384,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAnnotationGraphics(AnnotationGraphics annotationGraphics, DiagnosticChain diagnostics,
@@ -390,8 +394,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateFill(Fill fill, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -399,8 +403,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLine(Line line, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -408,17 +412,18 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateArcGraphics(ArcGraphics arcGraphics, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateArcGraphics(ArcGraphics arcGraphics, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		return validate_EveryDefaultConstraint(arcGraphics, diagnostics, context);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateArc(Arc arc, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -447,9 +452,9 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the samePageSourceTarget constraint of '<em>Arc</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the samePageSourceTarget constraint of '<em>Arc</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateArc_samePageSourceTarget(Arc arc, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -459,10 +464,10 @@ public class HlcorestructureValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "samePageSourceTarget", getObjectLabel(arc, context) }, new Object[] { arc },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "samePageSourceTarget", getObjectLabel(arc, context) },
+								new Object[] { arc }, context));
 			}
 			return false;
 		}
@@ -470,22 +475,23 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the differentSourceTarget constraint of '<em>Arc</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the differentSourceTarget constraint of '<em>Arc</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateArc_differentSourceTarget(Arc arc, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateArc_differentSourceTarget(Arc arc, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		// TODO implement the constraint
 		// -> specify the condition that violates the constraint
 		// -> verify the diagnostic details, including severity, code, and message
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "differentSourceTarget", getObjectLabel(arc, context) }, new Object[] { arc },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "differentSourceTarget", getObjectLabel(arc, context) },
+								new Object[] { arc }, context));
 			}
 			return false;
 		}
@@ -493,8 +499,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNode(Node node, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -502,8 +508,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateFont(Font font, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -511,8 +517,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePlaceNode(PlaceNode placeNode, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -520,8 +526,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateTransitionNode(TransitionNode transitionNode, DiagnosticChain diagnostics,
@@ -530,8 +536,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePlace(Place place, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -539,8 +545,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateRefTransition(RefTransition refTransition, DiagnosticChain diagnostics,
@@ -549,8 +555,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateTransition(Transition transition, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -558,8 +564,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateRefPlace(RefPlace refPlace, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -567,8 +573,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAttribute(Attribute attribute, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -576,8 +582,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAnnotation(Annotation annotation, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -585,8 +591,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAnyObject(AnyObject anyObject, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -594,8 +600,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateHLCoreAnnotation(HLCoreAnnotation hlCoreAnnotation, DiagnosticChain diagnostics,
@@ -604,8 +610,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateType(Type type, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -613,8 +619,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateHLMarking(HLMarking hlMarking, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -622,8 +628,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCondition(Condition condition, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -631,8 +637,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateHLAnnotation(HLAnnotation hlAnnotation, DiagnosticChain diagnostics,
@@ -641,17 +647,18 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateDeclaration(Declaration declaration, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateDeclaration(Declaration declaration, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		return validate_EveryDefaultConstraint(declaration, diagnostics, context);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePNType(PNType pnType, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -659,8 +666,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCSS2Color(CSS2Color css2Color, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -668,8 +675,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateGradient(Gradient gradient, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -677,8 +684,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLineShape(LineShape lineShape, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -686,8 +693,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateFontAlign(FontAlign fontAlign, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -695,8 +702,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateFontDecoration(FontDecoration fontDecoration, DiagnosticChain diagnostics,
@@ -705,8 +712,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCSS2FontFamily(CSS2FontFamily css2FontFamily, DiagnosticChain diagnostics,
@@ -715,8 +722,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCSS2FontSize(CSS2FontSize css2FontSize, DiagnosticChain diagnostics,
@@ -725,8 +732,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCSS2FontStyle(CSS2FontStyle css2FontStyle, DiagnosticChain diagnostics,
@@ -735,8 +742,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCSS2FontWeight(CSS2FontWeight css2FontWeight, DiagnosticChain diagnostics,
@@ -745,8 +752,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLineStyle(LineStyle lineStyle, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -754,8 +761,8 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateURI(URI uri, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -763,26 +770,28 @@ public class HlcorestructureValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateLongString(StringBuffer longString, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateLongString(StringBuffer longString, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		return true;
 	}
 
 	/**
-	 * Returns the resource locator that will be used to fetch messages for this validator's diagnostics.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the resource locator that will be used to fetch messages for this
+	 * validator's diagnostics. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public ResourceLocator getResourceLocator() {
 		// TODO
-		// Specialize this to return a resource locator for messages specific to this validator.
+		// Specialize this to return a resource locator for messages specific to this
+		// validator.
 		// Ensure that you remove @generated or mark it @generated NOT
 		return super.getResourceLocator();
 	}
 
-} //HlcorestructureValidator
+} // HlcorestructureValidator

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Addition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Addition.java
@@ -52,7 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='addition'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Addition extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Addition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Addition.java
@@ -42,15 +42,17 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Addition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Addition</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getAddition()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsKindOf(Number)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='addition' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsKindOf(Number)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='addition'
+ *        kind='son'"
  * @generated
  */
 public interface Addition extends IntegerOperator {
@@ -65,8 +67,8 @@ public interface Addition extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Division.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Division.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Division</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Division</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getDivision()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsKindOf(Number)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsKindOf(Number)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='div' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface Division extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Division.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Division.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='div' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Division extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThan.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='gt' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface GreaterThan extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThan.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Greater Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Greater
+ * Than</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getGreaterThan()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsTypeOf(booleans::Bool)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsTypeOf(booleans::Bool)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='gt' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface GreaterThan extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThanOrEqual.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThanOrEqual.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='geq' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface GreaterThanOrEqual extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThanOrEqual.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/GreaterThanOrEqual.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Greater Than Or Equal</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Greater
+ * Than Or Equal</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getGreaterThanOrEqual()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsTypeOf(booleans::Bool)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsTypeOf(booleans::Bool)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='geq' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface GreaterThanOrEqual extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLInteger.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLInteger.java
@@ -48,7 +48,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getHLInteger()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='integer'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface HLInteger extends HLPNNumber {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLInteger.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLInteger.java
@@ -42,13 +42,13 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>HL Integer</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>HL
+ * Integer</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getHLInteger()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='integer' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='integer'
+ *        kind='son'"
  * @generated
  */
 public interface HLInteger extends HLPNNumber {
@@ -63,8 +63,8 @@ public interface HLInteger extends HLPNNumber {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLPNNumber.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLPNNumber.java
@@ -43,33 +43,50 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>HLPN Number</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>HLPN
+ * Number</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant <em>Container Number Constant</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant
+ * <em>Container Number Constant</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getHLPNNumber()
- * @model abstract="true"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;' documentation='/**\n * Returns true if this sort and argument sort are actually \n * semantically the same sort, even in two different objects.\n * Ex: two FiniteEnumerations or two Integers.\n * @return true if so. \n * @param sort the sort to which we compare this one. \n \052/'"
+ * @model abstract="true" annotation="http://www.pnml.org/models/methods/SORT
+ *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
+ *        false;\n\t\tif
+ *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
+ *        {\n\t\t //by default they are the same sort, unless they have been
+ *        named.\n\t\t \tisEqual = true;\n\t\t \tif
+ *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
+ *        they have been explicitly named.\n\t\t\t\tisEqual =
+ *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}//
+ *        otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;'
+ *        documentation='/**\n * Returns true if this sort and argument sort are
+ *        actually \n * semantically the same sort, even in two different
+ *        objects.\n * Ex: two FiniteEnumerations or two Integers.\n * @return
+ *        true if so. \n * @param sort the sort to which we compare this one. \n
+ *        \052/'"
  * @generated
  */
 public interface HLPNNumber extends BuiltInSort {
 	/**
-	 * Returns the value of the '<em><b>Container Number Constant</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Number Constant</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Number Constant</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Number Constant</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Number Constant</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Number Constant</em>' container
+	 *         reference.
 	 * @see #setContainerNumberConstant(NumberConstant)
 	 * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getHLPNNumber_ContainerNumberConstant()
 	 * @see fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType
@@ -79,10 +96,13 @@ public interface HLPNNumber extends BuiltInSort {
 	NumberConstant getContainerNumberConstant();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant <em>Container Number Constant</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Number Constant</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant
+	 * <em>Container Number Constant</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Number Constant</em>'
+	 *              container reference.
 	 * @see #getContainerNumberConstant()
 	 * @generated
 	 */
@@ -92,8 +112,8 @@ public interface HLPNNumber extends BuiltInSort {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLPNNumber.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/HLPNNumber.java
@@ -55,13 +55,13 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getHLPNNumber()
- * @model abstract="true" annotation="http://www.pnml.org/models/methods/SORT
- *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
- *        false;\n\t\tif
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
  *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
  *        {\n\t\t //by default they are the same sort, unless they have been
  *        named.\n\t\t \tisEqual = true;\n\t\t \tif
- *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        (this.getContainerNamedSort() != null\n\t\t\t\t\t&amp;&amp;
  *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
  *        they have been explicitly named.\n\t\t\t\tisEqual =
  *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}//

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegerOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegerOperator.java
@@ -43,15 +43,16 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Integer Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Integer
+ * Operator</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getIntegerOperator()
- * @model abstract="true"
- *        annotation="http://www.pnml.org/models/OCL inputType='self.input->size() = 2 and self.input->forAll{c | c.oclIsKindOf(Number)}'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputType'"
+ * @model abstract="true" annotation="http://www.pnml.org/models/OCL
+ *        inputType='self.input->size() = 2 and self.input->forAll{c |
+ *        c.oclIsKindOf(Number)}'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputType'"
  * @generated
  */
 public interface IntegerOperator extends BuiltInOperator {
@@ -60,8 +61,8 @@ public interface IntegerOperator extends BuiltInOperator {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegerOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegerOperator.java
@@ -49,7 +49,7 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getIntegerOperator()
  * @model abstract="true" annotation="http://www.pnml.org/models/OCL
- *        inputType='self.input->size() = 2 and self.input->forAll{c |
+ *        inputType='self.input-&gt;size() = 2 and self.input-&gt;forAll{c |
  *        c.oclIsKindOf(Number)}'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputType'"

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegersFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegersFactory.java
@@ -34,146 +34,145 @@ package fr.lip6.move.pnml.pthlpng.integers;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage
  * @generated
  */
 public interface IntegersFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	IntegersFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.integers.impl.IntegersFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Natural</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Natural</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Natural</em>'.
 	 * @generated
 	 */
 	Natural createNatural();
 
 	/**
-	 * Returns a new object of class '<em>Positive</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Positive</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Positive</em>'.
 	 * @generated
 	 */
 	Positive createPositive();
 
 	/**
-	 * Returns a new object of class '<em>HL Integer</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>HL Integer</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>HL Integer</em>'.
 	 * @generated
 	 */
 	HLInteger createHLInteger();
 
 	/**
-	 * Returns a new object of class '<em>Number Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Number Constant</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Number Constant</em>'.
 	 * @generated
 	 */
 	NumberConstant createNumberConstant();
 
 	/**
-	 * Returns a new object of class '<em>Addition</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Addition</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Addition</em>'.
 	 * @generated
 	 */
 	Addition createAddition();
 
 	/**
-	 * Returns a new object of class '<em>Subtraction</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Subtraction</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Subtraction</em>'.
 	 * @generated
 	 */
 	Subtraction createSubtraction();
 
 	/**
-	 * Returns a new object of class '<em>Multiplication</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Multiplication</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Multiplication</em>'.
 	 * @generated
 	 */
 	Multiplication createMultiplication();
 
 	/**
-	 * Returns a new object of class '<em>Division</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Division</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Division</em>'.
 	 * @generated
 	 */
 	Division createDivision();
 
 	/**
-	 * Returns a new object of class '<em>Modulo</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Modulo</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Modulo</em>'.
 	 * @generated
 	 */
 	Modulo createModulo();
 
 	/**
-	 * Returns a new object of class '<em>Greater Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Greater Than</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Greater Than</em>'.
 	 * @generated
 	 */
 	GreaterThan createGreaterThan();
 
 	/**
-	 * Returns a new object of class '<em>Greater Than Or Equal</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Greater Than Or Equal</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Greater Than Or Equal</em>'.
 	 * @generated
 	 */
 	GreaterThanOrEqual createGreaterThanOrEqual();
 
 	/**
-	 * Returns a new object of class '<em>Less Than</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Less Than</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Less Than</em>'.
 	 * @generated
 	 */
 	LessThan createLessThan();
 
 	/**
-	 * Returns a new object of class '<em>Less Than Or Equal</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Less Than Or Equal</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Less Than Or Equal</em>'.
 	 * @generated
 	 */
 	LessThanOrEqual createLessThanOrEqual();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	IntegersPackage getIntegersPackage();
 
-} //IntegersFactory
+} // IntegersFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegersPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegersPackage.java
@@ -39,57 +39,55 @@ import org.eclipse.emf.ecore.EReference;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersFactory
  * @model kind="package"
  * @generated
  */
 public interface IntegersPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "integers";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///hlpn.integers.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "integers";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	IntegersPackage eINSTANCE = fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl <em>HLPN Number</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl <em>HLPN
+	 * Number</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getHLPNNumber()
 	 * @generated
@@ -97,36 +95,36 @@ public interface IntegersPackage extends EPackage {
 	int HLPN_NUMBER = 0;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER__MULTI = TermsPackage.BUILT_IN_SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER__CONTAINER_NAMED_SORT = TermsPackage.BUILT_IN_SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER__CONTAINER_VARIABLE_DECL = TermsPackage.BUILT_IN_SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -134,8 +132,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -143,8 +141,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -152,44 +150,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER__CONTAINER_EMPTY = TermsPackage.BUILT_IN_SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER__CONTAINER_PARTITION = TermsPackage.BUILT_IN_SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Container Number Constant</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Number Constant</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT = TermsPackage.BUILT_IN_SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>HLPN Number</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>HLPN Number</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HLPN_NUMBER_FEATURE_COUNT = TermsPackage.BUILT_IN_SORT_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl <em>Natural</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl
+	 * <em>Natural</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getNatural()
 	 * @generated
@@ -197,36 +196,36 @@ public interface IntegersPackage extends EPackage {
 	int NATURAL = 1;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL__MULTI = HLPN_NUMBER__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL__CONTAINER_NAMED_SORT = HLPN_NUMBER__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL__CONTAINER_VARIABLE_DECL = HLPN_NUMBER__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -234,8 +233,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -243,8 +242,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -252,44 +251,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL__CONTAINER_EMPTY = HLPN_NUMBER__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL__CONTAINER_PARTITION = HLPN_NUMBER__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Container Number Constant</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Number Constant</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL__CONTAINER_NUMBER_CONSTANT = HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT;
 
 	/**
-	 * The number of structural features of the '<em>Natural</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Natural</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NATURAL_FEATURE_COUNT = HLPN_NUMBER_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl <em>Positive</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl
+	 * <em>Positive</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getPositive()
 	 * @generated
@@ -297,36 +297,36 @@ public interface IntegersPackage extends EPackage {
 	int POSITIVE = 2;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE__MULTI = HLPN_NUMBER__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE__CONTAINER_NAMED_SORT = HLPN_NUMBER__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE__CONTAINER_VARIABLE_DECL = HLPN_NUMBER__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -334,8 +334,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -343,8 +343,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -352,44 +352,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE__CONTAINER_EMPTY = HLPN_NUMBER__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE__CONTAINER_PARTITION = HLPN_NUMBER__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Container Number Constant</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Number Constant</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE__CONTAINER_NUMBER_CONSTANT = HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT;
 
 	/**
-	 * The number of structural features of the '<em>Positive</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Positive</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int POSITIVE_FEATURE_COUNT = HLPN_NUMBER_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl <em>HL Integer</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl <em>HL
+	 * Integer</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getHLInteger()
 	 * @generated
@@ -397,36 +398,36 @@ public interface IntegersPackage extends EPackage {
 	int HL_INTEGER = 3;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER__MULTI = HLPN_NUMBER__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER__CONTAINER_NAMED_SORT = HLPN_NUMBER__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER__CONTAINER_VARIABLE_DECL = HLPN_NUMBER__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -434,8 +435,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -443,8 +444,8 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -452,44 +453,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER__CONTAINER_EMPTY = HLPN_NUMBER__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER__CONTAINER_PARTITION = HLPN_NUMBER__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Container Number Constant</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Number Constant</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER__CONTAINER_NUMBER_CONSTANT = HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT;
 
 	/**
-	 * The number of structural features of the '<em>HL Integer</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>HL Integer</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int HL_INTEGER_FEATURE_COUNT = HLPN_NUMBER_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl <em>Number Constant</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl <em>Number
+	 * Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getNumberConstant()
 	 * @generated
@@ -497,63 +499,63 @@ public interface IntegersPackage extends EPackage {
 	int NUMBER_CONSTANT = 4;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__SORT = TermsPackage.BUILT_IN_CONSTANT__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__CONTAINER_CONDITION = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_CONSTANT__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -561,44 +563,44 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__SUBTERM = TermsPackage.BUILT_IN_CONSTANT__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__OUTPUT = TermsPackage.BUILT_IN_CONSTANT__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__INPUT = TermsPackage.BUILT_IN_CONSTANT__INPUT;
 
 	/**
-	 * The feature id for the '<em><b>Type</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Type</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT__TYPE = TermsPackage.BUILT_IN_CONSTANT_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Value</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -606,17 +608,19 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Number Constant</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_CONSTANT_FEATURE_COUNT = TermsPackage.BUILT_IN_CONSTANT_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.IntegerOperatorImpl <em>Integer Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.IntegerOperatorImpl
+	 * <em>Integer Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegerOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getIntegerOperator()
 	 * @generated
@@ -624,63 +628,63 @@ public interface IntegersPackage extends EPackage {
 	int INTEGER_OPERATOR = 5;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__SORT = TermsPackage.BUILT_IN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__CONTAINER_CONDITION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -688,26 +692,26 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__SUBTERM = TermsPackage.BUILT_IN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR__OUTPUT = TermsPackage.BUILT_IN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -715,17 +719,18 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Integer Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int INTEGER_OPERATOR_FEATURE_COUNT = TermsPackage.BUILT_IN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl <em>Addition</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl
+	 * <em>Addition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getAddition()
 	 * @generated
@@ -733,63 +738,63 @@ public interface IntegersPackage extends EPackage {
 	int ADDITION = 6;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -797,44 +802,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Addition</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Addition</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADDITION_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl <em>Subtraction</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl
+	 * <em>Subtraction</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getSubtraction()
 	 * @generated
@@ -842,63 +848,63 @@ public interface IntegersPackage extends EPackage {
 	int SUBTRACTION = 7;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -906,44 +912,46 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Subtraction</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Subtraction</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACTION_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl <em>Multiplication</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl
+	 * <em>Multiplication</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getMultiplication()
 	 * @generated
@@ -951,63 +959,63 @@ public interface IntegersPackage extends EPackage {
 	int MULTIPLICATION = 8;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1015,26 +1023,26 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1042,17 +1050,18 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Multiplication</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTIPLICATION_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl <em>Division</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl
+	 * <em>Division</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getDivision()
 	 * @generated
@@ -1060,63 +1069,63 @@ public interface IntegersPackage extends EPackage {
 	int DIVISION = 9;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1124,44 +1133,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Division</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Division</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DIVISION_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl <em>Modulo</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl <em>Modulo</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getModulo()
 	 * @generated
@@ -1169,63 +1179,63 @@ public interface IntegersPackage extends EPackage {
 	int MODULO = 10;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1233,44 +1243,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Modulo</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Modulo</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MODULO_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl <em>Greater Than</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl <em>Greater
+	 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getGreaterThan()
 	 * @generated
@@ -1278,63 +1289,63 @@ public interface IntegersPackage extends EPackage {
 	int GREATER_THAN = 11;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1342,44 +1353,46 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Greater Than</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Greater Than</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl <em>Greater Than Or Equal</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl
+	 * <em>Greater Than Or Equal</em>}' class. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getGreaterThanOrEqual()
 	 * @generated
@@ -1387,63 +1400,63 @@ public interface IntegersPackage extends EPackage {
 	int GREATER_THAN_OR_EQUAL = 12;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1451,44 +1464,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Greater Than Or Equal</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Greater Than Or Equal</em>'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_OR_EQUAL_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl <em>Less Than</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl <em>Less
+	 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getLessThan()
 	 * @generated
@@ -1496,63 +1510,63 @@ public interface IntegersPackage extends EPackage {
 	int LESS_THAN = 13;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1560,44 +1574,45 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__INPUT = INTEGER_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Less Than</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Less Than</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl <em>Less Than Or Equal</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl <em>Less
+	 * Than Or Equal</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl
 	 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getLessThanOrEqual()
 	 * @generated
@@ -1605,63 +1620,63 @@ public interface IntegersPackage extends EPackage {
 	int LESS_THAN_OR_EQUAL = 14;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__SORT = INTEGER_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__CONTAINER_OPERATOR = INTEGER_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__CONTAINER_NAMED_OPERATOR = INTEGER_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__CONTAINER_HL_MARKING = INTEGER_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__CONTAINER_CONDITION = INTEGER_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__CONTAINER_HL_ANNOTATION = INTEGER_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1669,26 +1684,26 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__SUBTERM = INTEGER_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL__OUTPUT = INTEGER_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1696,17 +1711,18 @@ public interface IntegersPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Less Than Or Equal</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_OR_EQUAL_FEATURE_COUNT = INTEGER_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber <em>HLPN Number</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber <em>HLPN Number</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>HLPN Number</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.HLPNNumber
 	 * @generated
@@ -1714,10 +1730,13 @@ public interface IntegersPackage extends EPackage {
 	EClass getHLPNNumber();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant <em>Container Number Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Number Constant</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant
+	 * <em>Container Number Constant</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Number
+	 *         Constant</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant()
 	 * @see #getHLPNNumber()
 	 * @generated
@@ -1725,9 +1744,10 @@ public interface IntegersPackage extends EPackage {
 	EReference getHLPNNumber_ContainerNumberConstant();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Natural <em>Natural</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Natural <em>Natural</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Natural</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Natural
 	 * @generated
@@ -1735,9 +1755,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getNatural();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Positive <em>Positive</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Positive <em>Positive</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Positive</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Positive
 	 * @generated
@@ -1745,9 +1766,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getPositive();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.HLInteger <em>HL Integer</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLInteger <em>HL Integer</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>HL Integer</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.HLInteger
 	 * @generated
@@ -1755,9 +1777,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getHLInteger();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant <em>Number Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant <em>Number
+	 * Constant</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Number Constant</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.NumberConstant
 	 * @generated
@@ -1765,9 +1788,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getNumberConstant();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType <em>Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType
+	 * <em>Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Type</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType()
 	 * @see #getNumberConstant()
@@ -1776,9 +1800,10 @@ public interface IntegersPackage extends EPackage {
 	EReference getNumberConstant_Type();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue <em>Value</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue
+	 * <em>Value</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Value</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue()
 	 * @see #getNumberConstant()
@@ -1787,9 +1812,10 @@ public interface IntegersPackage extends EPackage {
 	EAttribute getNumberConstant_Value();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.IntegerOperator <em>Integer Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.IntegerOperator <em>Integer
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Integer Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.IntegerOperator
 	 * @generated
@@ -1797,9 +1823,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getIntegerOperator();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Addition <em>Addition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Addition <em>Addition</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Addition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Addition
 	 * @generated
@@ -1807,9 +1834,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getAddition();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Subtraction <em>Subtraction</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Subtraction
+	 * <em>Subtraction</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Subtraction</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Subtraction
 	 * @generated
@@ -1817,9 +1845,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getSubtraction();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Multiplication <em>Multiplication</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Multiplication
+	 * <em>Multiplication</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Multiplication</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Multiplication
 	 * @generated
@@ -1827,9 +1856,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getMultiplication();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Division <em>Division</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Division <em>Division</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Division</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Division
 	 * @generated
@@ -1837,9 +1867,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getDivision();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.Modulo <em>Modulo</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Modulo <em>Modulo</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Modulo</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Modulo
 	 * @generated
@@ -1847,9 +1878,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getModulo();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThan <em>Greater Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThan <em>Greater
+	 * Than</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Greater Than</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.GreaterThan
 	 * @generated
@@ -1857,9 +1889,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getGreaterThan();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual <em>Greater Than Or Equal</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual <em>Greater
+	 * Than Or Equal</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Greater Than Or Equal</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual
 	 * @generated
@@ -1867,9 +1900,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getGreaterThanOrEqual();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.LessThan <em>Less Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.LessThan <em>Less Than</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Less Than</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.LessThan
 	 * @generated
@@ -1877,9 +1911,10 @@ public interface IntegersPackage extends EPackage {
 	EClass getLessThan();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual <em>Less Than Or Equal</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual <em>Less Than Or
+	 * Equal</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Less Than Or Equal</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual
 	 * @generated
@@ -1887,31 +1922,32 @@ public interface IntegersPackage extends EPackage {
 	EClass getLessThanOrEqual();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	IntegersFactory getIntegersFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl <em>HLPN Number</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl <em>HLPN
+		 * Number</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getHLPNNumber()
 		 * @generated
@@ -1919,17 +1955,18 @@ public interface IntegersPackage extends EPackage {
 		EClass HLPN_NUMBER = eINSTANCE.getHLPNNumber();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Number Constant</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Number Constant</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT = eINSTANCE.getHLPNNumber_ContainerNumberConstant();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl <em>Natural</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl
+		 * <em>Natural</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getNatural()
 		 * @generated
@@ -1937,9 +1974,10 @@ public interface IntegersPackage extends EPackage {
 		EClass NATURAL = eINSTANCE.getNatural();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl <em>Positive</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl
+		 * <em>Positive</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getPositive()
 		 * @generated
@@ -1947,9 +1985,10 @@ public interface IntegersPackage extends EPackage {
 		EClass POSITIVE = eINSTANCE.getPositive();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl <em>HL Integer</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl <em>HL
+		 * Integer</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getHLInteger()
 		 * @generated
@@ -1957,9 +1996,10 @@ public interface IntegersPackage extends EPackage {
 		EClass HL_INTEGER = eINSTANCE.getHLInteger();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl <em>Number Constant</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl <em>Number
+		 * Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getNumberConstant()
 		 * @generated
@@ -1967,25 +2007,27 @@ public interface IntegersPackage extends EPackage {
 		EClass NUMBER_CONSTANT = eINSTANCE.getNumberConstant();
 
 		/**
-		 * The meta object literal for the '<em><b>Type</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Type</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NUMBER_CONSTANT__TYPE = eINSTANCE.getNumberConstant_Type();
 
 		/**
 		 * The meta object literal for the '<em><b>Value</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute NUMBER_CONSTANT__VALUE = eINSTANCE.getNumberConstant_Value();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.IntegerOperatorImpl <em>Integer Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.IntegerOperatorImpl
+		 * <em>Integer Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegerOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getIntegerOperator()
 		 * @generated
@@ -1993,9 +2035,10 @@ public interface IntegersPackage extends EPackage {
 		EClass INTEGER_OPERATOR = eINSTANCE.getIntegerOperator();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl <em>Addition</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl
+		 * <em>Addition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getAddition()
 		 * @generated
@@ -2003,9 +2046,10 @@ public interface IntegersPackage extends EPackage {
 		EClass ADDITION = eINSTANCE.getAddition();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl <em>Subtraction</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl
+		 * <em>Subtraction</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getSubtraction()
 		 * @generated
@@ -2013,9 +2057,11 @@ public interface IntegersPackage extends EPackage {
 		EClass SUBTRACTION = eINSTANCE.getSubtraction();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl <em>Multiplication</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl
+		 * <em>Multiplication</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getMultiplication()
 		 * @generated
@@ -2023,9 +2069,10 @@ public interface IntegersPackage extends EPackage {
 		EClass MULTIPLICATION = eINSTANCE.getMultiplication();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl <em>Division</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl
+		 * <em>Division</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getDivision()
 		 * @generated
@@ -2033,9 +2080,10 @@ public interface IntegersPackage extends EPackage {
 		EClass DIVISION = eINSTANCE.getDivision();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl <em>Modulo</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl <em>Modulo</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getModulo()
 		 * @generated
@@ -2043,9 +2091,10 @@ public interface IntegersPackage extends EPackage {
 		EClass MODULO = eINSTANCE.getModulo();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl <em>Greater Than</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl <em>Greater
+		 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getGreaterThan()
 		 * @generated
@@ -2053,9 +2102,11 @@ public interface IntegersPackage extends EPackage {
 		EClass GREATER_THAN = eINSTANCE.getGreaterThan();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl <em>Greater Than Or Equal</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl
+		 * <em>Greater Than Or Equal</em>}' class. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getGreaterThanOrEqual()
 		 * @generated
@@ -2063,9 +2114,10 @@ public interface IntegersPackage extends EPackage {
 		EClass GREATER_THAN_OR_EQUAL = eINSTANCE.getGreaterThanOrEqual();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl <em>Less Than</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl <em>Less
+		 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getLessThan()
 		 * @generated
@@ -2073,9 +2125,10 @@ public interface IntegersPackage extends EPackage {
 		EClass LESS_THAN = eINSTANCE.getLessThan();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl <em>Less Than Or Equal</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl <em>Less
+		 * Than Or Equal</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl
 		 * @see fr.lip6.move.pnml.pthlpng.integers.impl.IntegersPackageImpl#getLessThanOrEqual()
 		 * @generated
@@ -2084,4 +2137,4 @@ public interface IntegersPackage extends EPackage {
 
 	}
 
-} //IntegersPackage
+} // IntegersPackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegersPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/IntegersPackage.java
@@ -66,7 +66,7 @@ public interface IntegersPackage extends EPackage {
 	 * 
 	 * @generated
 	 */
-	String eNS_URI = "http:///hlpn.integers.ecore";
+	String eNS_URI = "http:///pthlpng.integers.ecore";
 
 	/**
 	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThan.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='lt' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface LessThan extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThan.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Less Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Less
+ * Than</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getLessThan()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsTypeOf(booleans::Bool)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsTypeOf(booleans::Bool)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='lt' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface LessThan extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThanOrEqual.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThanOrEqual.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Less Than Or Equal</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Less
+ * Than Or Equal</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getLessThanOrEqual()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsTypeOf(booleans::Bool)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsTypeOf(booleans::Bool)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='leq' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface LessThanOrEqual extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThanOrEqual.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/LessThanOrEqual.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='leq' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface LessThanOrEqual extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Modulo.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Modulo.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='mod' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Modulo extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Modulo.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Modulo.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Modulo</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Modulo</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getModulo()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsKindOf(Number)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsKindOf(Number)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='mod' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface Modulo extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Multiplication.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Multiplication.java
@@ -42,14 +42,15 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Multiplication</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Multiplication</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getMultiplication()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsKindOf(Number)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsKindOf(Number)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='mult' kind='son'"
  * @generated
  */
@@ -65,8 +66,8 @@ public interface Multiplication extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Multiplication.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Multiplication.java
@@ -52,6 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='mult' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Multiplication extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Natural.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Natural.java
@@ -48,7 +48,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getNatural()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='natural'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Natural extends HLPNNumber {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Natural.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Natural.java
@@ -42,13 +42,13 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Natural</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Natural</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getNatural()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='natural' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='natural'
+ *        kind='son'"
  * @generated
  */
 public interface Natural extends HLPNNumber {
@@ -63,8 +63,8 @@ public interface Natural extends HLPNNumber {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/NumberConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/NumberConstant.java
@@ -58,11 +58,12 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getNumberConstant()
  * @model annotation="http://www.pnml.org/models/OCL
- *        typeType='self.input->size() = 0 and self.type.oclIsTypeOf(Natural)
- *        implies self.value >= 0 and self.type.oclIsTypeOf(Positive) implies
- *        self.value > 0'" annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        typeType='self.input-&gt;size() = 0 and self.type.oclIsTypeOf(Natural)
+ *        implies self.value &gt;= 0 and self.type.oclIsTypeOf(Positive) implies
+ *        self.value &gt; 0'" annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='typeType'" annotation="http://www.pnml.org/models/ToPNML
  *        tag='numberconstant' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface NumberConstant extends BuiltInConstant {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/NumberConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/NumberConstant.java
@@ -43,34 +43,40 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Number Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Number
+ * Constant</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType <em>Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue <em>Value</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType
+ * <em>Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue
+ * <em>Value</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getNumberConstant()
- * @model annotation="http://www.pnml.org/models/OCL typeType='self.input->size() = 0 and self.type.oclIsTypeOf(Natural) implies self.value >= 0 and self.type.oclIsTypeOf(Positive) implies self.value > 0'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='typeType'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='numberconstant' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        typeType='self.input->size() = 0 and self.type.oclIsTypeOf(Natural)
+ *        implies self.value >= 0 and self.type.oclIsTypeOf(Positive) implies
+ *        self.value > 0'" annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='typeType'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='numberconstant' kind='son'"
  * @generated
  */
 public interface NumberConstant extends BuiltInConstant {
 	/**
-	 * Returns the value of the '<em><b>Type</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant <em>Container Number Constant</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Type</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber#getContainerNumberConstant
+	 * <em>Container Number Constant</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Type</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Type</em>' containment reference.
 	 * @see #setType(HLPNNumber)
 	 * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getNumberConstant_Type()
@@ -82,9 +88,11 @@ public interface NumberConstant extends BuiltInConstant {
 	HLPNNumber getType();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType <em>Type</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getType
+	 * <em>Type</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Type</em>' containment reference.
 	 * @see #getType()
 	 * @generated
@@ -92,26 +100,28 @@ public interface NumberConstant extends BuiltInConstant {
 	void setType(HLPNNumber value);
 
 	/**
-	 * Returns the value of the '<em><b>Value</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Value</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Value</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Value</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Value</em>' attribute.
 	 * @see #setValue(Long)
 	 * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getNumberConstant_Value()
-	 * @model required="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='value' kind='attribute'"
+	 * @model required="true" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='value' kind='attribute'"
 	 * @generated
 	 */
 	Long getValue();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant#getValue
+	 * <em>Value</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Value</em>' attribute.
 	 * @see #getValue()
 	 * @generated
@@ -128,8 +138,8 @@ public interface NumberConstant extends BuiltInConstant {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Positive.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Positive.java
@@ -48,7 +48,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getPositive()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='positive'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Positive extends HLPNNumber {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Positive.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Positive.java
@@ -42,13 +42,13 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Positive</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Positive</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getPositive()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='positive' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='positive'
+ *        kind='son'"
  * @generated
  */
 public interface Positive extends HLPNNumber {
@@ -63,8 +63,8 @@ public interface Positive extends HLPNNumber {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Subtraction.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Subtraction.java
@@ -42,15 +42,17 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Subtraction</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Subtraction</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#getSubtraction()
- * @model annotation="http://www.pnml.org/models/OCL outputType='self.output.oclIsKindOf(Number)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='outputType'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='subtraction' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        outputType='self.output.oclIsKindOf(Number)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='outputType'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='subtraction'
+ *        kind='son'"
  * @generated
  */
 public interface Subtraction extends IntegerOperator {
@@ -65,8 +67,8 @@ public interface Subtraction extends IntegerOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Subtraction.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/Subtraction.java
@@ -52,7 +52,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='outputType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='subtraction'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Subtraction extends IntegerOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/AdditionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/AdditionHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class AdditionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class AdditionHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class AdditionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Addition item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AdditionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AdditionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AdditionHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AdditionHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AdditionHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AdditionHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AdditionHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AdditionHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AdditionHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AdditionHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AdditionHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AdditionHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AdditionHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AdditionHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAddition();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAddition();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public AdditionHLAPI(Addition lowLevelAPI){
+	public AdditionHLAPI(Addition lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class AdditionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Addition getContainedItem(){
+	public Addition getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(AdditionHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(AdditionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/DivisionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/DivisionHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class DivisionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class DivisionHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class DivisionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Division item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DivisionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DivisionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DivisionHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DivisionHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DivisionHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DivisionHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DivisionHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DivisionHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DivisionHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DivisionHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DivisionHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DivisionHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public DivisionHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public DivisionHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDivision();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDivision();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public DivisionHLAPI(Division lowLevelAPI){
+	public DivisionHLAPI(Division lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class DivisionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Division getContainedItem(){
+	public Division getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(DivisionHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(DivisionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/GreaterThanHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/GreaterThanHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class GreaterThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class GreaterThanHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class GreaterThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private GreaterThan item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public GreaterThanHLAPI(GreaterThan lowLevelAPI){
+	public GreaterThanHLAPI(GreaterThan lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class GreaterThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public GreaterThan getContainedItem(){
+	public GreaterThan getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(GreaterThanHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(GreaterThanHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/GreaterThanOrEqualHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/GreaterThanOrEqualHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class GreaterThanOrEqualHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class GreaterThanOrEqualHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class GreaterThanOrEqualHLAPI implements HLAPIClass,TermHLAPI,OperatorHLA
 	private GreaterThanOrEqual item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanOrEqualHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanOrEqualHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanOrEqualHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanOrEqualHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanOrEqualHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanOrEqualHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanOrEqualHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanOrEqualHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanOrEqualHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanOrEqualHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanOrEqualHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanOrEqualHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThanOrEqual();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThanOrEqual();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public GreaterThanOrEqualHLAPI(GreaterThanOrEqual lowLevelAPI){
+	public GreaterThanOrEqualHLAPI(GreaterThanOrEqual lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class GreaterThanOrEqualHLAPI implements HLAPIClass,TermHLAPI,OperatorHLA
 	/**
 	 * Return encapsulated object
 	 */
-	public GreaterThanOrEqual getContainedItem(){
+	public GreaterThanOrEqual getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(GreaterThanOrEqualHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(GreaterThanOrEqualHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/HLIntegerHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/HLIntegerHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI;
 
-
-public class HLIntegerHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
+public class HLIntegerHLAPI implements HLAPIClass, SortHLAPI, HLPNNumberHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,185 +73,165 @@ public class HLIntegerHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
 	private HLInteger item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public HLIntegerHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI() {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public HLIntegerHLAPI(
-		 NumberConstantHLAPI containerNumberConstant
-	){//BEGIN CONSTRUCTOR BODY
+
+	public HLIntegerHLAPI(NumberConstantHLAPI containerNumberConstant) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createHLInteger();}
-	
- 		
- 		if(containerNumberConstant!=null)
-			item.setContainerNumberConstant((NumberConstant)containerNumberConstant.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createHLInteger();
+		}
+
+		if (containerNumberConstant != null)
+			item.setContainerNumberConstant((NumberConstant) containerNumberConstant.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public HLIntegerHLAPI(HLInteger lowLevelAPI){
+	public HLIntegerHLAPI(HLInteger lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -260,380 +239,338 @@ public class HLIntegerHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public HLInteger getContainedItem(){
+	public HLInteger getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NumberConstant getContainerNumberConstant(){
+	public NumberConstant getContainerNumberConstant() {
 		return item.getContainerNumberConstant();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NumberConstantHLAPI getContainerNumberConstantHLAPI(){
-			if(item.getContainerNumberConstant() == null) return null;
-			return new NumberConstantHLAPI(item.getContainerNumberConstant());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
+			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NumberConstantHLAPI getContainerNumberConstantHLAPI() {
+		if (item.getContainerNumberConstant() == null)
+			return null;
+		return new NumberConstantHLAPI(item.getContainerNumberConstant());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNumberConstant
 	 */
 	public void setContainerNumberConstantHLAPI(
-	
-	NumberConstantHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNumberConstant((NumberConstant)elem.getContainedItem());
-	
+
+			NumberConstantHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNumberConstant((NumberConstant) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(HLIntegerHLAPI item){
+	// equals method
+	public boolean equals(HLIntegerHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/HLPNNumberHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/HLPNNumberHLAPI.java
@@ -53,232 +53,170 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI;
 
-public interface HLPNNumberHLAPI extends HLAPIClass,SortHLAPI{
+public interface HLPNNumberHLAPI extends HLAPIClass, SortHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public MultisetSort getMulti();
-	
+
 	/**
 	 *
 	 */
 	public NamedSort getContainerNamedSort();
-	
+
 	/**
 	 *
 	 */
 	public VariableDecl getContainerVariableDecl();
-	
+
 	/**
 	 *
 	 */
 	public ProductSort getContainerProductSort();
-	
+
 	/**
 	 *
 	 */
 	public Type getContainerType();
-	
+
 	/**
 	 *
 	 */
 	public All getContainerAll();
-	
+
 	/**
 	 *
 	 */
 	public Empty getContainerEmpty();
-	
+
 	/**
 	 *
 	 */
 	public Partition getContainerPartition();
-	
+
 	/**
 	 *
 	 */
 	public NumberConstant getContainerNumberConstant();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NumberConstantHLAPI getContainerNumberConstantHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public MultisetSortHLAPI getMultiHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public AllHLAPI getContainerAllHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NumberConstantHLAPI getContainerNumberConstantHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
-	public void setMultiHLAPI(
-	MultisetSortHLAPI elem);
-	
+	public void setMultiHLAPI(MultisetSortHLAPI elem);
+
 	/**
 	 * set ContainerNamedSort
 	 */
-	public void setContainerNamedSortHLAPI(
-	NamedSortHLAPI elem);
-	
+	public void setContainerNamedSortHLAPI(NamedSortHLAPI elem);
+
 	/**
 	 * set ContainerVariableDecl
 	 */
-	public void setContainerVariableDeclHLAPI(
-	VariableDeclHLAPI elem);
-	
+	public void setContainerVariableDeclHLAPI(VariableDeclHLAPI elem);
+
 	/**
 	 * set ContainerProductSort
 	 */
-	public void setContainerProductSortHLAPI(
-	ProductSortHLAPI elem);
-	
+	public void setContainerProductSortHLAPI(ProductSortHLAPI elem);
+
 	/**
 	 * set ContainerType
 	 */
-	public void setContainerTypeHLAPI(
-	TypeHLAPI elem);
-	
+	public void setContainerTypeHLAPI(TypeHLAPI elem);
+
 	/**
 	 * set ContainerAll
 	 */
-	public void setContainerAllHLAPI(
-	AllHLAPI elem);
-	
+	public void setContainerAllHLAPI(AllHLAPI elem);
+
 	/**
 	 * set ContainerEmpty
 	 */
-	public void setContainerEmptyHLAPI(
-	EmptyHLAPI elem);
-	
+	public void setContainerEmptyHLAPI(EmptyHLAPI elem);
+
 	/**
 	 * set ContainerPartition
 	 */
-	public void setContainerPartitionHLAPI(
-	PartitionHLAPI elem);
-	
+	public void setContainerPartitionHLAPI(PartitionHLAPI elem);
+
 	/**
 	 * set ContainerNumberConstant
 	 */
-	public void setContainerNumberConstantHLAPI(
-	NumberConstantHLAPI elem);
-	
+	public void setContainerNumberConstantHLAPI(NumberConstantHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/LessThanHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/LessThanHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class LessThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class LessThanHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class LessThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private LessThan item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public LessThanHLAPI(LessThan lowLevelAPI){
+	public LessThanHLAPI(LessThan lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class LessThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public LessThan getContainedItem(){
+	public LessThan getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(LessThanHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(LessThanHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/LessThanOrEqualHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/LessThanOrEqualHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class LessThanOrEqualHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class LessThanOrEqualHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class LessThanOrEqualHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private LessThanOrEqual item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanOrEqualHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanOrEqualHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanOrEqualHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanOrEqualHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanOrEqualHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanOrEqualHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanOrEqualHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanOrEqualHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanOrEqualHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanOrEqualHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanOrEqualHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanOrEqualHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanOrEqualHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanOrEqualHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThanOrEqual();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThanOrEqual();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public LessThanOrEqualHLAPI(LessThanOrEqual lowLevelAPI){
+	public LessThanOrEqualHLAPI(LessThanOrEqual lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class LessThanOrEqualHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public LessThanOrEqual getContainedItem(){
+	public LessThanOrEqual getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(LessThanOrEqualHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(LessThanOrEqualHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/ModuloHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/ModuloHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class ModuloHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class ModuloHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class ModuloHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Modulo item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ModuloHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ModuloHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ModuloHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ModuloHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ModuloHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ModuloHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ModuloHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ModuloHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ModuloHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ModuloHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ModuloHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ModuloHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ModuloHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ModuloHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createModulo();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createModulo();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ModuloHLAPI(Modulo lowLevelAPI){
+	public ModuloHLAPI(Modulo lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class ModuloHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Modulo getContainedItem(){
+	public Modulo getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ModuloHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ModuloHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/MultiplicationHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/MultiplicationHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class MultiplicationHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class MultiplicationHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class MultiplicationHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Multiplication item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultiplicationHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultiplicationHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public MultiplicationHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public MultiplicationHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public MultiplicationHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public MultiplicationHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public MultiplicationHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public MultiplicationHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public MultiplicationHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public MultiplicationHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public MultiplicationHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public MultiplicationHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public MultiplicationHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public MultiplicationHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultiplication();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultiplication();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public MultiplicationHLAPI(Multiplication lowLevelAPI){
+	public MultiplicationHLAPI(Multiplication lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class MultiplicationHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Multiplication getContainedItem(){
+	public Multiplication getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(MultiplicationHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(MultiplicationHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/NaturalHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/NaturalHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI;
 
-
-public class NaturalHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
+public class NaturalHLAPI implements HLAPIClass, SortHLAPI, HLPNNumberHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,185 +73,165 @@ public class NaturalHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
 	private Natural item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NaturalHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI() {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NaturalHLAPI(
-		 NumberConstantHLAPI containerNumberConstant
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NaturalHLAPI(NumberConstantHLAPI containerNumberConstant) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNatural();}
-	
- 		
- 		if(containerNumberConstant!=null)
-			item.setContainerNumberConstant((NumberConstant)containerNumberConstant.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNatural();
+		}
+
+		if (containerNumberConstant != null)
+			item.setContainerNumberConstant((NumberConstant) containerNumberConstant.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NaturalHLAPI(Natural lowLevelAPI){
+	public NaturalHLAPI(Natural lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -260,380 +239,338 @@ public class NaturalHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Natural getContainedItem(){
+	public Natural getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NumberConstant getContainerNumberConstant(){
+	public NumberConstant getContainerNumberConstant() {
 		return item.getContainerNumberConstant();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NumberConstantHLAPI getContainerNumberConstantHLAPI(){
-			if(item.getContainerNumberConstant() == null) return null;
-			return new NumberConstantHLAPI(item.getContainerNumberConstant());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
+			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NumberConstantHLAPI getContainerNumberConstantHLAPI() {
+		if (item.getContainerNumberConstant() == null)
+			return null;
+		return new NumberConstantHLAPI(item.getContainerNumberConstant());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNumberConstant
 	 */
 	public void setContainerNumberConstantHLAPI(
-	
-	NumberConstantHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNumberConstant((NumberConstant)elem.getContainedItem());
-	
+
+			NumberConstantHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNumberConstant((NumberConstant) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NaturalHLAPI item){
+	// equals method
+	public boolean equals(NaturalHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/NumberConstantHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/NumberConstantHLAPI.java
@@ -66,8 +66,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class NumberConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class NumberConstantHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -75,558 +74,446 @@ public class NumberConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private NumberConstant item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberConstantHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberConstantHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
+
+			, java.lang.Long value) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, java.lang.Long value
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberConstantHLAPI(HLPNNumberHLAPI type
+
+			, java.lang.Long value
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberConstant();
+		}
+
+		if (type != null)
+			item.setType((HLPNNumber) type.getContainedItem());
+
+		if (value != null) {
+
+			item.setValue(value);
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberConstantHLAPI(
-		 HLPNNumberHLAPI type
-	
-		, java.lang.Long value
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberConstant();}
-	
- 		
- 		if(type!=null)
-			item.setType((HLPNNumber)type.getContainedItem());
-		
-	
- 		
-			if(value!=null){
-			
-				item.setValue(value);
-			}
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NumberConstantHLAPI(NumberConstant lowLevelAPI){
+	public NumberConstantHLAPI(NumberConstant lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -634,1669 +521,1546 @@ public class NumberConstantHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public NumberConstant getContainedItem(){
+	public NumberConstant getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLPNNumber getType(){
+	public HLPNNumber getType() {
 		return item.getType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Long getValue(){
+	public Long getValue() {
 		return item.getValue();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public HLPNNumberHLAPI getTypeHLAPI(){
-			if(item.getType() == null) return null;
-			HLPNNumber object = item.getType();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLPNNumberHLAPI getTypeHLAPI() {
+		if (item.getType() == null)
+			return null;
+		HLPNNumber object = item.getType();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Type
 	 */
 	public void setTypeHLAPI(
-	
-	HLPNNumberHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setType((HLPNNumber)elem.getContainedItem());
-	
+
+			HLPNNumberHLAPI elem) {
+
+		if (elem != null)
+			item.setType((HLPNNumber) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Value
 	 */
 	public void setValueHLAPI(
-	
-	java.lang.Long elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.Long elem) {
+
+		if (elem != null) {
+
 			item.setValue(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NumberConstantHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(NumberConstantHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/PositiveHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/PositiveHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI;
 
-
-public class PositiveHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
+public class PositiveHLAPI implements HLAPIClass, SortHLAPI, HLPNNumberHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,185 +73,165 @@ public class PositiveHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
 	private Positive item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PositiveHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI() {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PositiveHLAPI(
-		 NumberConstantHLAPI containerNumberConstant
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PositiveHLAPI(NumberConstantHLAPI containerNumberConstant) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPositive();}
-	
- 		
- 		if(containerNumberConstant!=null)
-			item.setContainerNumberConstant((NumberConstant)containerNumberConstant.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPositive();
+		}
+
+		if (containerNumberConstant != null)
+			item.setContainerNumberConstant((NumberConstant) containerNumberConstant.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PositiveHLAPI(Positive lowLevelAPI){
+	public PositiveHLAPI(Positive lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -260,380 +239,338 @@ public class PositiveHLAPI implements HLAPIClass,SortHLAPI,HLPNNumberHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Positive getContainedItem(){
+	public Positive getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NumberConstant getContainerNumberConstant(){
+	public NumberConstant getContainerNumberConstant() {
 		return item.getContainerNumberConstant();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NumberConstantHLAPI getContainerNumberConstantHLAPI(){
-			if(item.getContainerNumberConstant() == null) return null;
-			return new NumberConstantHLAPI(item.getContainerNumberConstant());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
+			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NumberConstantHLAPI getContainerNumberConstantHLAPI() {
+		if (item.getContainerNumberConstant() == null)
+			return null;
+		return new NumberConstantHLAPI(item.getContainerNumberConstant());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNumberConstant
 	 */
 	public void setContainerNumberConstantHLAPI(
-	
-	NumberConstantHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNumberConstant((NumberConstant)elem.getContainedItem());
-	
+
+			NumberConstantHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNumberConstant((NumberConstant) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(PositiveHLAPI item){
+	// equals method
+	public boolean equals(PositiveHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/SubtractionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/hlapi/SubtractionHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class SubtractionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class SubtractionHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class SubtractionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Subtraction item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractionHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractionHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractionHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractionHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractionHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractionHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractionHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractionHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractionHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractionHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractionHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractionHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractionHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractionHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		IntegersFactory fact = IntegersFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtraction();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtraction();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public SubtractionHLAPI(Subtraction lowLevelAPI){
+	public SubtractionHLAPI(Subtraction lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class SubtractionHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Subtraction getContainedItem(){
+	public Subtraction getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(SubtractionHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(SubtractionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/AdditionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/AdditionImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Addition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Addition</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AdditionImpl() {
@@ -81,8 +80,8 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 		return IntegersPackage.Literals.ADDITION;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class AdditionImpl extends IntegerOperatorImpl implements Addition {
 		return retour;
 
 	}
-} //AdditionImpl
+} // AdditionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/DivisionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/DivisionImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Division</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Division</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class DivisionImpl extends IntegerOperatorImpl implements Division {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DivisionImpl() {
@@ -81,8 +80,8 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 		return IntegersPackage.Literals.DIVISION;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class DivisionImpl extends IntegerOperatorImpl implements Division {
 		return retour;
 
 	}
-} //DivisionImpl
+} // DivisionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/GreaterThanImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/GreaterThanImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Greater Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Greater
+ * Than</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected GreaterThanImpl() {
@@ -81,8 +80,8 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 		return IntegersPackage.Literals.GREATER_THAN;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class GreaterThanImpl extends IntegerOperatorImpl implements GreaterThan 
 		return retour;
 
 	}
-} //GreaterThanImpl
+} // GreaterThanImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/GreaterThanOrEqualImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/GreaterThanOrEqualImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Greater Than Or Equal</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Greater
+ * Than Or Equal</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements GreaterThanOrEqual {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected GreaterThanOrEqualImpl() {
@@ -81,8 +80,8 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 		return IntegersPackage.Literals.GREATER_THAN_OR_EQUAL;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class GreaterThanOrEqualImpl extends IntegerOperatorImpl implements Great
 		return retour;
 
 	}
-} //GreaterThanOrEqualImpl
+} // GreaterThanOrEqualImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/HLIntegerImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/HLIntegerImpl.java
@@ -55,9 +55,8 @@ import fr.lip6.move.pnml.pthlpng.integers.IntegersPackage;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>HL Integer</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>HL
+ * Integer</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -65,8 +64,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected HLIntegerImpl() {
@@ -74,8 +73,8 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -88,10 +87,10 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -109,12 +108,12 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -127,22 +126,22 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -151,10 +150,10 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -177,12 +176,12 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -235,4 +234,4 @@ public class HLIntegerImpl extends HLPNNumberImpl implements HLInteger {
 		return retour;
 
 	}
-} //HLIntegerImpl
+} // HLIntegerImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/HLPNNumberImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/HLPNNumberImpl.java
@@ -46,13 +46,13 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>HLPN Number</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>HLPN
+ * Number</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl#getContainerNumberConstant <em>Container Number Constant</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.integers.impl.HLPNNumberImpl#getContainerNumberConstant
+ * <em>Container Number Constant</em>}</li>
  * </ul>
  * </p>
  *
@@ -60,8 +60,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl;
  */
 public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumber {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected HLPNNumberImpl() {
@@ -69,8 +69,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -79,8 +79,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -91,8 +91,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNumberConstant(NumberConstant newContainerNumberConstant,
@@ -103,14 +103,15 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNumberConstant(NumberConstant newContainerNumberConstant) {
 		if (newContainerNumberConstant != eInternalContainer()
-				|| (eContainerFeatureID() != IntegersPackage.HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT && newContainerNumberConstant != null)) {
+				|| (eContainerFeatureID() != IntegersPackage.HLPN_NUMBER__CONTAINER_NUMBER_CONSTANT
+						&& newContainerNumberConstant != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNumberConstant))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -129,8 +130,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -145,8 +146,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -159,8 +160,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -174,8 +175,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -188,8 +189,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -203,8 +204,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -218,8 +219,8 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -238,16 +239,16 @@ public abstract class HLPNNumberImpl extends BuiltInSortImpl implements HLPNNumb
 	public boolean equalSorts(Sort sort) {
 		boolean isEqual = false;
 		if (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {
-			//by default they are the same sort, unless they have been named.
+			// by default they are the same sort, unless they have been named.
 			isEqual = true;
 			if (this.getContainerNamedSort() != null && sort.getContainerNamedSort() != null) {
 				// we test them if they have been explicitly named.
 				isEqual = this.getContainerNamedSort().getName()
 						.equalsIgnoreCase(sort.getContainerNamedSort().getName());
-			}// otherwise, keep the default.
+			} // otherwise, keep the default.
 		}
 		return isEqual;
 
 	}
 
-} //HLPNNumberImpl
+} // HLPNNumberImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/IntegerOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/IntegerOperatorImpl.java
@@ -39,9 +39,8 @@ import fr.lip6.move.pnml.pthlpng.integers.IntegersPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Integer Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Integer
+ * Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -49,8 +48,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl;
  */
 public abstract class IntegerOperatorImpl extends BuiltInOperatorImpl implements IntegerOperator {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected IntegerOperatorImpl() {
@@ -58,8 +57,8 @@ public abstract class IntegerOperatorImpl extends BuiltInOperatorImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -69,4 +68,4 @@ public abstract class IntegerOperatorImpl extends BuiltInOperatorImpl implements
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //IntegerOperatorImpl
+} // IntegerOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/IntegersFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/IntegersFactoryImpl.java
@@ -54,16 +54,16 @@ import fr.lip6.move.pnml.pthlpng.integers.Positive;
 import fr.lip6.move.pnml.pthlpng.integers.Subtraction;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static IntegersFactory init() {
@@ -80,9 +80,9 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public IntegersFactoryImpl() {
@@ -90,8 +90,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +129,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -140,8 +140,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -151,8 +151,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -162,8 +162,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -173,8 +173,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -184,8 +184,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -195,8 +195,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -206,8 +206,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -217,8 +217,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -228,8 +228,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -239,8 +239,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -250,8 +250,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -261,8 +261,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -272,8 +272,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -282,8 +282,8 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -292,4 +292,4 @@ public class IntegersFactoryImpl extends EFactoryImpl implements IntegersFactory
 		return IntegersPackage.eINSTANCE;
 	}
 
-} //IntegersFactoryImpl
+} // IntegersFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/IntegersPackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/IntegersPackageImpl.java
@@ -70,127 +70,127 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass hlpnNumberEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass naturalEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass positiveEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass hlIntegerEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass numberConstantEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass integerOperatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass additionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass subtractionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass multiplicationEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass divisionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass moduloEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass greaterThanEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass greaterThanOrEqualEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass lessThanEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass lessThanOrEqualEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage#eNS_URI
 	 * @see #init()
@@ -201,19 +201,22 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link IntegersPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link IntegersPackage#eINSTANCE} when that
+	 * field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -224,29 +227,37 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 			return (IntegersPackage) EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI);
 
 		// Obtain or create and register package
-		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.get(eNS_URI) : new IntegersPackageImpl());
+		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
+				.get(eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
+						: new IntegersPackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
 		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) : BooleansPackage.eINSTANCE);
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(DotsPackage.eNS_URI) : DotsPackage.eINSTANCE);
+				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI)
+						: BooleansPackage.eINSTANCE);
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI)
+						: DotsPackage.eINSTANCE);
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) : HlcorestructurePackage.eINSTANCE);
+				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(HlcorestructurePackage.eNS_URI)
+						: HlcorestructurePackage.eINSTANCE);
 		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) : MultisetsPackage.eINSTANCE);
+				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI)
+						: MultisetsPackage.eINSTANCE);
 		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) : PartitionsPackage.eINSTANCE);
+				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI)
+						: PartitionsPackage.eINSTANCE);
 		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) : TermsPackage.eINSTANCE);
+				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI)
+						: TermsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theIntegersPackage.createPackageContents();
@@ -283,8 +294,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -293,8 +304,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -303,8 +314,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -313,8 +324,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -323,8 +334,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -333,8 +344,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -343,8 +354,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -353,8 +364,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -363,8 +374,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -373,8 +384,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -383,8 +394,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -393,8 +404,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -403,8 +414,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -413,8 +424,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -423,8 +434,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -433,8 +444,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -443,8 +454,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -453,8 +464,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -463,8 +474,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -473,17 +484,17 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -527,17 +538,17 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -577,14 +588,14 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 		// Initialize classes and features; add operations and parameters
 		initEClass(hlpnNumberEClass, HLPNNumber.class, "HLPNNumber", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getHLPNNumber_ContainerNumberConstant(), this.getNumberConstant(),
-				this.getNumberConstant_Type(), "containerNumberConstant", null, 0, 1, HLPNNumber.class, !IS_TRANSIENT,
-				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
-				!IS_DERIVED, IS_ORDERED);
+		initEReference(getHLPNNumber_ContainerNumberConstant(), this.getNumberConstant(), this.getNumberConstant_Type(),
+				"containerNumberConstant", null, 0, 1, HLPNNumber.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
+				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(naturalEClass, Natural.class, "Natural", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(positiveEClass, Positive.class, "Positive", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(positiveEClass, Positive.class, "Positive", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(hlIntegerEClass, HLInteger.class, "HLInteger", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -601,7 +612,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 		initEClass(integerOperatorEClass, IntegerOperator.class, "IntegerOperator", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(additionEClass, Addition.class, "Addition", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(additionEClass, Addition.class, "Addition", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(subtractionEClass, Subtraction.class, "Subtraction", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -609,7 +621,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 		initEClass(multiplicationEClass, Multiplication.class, "Multiplication", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(divisionEClass, Division.class, "Division", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(divisionEClass, Division.class, "Division", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(moduloEClass, Modulo.class, "Modulo", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
@@ -619,7 +632,8 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 		initEClass(greaterThanOrEqualEClass, GreaterThanOrEqual.class, "GreaterThanOrEqual", !IS_ABSTRACT,
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(lessThanEClass, LessThan.class, "LessThan", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(lessThanEClass, LessThan.class, "LessThan", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(lessThanOrEqualEClass, LessThanOrEqual.class, "LessThanOrEqual", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -641,9 +655,9 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -665,29 +679,24 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/methods/SORT</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for
+	 * <b>http://www.pnml.org/models/methods/SORT</b>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createSORTAnnotations() {
 		String source = "http://www.pnml.org/models/methods/SORT";
-		addAnnotation(
-				hlpnNumberEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;",
-						"documentation",
-						"/**\n * Returns true if this sort and argument sort are actually \n * semantically the same sort, even in two different objects.\n * Ex: two FiniteEnumerations or two Integers.\n * @return true if so. \n * @param sort the sort to which we compare this one. \n */" });
+		addAnnotation(hlpnNumberEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body",
+				"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t    //by default they are the same sort, unless they have been named.\n\t\t  \tisEqual = true;\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}// otherwise, keep the default.\n\t\t}\n\t\treturn isEqual;",
+				"documentation",
+				"/**\n * Returns true if this sort and argument sort are actually \n * semantically the same sort, even in two different objects.\n * Ex: two FiniteEnumerations or two Integers.\n * @return true if so. \n * @param sort the sort to which we compare this one. \n */" });
 	}
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -710,19 +719,15 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createOCLAnnotations() {
 		String source = "http://www.pnml.org/models/OCL";
-		addAnnotation(
-				numberConstantEClass,
-				source,
-				new String[] {
-						"typeType",
-						"self.input->size() = 0 and self.type.oclIsTypeOf(Natural) implies self.value >= 0 and self.type.oclIsTypeOf(Positive) implies self.value > 0" });
+		addAnnotation(numberConstantEClass, source, new String[] { "typeType",
+				"self.input->size() = 0 and self.type.oclIsTypeOf(Natural) implies self.value >= 0 and self.type.oclIsTypeOf(Positive) implies self.value > 0" });
 		addAnnotation(integerOperatorEClass, source, new String[] { "inputType",
 				"self.input->size() = 2 and self.input->forAll{c | c.oclIsKindOf(Number)}" });
 		addAnnotation(additionEClass, source, new String[] { "outputType", "self.output.oclIsKindOf(Number)" });
@@ -732,17 +737,17 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 		addAnnotation(moduloEClass, source, new String[] { "outputType", "self.output.oclIsKindOf(Number)" });
 		addAnnotation(greaterThanEClass, source,
 				new String[] { "outputType", "self.output.oclIsTypeOf(booleans::Bool)" });
-		addAnnotation(greaterThanOrEqualEClass, source, new String[] { "outputType",
-				"self.output.oclIsTypeOf(booleans::Bool)" });
+		addAnnotation(greaterThanOrEqualEClass, source,
+				new String[] { "outputType", "self.output.oclIsTypeOf(booleans::Bool)" });
 		addAnnotation(lessThanEClass, source, new String[] { "outputType", "self.output.oclIsTypeOf(booleans::Bool)" });
-		addAnnotation(lessThanOrEqualEClass, source, new String[] { "outputType",
-				"self.output.oclIsTypeOf(booleans::Bool)" });
+		addAnnotation(lessThanOrEqualEClass, source,
+				new String[] { "outputType", "self.output.oclIsTypeOf(booleans::Bool)" });
 	}
 
 	/**
 	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createEcoreAnnotations() {
@@ -760,4 +765,4 @@ public class IntegersPackageImpl extends EPackageImpl implements IntegersPackage
 		addAnnotation(lessThanOrEqualEClass, source, new String[] { "constraints", "outputType" });
 	}
 
-} //IntegersPackageImpl
+} // IntegersPackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/LessThanImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/LessThanImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Less Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Less
+ * Than</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected LessThanImpl() {
@@ -81,8 +80,8 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 		return IntegersPackage.Literals.LESS_THAN;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class LessThanImpl extends IntegerOperatorImpl implements LessThan {
 		return retour;
 
 	}
-} //LessThanImpl
+} // LessThanImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/LessThanOrEqualImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/LessThanOrEqualImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Less Than Or Equal</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Less
+ * Than Or Equal</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThanOrEqual {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected LessThanOrEqualImpl() {
@@ -81,8 +80,8 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 		return IntegersPackage.Literals.LESS_THAN_OR_EQUAL;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class LessThanOrEqualImpl extends IntegerOperatorImpl implements LessThan
 		return retour;
 
 	}
-} //LessThanOrEqualImpl
+} // LessThanOrEqualImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/ModuloImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/ModuloImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Modulo</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Modulo</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ModuloImpl() {
@@ -81,8 +80,8 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 		return IntegersPackage.Literals.MODULO;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class ModuloImpl extends IntegerOperatorImpl implements Modulo {
 		return retour;
 
 	}
-} //ModuloImpl
+} // ModuloImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/MultiplicationImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/MultiplicationImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Multiplication</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Multiplication</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplication {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected MultiplicationImpl() {
@@ -81,8 +80,8 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 		return IntegersPackage.Literals.MULTIPLICATION;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class MultiplicationImpl extends IntegerOperatorImpl implements Multiplic
 		return retour;
 
 	}
-} //MultiplicationImpl
+} // MultiplicationImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/NaturalImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/NaturalImpl.java
@@ -55,9 +55,8 @@ import fr.lip6.move.pnml.pthlpng.integers.Natural;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Natural</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Natural</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -65,8 +64,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class NaturalImpl extends HLPNNumberImpl implements Natural {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NaturalImpl() {
@@ -74,8 +73,8 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -88,10 +87,10 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -109,12 +108,12 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -127,22 +126,22 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -151,10 +150,10 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -177,12 +176,12 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -235,4 +234,4 @@ public class NaturalImpl extends HLPNNumberImpl implements Natural {
 		return retour;
 
 	}
-} //NaturalImpl
+} // NaturalImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/NumberConstantImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/NumberConstantImpl.java
@@ -73,14 +73,15 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Number Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Number
+ * Constant</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl#getType <em>Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl#getValue <em>Value</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl#getType
+ * <em>Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl#getValue
+ * <em>Value</em>}</li>
  * </ul>
  * </p>
  *
@@ -88,9 +89,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class NumberConstantImpl extends BuiltInConstantImpl implements NumberConstant {
 	/**
-	 * The cached value of the '{@link #getType() <em>Type</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getType() <em>Type</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getType()
 	 * @generated
 	 * @ordered
@@ -98,9 +99,9 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	protected HLPNNumber type;
 
 	/**
-	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getValue() <em>Value</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -108,9 +109,9 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	protected static final Long VALUE_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getValue() <em>Value</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getValue()
 	 * @generated
 	 * @ordered
@@ -118,8 +119,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	protected Long value = VALUE_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NumberConstantImpl() {
@@ -127,8 +128,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -137,8 +138,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -147,8 +148,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetType(HLPNNumber newType, NotificationChain msgs) {
@@ -166,8 +167,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -189,8 +190,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -199,8 +200,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -213,8 +214,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -222,16 +223,16 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		switch (featureID) {
 		case IntegersPackage.NUMBER_CONSTANT__TYPE:
 			if (type != null)
-				msgs = ((InternalEObject) type).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- IntegersPackage.NUMBER_CONSTANT__TYPE, null, msgs);
+				msgs = ((InternalEObject) type).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - IntegersPackage.NUMBER_CONSTANT__TYPE, null, msgs);
 			return basicSetType((HLPNNumber) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -244,8 +245,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -260,8 +261,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -278,8 +279,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -296,8 +297,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -312,8 +313,8 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -328,24 +329,24 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		return result.toString();
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 1
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 1
+		// sons 2
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -363,7 +364,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getValue() != null) {
 			sb.append(" value");
@@ -376,7 +377,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -431,20 +432,20 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//1
-		//2
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 1
+		// 2
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("value")) != null) {
 			try {
@@ -454,7 +455,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -767,7 +768,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 			if (type.getLocalName().equals("natural")) {
 				Natural item;
@@ -777,7 +778,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 				item.setContainerNumberConstant(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("positive")) {
 				Positive item;
@@ -787,7 +788,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 				item.setContainerNumberConstant(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("integer")) {
 				HLInteger item;
@@ -797,30 +798,30 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 				item.setContainerNumberConstant(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 1
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 1
+		// sons 2
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -843,7 +844,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getValue() != null) {
 			sb.append(" value");
@@ -856,7 +857,7 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -974,4 +975,4 @@ public class NumberConstantImpl extends BuiltInConstantImpl implements NumberCon
 		return retour;
 
 	}
-} //NumberConstantImpl
+} // NumberConstantImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/NumberConstantImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/NumberConstantImpl.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/PositiveImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/PositiveImpl.java
@@ -55,9 +55,8 @@ import fr.lip6.move.pnml.pthlpng.integers.Positive;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Positive</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Positive</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -65,8 +64,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class PositiveImpl extends HLPNNumberImpl implements Positive {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PositiveImpl() {
@@ -74,8 +73,8 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -88,10 +87,10 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -109,12 +108,12 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -127,22 +126,22 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -151,10 +150,10 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -177,12 +176,12 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -235,4 +234,4 @@ public class PositiveImpl extends HLPNNumberImpl implements Positive {
 		return retour;
 
 	}
-} //PositiveImpl
+} // PositiveImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/SubtractionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/impl/SubtractionImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Subtraction</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Subtraction</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected SubtractionImpl() {
@@ -81,8 +80,8 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 		return IntegersPackage.Literals.SUBTRACTION;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		IntegersFactory fact = IntegersFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -502,30 +501,30 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -548,13 +547,13 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -656,4 +655,4 @@ public class SubtractionImpl extends IntegerOperatorImpl implements Subtraction 
 		return retour;
 
 	}
-} //SubtractionImpl
+} // SubtractionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/util/IntegersAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/util/IntegersAdapterFactory.java
@@ -60,26 +60,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage
  * @generated
  */
 public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static IntegersPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public IntegersAdapterFactory() {
@@ -89,10 +88,11 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -108,9 +108,9 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected IntegersSwitch<Adapter> modelSwitch = new IntegersSwitch<Adapter>() {
@@ -226,9 +226,9 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -239,11 +239,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber <em>HLPN Number</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLPNNumber <em>HLPN Number</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.HLPNNumber
 	 * @generated
@@ -253,11 +254,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Natural <em>Natural</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Natural <em>Natural</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Natural
 	 * @generated
@@ -267,11 +269,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Positive <em>Positive</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Positive <em>Positive</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Positive
 	 * @generated
@@ -281,11 +284,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.HLInteger <em>HL Integer</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.HLInteger <em>HL Integer</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.HLInteger
 	 * @generated
@@ -295,11 +299,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant <em>Number Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.NumberConstant <em>Number
+	 * Constant</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.NumberConstant
 	 * @generated
@@ -309,11 +314,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.IntegerOperator <em>Integer Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.IntegerOperator <em>Integer
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.IntegerOperator
 	 * @generated
@@ -323,11 +329,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Addition <em>Addition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Addition <em>Addition</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Addition
 	 * @generated
@@ -337,11 +344,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Subtraction <em>Subtraction</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Subtraction
+	 * <em>Subtraction</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Subtraction
 	 * @generated
@@ -351,11 +359,13 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Multiplication <em>Multiplication</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Multiplication
+	 * <em>Multiplication</em>}'. <!-- begin-user-doc --> This default
+	 * implementation returns null so that we can easily ignore cases; it's useful
+	 * to ignore a case when inheritance will catch all the cases anyway. <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Multiplication
 	 * @generated
@@ -365,11 +375,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Division <em>Division</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Division <em>Division</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Division
 	 * @generated
@@ -379,11 +390,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.Modulo <em>Modulo</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.Modulo <em>Modulo</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.Modulo
 	 * @generated
@@ -393,11 +405,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThan <em>Greater Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThan <em>Greater
+	 * Than</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.GreaterThan
 	 * @generated
@@ -407,11 +420,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual <em>Greater Than Or Equal</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual <em>Greater
+	 * Than Or Equal</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual
 	 * @generated
@@ -421,11 +435,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.LessThan <em>Less Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.LessThan <em>Less Than</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.LessThan
 	 * @generated
@@ -435,11 +450,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual <em>Less Than Or Equal</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual <em>Less Than Or
+	 * Equal</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual
 	 * @generated
@@ -449,11 +465,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort
 	 * @generated
@@ -463,11 +480,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInSort
 	 * @generated
@@ -477,11 +495,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -491,11 +510,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -505,11 +525,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In
+	 * Constant</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant
 	 * @generated
@@ -519,11 +540,12 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator
 	 * @generated
@@ -533,10 +555,9 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -544,4 +565,4 @@ public class IntegersAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //IntegersAdapterFactory
+} // IntegersAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/util/IntegersSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/util/IntegersSwitch.java
@@ -59,31 +59,28 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage
  * @generated
  */
 public class IntegersSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static IntegersPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public IntegersSwitch() {
@@ -93,9 +90,9 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -106,9 +103,10 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -332,13 +330,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>HLPN Number</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>HLPN
+	 * Number</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>HLPN Number</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>HLPN
+	 *         Number</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -347,13 +345,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Natural</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Natural</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Natural</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Natural</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -362,13 +360,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Positive</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Positive</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Positive</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Positive</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -377,13 +376,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>HL Integer</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>HL
+	 * Integer</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>HL Integer</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>HL
+	 *         Integer</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -392,13 +391,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Number Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Number
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Number Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Number
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -407,13 +406,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Integer Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Integer
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Integer Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Integer
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -422,13 +421,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Addition</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Addition</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Addition</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Addition</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -437,13 +437,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Subtraction</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Subtraction</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Subtraction</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Subtraction</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -452,13 +453,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Multiplication</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Multiplication</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Multiplication</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Multiplication</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -467,13 +469,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Division</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Division</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Division</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Division</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -482,13 +485,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Modulo</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Modulo</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Modulo</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Modulo</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -497,13 +500,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Greater Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Greater
+	 * Than</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Greater Than</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Greater
+	 *         Than</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -512,13 +515,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Greater Than Or Equal</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Greater
+	 * Than Or Equal</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Greater Than Or Equal</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Greater
+	 *         Than Or Equal</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -527,13 +531,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Less Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Less
+	 * Than</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Less Than</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Less
+	 *         Than</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -542,13 +546,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Less Than Or Equal</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Less
+	 * Than Or Equal</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Less Than Or Equal</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Less
+	 *         Than Or Equal</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -557,13 +562,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Sort</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -572,13 +577,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -587,13 +592,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Term</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Term</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Term</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Term</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -602,13 +607,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Operator</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -617,13 +623,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -632,13 +638,13 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -647,13 +653,14 @@ public class IntegersSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -662,4 +669,4 @@ public class IntegersSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //IntegersSwitch
+} // IntegersSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/util/IntegersValidator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/integers/util/IntegersValidator.java
@@ -58,25 +58,25 @@ import fr.lip6.move.pnml.pthlpng.integers.Subtraction;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Validator</b> for the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Validator</b> for the model. <!-- end-user-doc
+ * -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.integers.IntegersPackage
  * @generated
  */
 public class IntegersValidator extends EObjectValidator {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final IntegersValidator INSTANCE = new IntegersValidator();
 
 	/**
-	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource() source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode() codes} from this package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource()
+	 * source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode()
+	 * codes} from this package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.common.util.Diagnostic#getSource()
 	 * @see org.eclipse.emf.common.util.Diagnostic#getCode()
 	 * @generated
@@ -84,33 +84,35 @@ public class IntegersValidator extends EObjectValidator {
 	public static final String DIAGNOSTIC_SOURCE = "fr.lip6.move.pnml.pthlpng.integers";
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 0;
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
-	 * <!-- begin-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants in a derived class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static final int DIAGNOSTIC_CODE_COUNT = GENERATED_DIAGNOSTIC_CODE_COUNT;
 
 	/**
-	 * The cached base package validator.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached base package validator. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	protected TermsValidator termsValidator;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public IntegersValidator() {
@@ -119,9 +121,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the package of this validator switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package of this validator switch. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -131,12 +133,13 @@ public class IntegersValidator extends EObjectValidator {
 
 	/**
 	 * Calls <code>validateXXX</code> for the corresponding classifier of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		switch (classifierID) {
 		case IntegersPackage.HLPN_NUMBER:
 			return validateHLPNNumber((HLPNNumber) value, diagnostics, context);
@@ -174,8 +177,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateHLPNNumber(HLPNNumber hlpnNumber, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -183,8 +186,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNatural(Natural natural, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -192,8 +195,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePositive(Positive positive, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -201,8 +204,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateHLInteger(HLInteger hlInteger, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -210,8 +213,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNumberConstant(NumberConstant numberConstant, DiagnosticChain diagnostics,
@@ -241,9 +244,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the typeType constraint of '<em>Number Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the typeType constraint of '<em>Number Constant</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNumberConstant_typeType(NumberConstant numberConstant, DiagnosticChain diagnostics,
@@ -254,10 +257,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "typeType", getObjectLabel(numberConstant, context) },
-						new Object[] { numberConstant }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "typeType", getObjectLabel(numberConstant, context) },
+								new Object[] { numberConstant }, context));
 			}
 			return false;
 		}
@@ -265,8 +268,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateIntegerOperator(IntegerOperator integerOperator, DiagnosticChain diagnostics,
@@ -296,9 +299,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputType constraint of '<em>Integer Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputType constraint of '<em>Integer Operator</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateIntegerOperator_inputType(IntegerOperator integerOperator, DiagnosticChain diagnostics,
@@ -309,10 +312,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputType", getObjectLabel(integerOperator, context) },
-						new Object[] { integerOperator }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputType", getObjectLabel(integerOperator, context) },
+								new Object[] { integerOperator }, context));
 			}
 			return false;
 		}
@@ -320,8 +323,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAddition(Addition addition, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -352,9 +355,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Addition</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Addition</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAddition_outputType(Addition addition, DiagnosticChain diagnostics,
@@ -365,10 +368,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(addition, context) }, new Object[] { addition },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(addition, context) },
+								new Object[] { addition }, context));
 			}
 			return false;
 		}
@@ -376,11 +379,12 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateSubtraction(Subtraction subtraction, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateSubtraction(Subtraction subtraction, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		if (!validate_NoCircularContainment(subtraction, diagnostics, context))
 			return false;
 		boolean result = validate_EveryMultiplicityConforms(subtraction, diagnostics, context);
@@ -408,9 +412,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Subtraction</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Subtraction</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateSubtraction_outputType(Subtraction subtraction, DiagnosticChain diagnostics,
@@ -421,10 +425,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(subtraction, context) },
-						new Object[] { subtraction }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(subtraction, context) },
+								new Object[] { subtraction }, context));
 			}
 			return false;
 		}
@@ -432,8 +436,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateMultiplication(Multiplication multiplication, DiagnosticChain diagnostics,
@@ -465,9 +469,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Multiplication</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Multiplication</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateMultiplication_outputType(Multiplication multiplication, DiagnosticChain diagnostics,
@@ -478,10 +482,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(multiplication, context) },
-						new Object[] { multiplication }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(multiplication, context) },
+								new Object[] { multiplication }, context));
 			}
 			return false;
 		}
@@ -489,8 +493,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateDivision(Division division, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -521,9 +525,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Division</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Division</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateDivision_outputType(Division division, DiagnosticChain diagnostics,
@@ -534,10 +538,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(division, context) }, new Object[] { division },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(division, context) },
+								new Object[] { division }, context));
 			}
 			return false;
 		}
@@ -545,8 +549,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateModulo(Modulo modulo, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -577,9 +581,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Modulo</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Modulo</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateModulo_outputType(Modulo modulo, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -589,9 +593,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic", new Object[] { "outputType",
-								getObjectLabel(modulo, context) }, new Object[] { modulo }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(modulo, context) }, new Object[] { modulo },
+								context));
 			}
 			return false;
 		}
@@ -599,11 +604,12 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateGreaterThan(GreaterThan greaterThan, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateGreaterThan(GreaterThan greaterThan, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		if (!validate_NoCircularContainment(greaterThan, diagnostics, context))
 			return false;
 		boolean result = validate_EveryMultiplicityConforms(greaterThan, diagnostics, context);
@@ -631,9 +637,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Greater Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Greater Than</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateGreaterThan_outputType(GreaterThan greaterThan, DiagnosticChain diagnostics,
@@ -644,10 +650,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(greaterThan, context) },
-						new Object[] { greaterThan }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(greaterThan, context) },
+								new Object[] { greaterThan }, context));
 			}
 			return false;
 		}
@@ -655,8 +661,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateGreaterThanOrEqual(GreaterThanOrEqual greaterThanOrEqual, DiagnosticChain diagnostics,
@@ -688,9 +694,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Greater Than Or Equal</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Greater Than Or Equal</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateGreaterThanOrEqual_outputType(GreaterThanOrEqual greaterThanOrEqual,
@@ -701,10 +707,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(greaterThanOrEqual, context) },
-						new Object[] { greaterThanOrEqual }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(greaterThanOrEqual, context) },
+								new Object[] { greaterThanOrEqual }, context));
 			}
 			return false;
 		}
@@ -712,8 +718,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLessThan(LessThan lessThan, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -744,9 +750,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Less Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Less Than</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLessThan_outputType(LessThan lessThan, DiagnosticChain diagnostics,
@@ -757,10 +763,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(lessThan, context) }, new Object[] { lessThan },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(lessThan, context) },
+								new Object[] { lessThan }, context));
 			}
 			return false;
 		}
@@ -768,8 +774,8 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLessThanOrEqual(LessThanOrEqual lessThanOrEqual, DiagnosticChain diagnostics,
@@ -801,9 +807,9 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the outputType constraint of '<em>Less Than Or Equal</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the outputType constraint of '<em>Less Than Or Equal</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLessThanOrEqual_outputType(LessThanOrEqual lessThanOrEqual, DiagnosticChain diagnostics,
@@ -814,10 +820,10 @@ public class IntegersValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "outputType", getObjectLabel(lessThanOrEqual, context) },
-						new Object[] { lessThanOrEqual }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "outputType", getObjectLabel(lessThanOrEqual, context) },
+								new Object[] { lessThanOrEqual }, context));
 			}
 			return false;
 		}
@@ -825,17 +831,18 @@ public class IntegersValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the resource locator that will be used to fetch messages for this validator's diagnostics.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the resource locator that will be used to fetch messages for this
+	 * validator's diagnostics. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public ResourceLocator getResourceLocator() {
 		// TODO
-		// Specialize this to return a resource locator for messages specific to this validator.
+		// Specialize this to return a resource locator for messages specific to this
+		// validator.
 		// Ensure that you remove @generated or mark it @generated NOT
 		return super.getResourceLocator();
 	}
 
-} //IntegersValidator
+} // IntegersValidator

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Add.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Add.java
@@ -49,11 +49,11 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getAdd()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputType='self.input->size() >= 2 and self.input->forAll{c |
+ *        inputType='self.input-&gt;size() &gt;= 2 and self.input-&gt;forAll{c |
  *        c.oclIsKindOf(terms::MultisetSort)} '"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputType'" annotation="http://www.pnml.org/models/ToPNML
- *        tag='add' kind='son'"
+ *        tag='add' kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Add extends MultisetOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Add.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Add.java
@@ -43,15 +43,17 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Add</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Add</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getAdd()
- * @model annotation="http://www.pnml.org/models/OCL inputType='self.input->size() >= 2 and self.input->forAll{c | c.oclIsKindOf(terms::MultisetSort)} '"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputType'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='add' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputType='self.input->size() >= 2 and self.input->forAll{c |
+ *        c.oclIsKindOf(terms::MultisetSort)} '"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputType'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='add' kind='son'"
  * @generated
  */
 public interface Add extends MultisetOperator {
@@ -66,8 +68,8 @@ public interface Add extends MultisetOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/All.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/All.java
@@ -57,10 +57,11 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getAll()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputOutputTypes='self.input->size() = 0'"
+ *        inputOutputTypes='self.input-&gt;size() = 0'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='all' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface All extends MultisetOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/All.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/All.java
@@ -44,47 +44,53 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 import fr.lip6.move.pnml.pthlpng.terms.Sort;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>All</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>All</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort <em>Refsort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort
+ * <em>Refsort</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getAll()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.input->size() = 0'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.input->size() = 0'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='all' kind='son'"
  * @generated
  */
 public interface All extends MultisetOperator {
 	/**
-	 * Returns the value of the '<em><b>Refsort</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container All</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Refsort</b></em>' containment reference. It
+	 * is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container
+	 * All</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Refsort</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Refsort</em>' containment reference.
 	 * @see #setRefsort(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getAll_Refsort()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll
-	 * @model opposite="containerAll" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerAll" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Sort getRefsort();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort <em>Refsort</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort <em>Refsort</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Refsort</em>' containment reference.
 	 * @see #getRefsort()
 	 * @generated
@@ -101,8 +107,8 @@ public interface All extends MultisetOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Cardinality.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Cardinality.java
@@ -54,7 +54,7 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='cardinality'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Cardinality extends BuiltInOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Cardinality.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Cardinality.java
@@ -43,15 +43,18 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Cardinality</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Cardinality</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getCardinality()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsTypeOf(integers::Natural) and self.input.oclIsKindOf(terms::MultisetSort)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='cardinality' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsTypeOf(integers::Natural) and
+ *        self.input.oclIsKindOf(terms::MultisetSort)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='cardinality'
+ *        kind='son'"
  * @generated
  */
 public interface Cardinality extends BuiltInOperator {
@@ -66,8 +69,8 @@ public interface Cardinality extends BuiltInOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/CardinalityOf.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/CardinalityOf.java
@@ -43,15 +43,18 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Cardinality Of</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Cardinality Of</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getCardinalityOf()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsTypeOf(integers::Natural) and self.input.size() = 2'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='cardinalityof' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsTypeOf(integers::Natural) and
+ *        self.input.size() = 2'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='cardinalityof'
+ *        kind='son'"
  * @generated
  */
 public interface CardinalityOf extends BuiltInOperator {
@@ -66,8 +69,8 @@ public interface CardinalityOf extends BuiltInOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/CardinalityOf.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/CardinalityOf.java
@@ -54,7 +54,7 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='cardinalityof'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface CardinalityOf extends BuiltInOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Contains.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Contains.java
@@ -43,15 +43,19 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Contains</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Contains</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getContains()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and self.input->size() = 2 and self.input->forAll {c | c.oclIsKindOf(terms::MultisetSort)}'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='contains' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and
+ *        self.input->size() = 2 and self.input->forAll {c |
+ *        c.oclIsKindOf(terms::MultisetSort)}'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='contains'
+ *        kind='son'"
  * @generated
  */
 public interface Contains extends BuiltInOperator {
@@ -66,8 +70,8 @@ public interface Contains extends BuiltInOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Contains.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Contains.java
@@ -50,12 +50,12 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getContains()
  * @model annotation="http://www.pnml.org/models/OCL
  *        inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and
- *        self.input->size() = 2 and self.input->forAll {c |
+ *        self.input-&gt;size() = 2 and self.input-&gt;forAll {c |
  *        c.oclIsKindOf(terms::MultisetSort)}'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='contains'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Contains extends BuiltInOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Empty.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Empty.java
@@ -56,10 +56,11 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getEmpty()
- * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input->size
- *        = 0'" annotation="http://www.eclipse.org/emf/2002/Ecore
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        InputSize='self.input-&gt;size = 0'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
- *        tag='empty' kind='son'"
+ *        tag='empty' kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Empty extends MultisetOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Empty.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Empty.java
@@ -44,33 +44,36 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 import fr.lip6.move.pnml.pthlpng.terms.Sort;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Empty</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Empty</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort <em>Refsort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort
+ * <em>Refsort</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getEmpty()
- * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input->size = 0'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='InputSize'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='empty' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL InputSize='self.input->size
+ *        = 0'" annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='InputSize'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='empty' kind='son'"
  * @generated
  */
 public interface Empty extends MultisetOperator {
 	/**
-	 * Returns the value of the '<em><b>Refsort</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container Empty</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Refsort</b></em>' containment reference. It
+	 * is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container
+	 * Empty</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Refsort</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Refsort</em>' containment reference.
 	 * @see #setRefsort(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getEmpty_Refsort()
@@ -82,9 +85,11 @@ public interface Empty extends MultisetOperator {
 	Sort getRefsort();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort <em>Refsort</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort
+	 * <em>Refsort</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Refsort</em>' containment reference.
 	 * @see #getRefsort()
 	 * @generated
@@ -101,8 +106,8 @@ public interface Empty extends MultisetOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/MultisetsFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/MultisetsFactory.java
@@ -34,110 +34,109 @@ package fr.lip6.move.pnml.pthlpng.multisets;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage
  * @generated
  */
 public interface MultisetsFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	MultisetsFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Cardinality</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Cardinality</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Cardinality</em>'.
 	 * @generated
 	 */
 	Cardinality createCardinality();
 
 	/**
-	 * Returns a new object of class '<em>Contains</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Contains</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Contains</em>'.
 	 * @generated
 	 */
 	Contains createContains();
 
 	/**
-	 * Returns a new object of class '<em>Cardinality Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Cardinality Of</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Cardinality Of</em>'.
 	 * @generated
 	 */
 	CardinalityOf createCardinalityOf();
 
 	/**
-	 * Returns a new object of class '<em>Add</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Add</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Add</em>'.
 	 * @generated
 	 */
 	Add createAdd();
 
 	/**
-	 * Returns a new object of class '<em>All</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>All</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>All</em>'.
 	 * @generated
 	 */
 	All createAll();
 
 	/**
-	 * Returns a new object of class '<em>Empty</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Empty</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Empty</em>'.
 	 * @generated
 	 */
 	Empty createEmpty();
 
 	/**
-	 * Returns a new object of class '<em>Number Of</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Number Of</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Number Of</em>'.
 	 * @generated
 	 */
 	NumberOf createNumberOf();
 
 	/**
-	 * Returns a new object of class '<em>Subtract</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Subtract</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Subtract</em>'.
 	 * @generated
 	 */
 	Subtract createSubtract();
 
 	/**
-	 * Returns a new object of class '<em>Scalar Product</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Scalar Product</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Scalar Product</em>'.
 	 * @generated
 	 */
 	ScalarProduct createScalarProduct();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	MultisetsPackage getMultisetsPackage();
 
-} //MultisetsFactory
+} // MultisetsFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/MultisetsPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/MultisetsPackage.java
@@ -38,57 +38,55 @@ import org.eclipse.emf.ecore.EReference;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsFactory
  * @model kind="package"
  * @generated
  */
 public interface MultisetsPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "multisets";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///pthlpng.multisets.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "multisets";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	MultisetsPackage eINSTANCE = fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl <em>Cardinality</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl
+	 * <em>Cardinality</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getCardinality()
 	 * @generated
@@ -96,63 +94,63 @@ public interface MultisetsPackage extends EPackage {
 	int CARDINALITY = 0;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__SORT = TermsPackage.BUILT_IN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__CONTAINER_CONDITION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -160,44 +158,45 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__SUBTERM = TermsPackage.BUILT_IN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__OUTPUT = TermsPackage.BUILT_IN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY__INPUT = TermsPackage.BUILT_IN_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Cardinality</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Cardinality</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_FEATURE_COUNT = TermsPackage.BUILT_IN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl <em>Contains</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl
+	 * <em>Contains</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getContains()
 	 * @generated
@@ -205,63 +204,63 @@ public interface MultisetsPackage extends EPackage {
 	int CONTAINS = 1;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__SORT = TermsPackage.BUILT_IN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__CONTAINER_CONDITION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -269,44 +268,46 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__SUBTERM = TermsPackage.BUILT_IN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__OUTPUT = TermsPackage.BUILT_IN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS__INPUT = TermsPackage.BUILT_IN_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Contains</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Contains</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CONTAINS_FEATURE_COUNT = TermsPackage.BUILT_IN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl <em>Cardinality Of</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl
+	 * <em>Cardinality Of</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getCardinalityOf()
 	 * @generated
@@ -314,63 +315,63 @@ public interface MultisetsPackage extends EPackage {
 	int CARDINALITY_OF = 2;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__SORT = TermsPackage.BUILT_IN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__CONTAINER_CONDITION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -378,26 +379,26 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__SUBTERM = TermsPackage.BUILT_IN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF__OUTPUT = TermsPackage.BUILT_IN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -405,17 +406,18 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Cardinality Of</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int CARDINALITY_OF_FEATURE_COUNT = TermsPackage.BUILT_IN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl <em>Add</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl <em>Add</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getAdd()
 	 * @generated
@@ -423,63 +425,63 @@ public interface MultisetsPackage extends EPackage {
 	int ADD = 3;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__SORT = TermsPackage.MULTISET_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__CONTAINER_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__CONTAINER_NAMED_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__CONTAINER_HL_MARKING = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__CONTAINER_CONDITION = TermsPackage.MULTISET_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__CONTAINER_HL_ANNOTATION = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -487,44 +489,45 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__SUBTERM = TermsPackage.MULTISET_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__OUTPUT = TermsPackage.MULTISET_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD__INPUT = TermsPackage.MULTISET_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Add</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Add</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ADD_FEATURE_COUNT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl <em>All</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl <em>All</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getAll()
 	 * @generated
@@ -532,63 +535,63 @@ public interface MultisetsPackage extends EPackage {
 	int ALL = 4;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__SORT = TermsPackage.MULTISET_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__CONTAINER_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__CONTAINER_NAMED_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__CONTAINER_HL_MARKING = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__CONTAINER_CONDITION = TermsPackage.MULTISET_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__CONTAINER_HL_ANNOTATION = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -596,53 +599,54 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__SUBTERM = TermsPackage.MULTISET_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__OUTPUT = TermsPackage.MULTISET_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__INPUT = TermsPackage.MULTISET_OPERATOR__INPUT;
 
 	/**
-	 * The feature id for the '<em><b>Refsort</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Refsort</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL__REFSORT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>All</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>All</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int ALL_FEATURE_COUNT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl <em>Empty</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl <em>Empty</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getEmpty()
 	 * @generated
@@ -650,63 +654,63 @@ public interface MultisetsPackage extends EPackage {
 	int EMPTY = 5;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__SORT = TermsPackage.MULTISET_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__CONTAINER_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__CONTAINER_NAMED_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__CONTAINER_HL_MARKING = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__CONTAINER_CONDITION = TermsPackage.MULTISET_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__CONTAINER_HL_ANNOTATION = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -714,53 +718,54 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__SUBTERM = TermsPackage.MULTISET_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__OUTPUT = TermsPackage.MULTISET_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__INPUT = TermsPackage.MULTISET_OPERATOR__INPUT;
 
 	/**
-	 * The feature id for the '<em><b>Refsort</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Refsort</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY__REFSORT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Empty</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Empty</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int EMPTY_FEATURE_COUNT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl <em>Number Of</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl <em>Number
+	 * Of</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getNumberOf()
 	 * @generated
@@ -768,63 +773,63 @@ public interface MultisetsPackage extends EPackage {
 	int NUMBER_OF = 6;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__SORT = TermsPackage.MULTISET_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__CONTAINER_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__CONTAINER_NAMED_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__CONTAINER_HL_MARKING = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__CONTAINER_CONDITION = TermsPackage.MULTISET_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__CONTAINER_HL_ANNOTATION = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -832,44 +837,45 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__SUBTERM = TermsPackage.MULTISET_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__OUTPUT = TermsPackage.MULTISET_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF__INPUT = TermsPackage.MULTISET_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Number Of</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Number Of</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NUMBER_OF_FEATURE_COUNT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl <em>Subtract</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl
+	 * <em>Subtract</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getSubtract()
 	 * @generated
@@ -877,63 +883,63 @@ public interface MultisetsPackage extends EPackage {
 	int SUBTRACT = 7;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__SORT = TermsPackage.MULTISET_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__CONTAINER_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__CONTAINER_NAMED_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__CONTAINER_HL_MARKING = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__CONTAINER_CONDITION = TermsPackage.MULTISET_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__CONTAINER_HL_ANNOTATION = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -941,44 +947,45 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__SUBTERM = TermsPackage.MULTISET_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__OUTPUT = TermsPackage.MULTISET_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT__INPUT = TermsPackage.MULTISET_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Subtract</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Subtract</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SUBTRACT_FEATURE_COUNT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl <em>Scalar Product</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl <em>Scalar
+	 * Product</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getScalarProduct()
 	 * @generated
@@ -986,63 +993,63 @@ public interface MultisetsPackage extends EPackage {
 	int SCALAR_PRODUCT = 8;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__SORT = TermsPackage.MULTISET_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__CONTAINER_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__CONTAINER_NAMED_OPERATOR = TermsPackage.MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__CONTAINER_HL_MARKING = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__CONTAINER_CONDITION = TermsPackage.MULTISET_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__CONTAINER_HL_ANNOTATION = TermsPackage.MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1050,26 +1057,26 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__SUBTERM = TermsPackage.MULTISET_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT__OUTPUT = TermsPackage.MULTISET_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1077,17 +1084,18 @@ public interface MultisetsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Scalar Product</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SCALAR_PRODUCT_FEATURE_COUNT = TermsPackage.MULTISET_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.Cardinality <em>Cardinality</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Cardinality
+	 * <em>Cardinality</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Cardinality</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Cardinality
 	 * @generated
@@ -1095,9 +1103,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getCardinality();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.Contains <em>Contains</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Contains <em>Contains</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Contains</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Contains
 	 * @generated
@@ -1105,9 +1114,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getContains();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf <em>Cardinality Of</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf <em>Cardinality
+	 * Of</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Cardinality Of</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf
 	 * @generated
@@ -1115,9 +1125,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getCardinalityOf();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.Add <em>Add</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Add <em>Add</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Add</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Add
 	 * @generated
@@ -1125,9 +1136,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getAdd();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.All <em>All</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.All <em>All</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>All</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.All
 	 * @generated
@@ -1135,9 +1147,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getAll();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort <em>Refsort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort
+	 * <em>Refsort</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Refsort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort()
 	 * @see #getAll()
@@ -1146,9 +1159,10 @@ public interface MultisetsPackage extends EPackage {
 	EReference getAll_Refsort();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty <em>Empty</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty <em>Empty</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Empty</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Empty
 	 * @generated
@@ -1156,9 +1170,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getEmpty();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort <em>Refsort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort
+	 * <em>Refsort</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Refsort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort()
 	 * @see #getEmpty()
@@ -1167,9 +1182,10 @@ public interface MultisetsPackage extends EPackage {
 	EReference getEmpty_Refsort();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.NumberOf <em>Number Of</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.NumberOf <em>Number Of</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Number Of</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.NumberOf
 	 * @generated
@@ -1177,9 +1193,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getNumberOf();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.Subtract <em>Subtract</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Subtract <em>Subtract</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Subtract</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Subtract
 	 * @generated
@@ -1187,9 +1204,10 @@ public interface MultisetsPackage extends EPackage {
 	EClass getSubtract();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct <em>Scalar Product</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct <em>Scalar
+	 * Product</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Scalar Product</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct
 	 * @generated
@@ -1197,31 +1215,32 @@ public interface MultisetsPackage extends EPackage {
 	EClass getScalarProduct();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	MultisetsFactory getMultisetsFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl <em>Cardinality</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl
+		 * <em>Cardinality</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getCardinality()
 		 * @generated
@@ -1229,9 +1248,10 @@ public interface MultisetsPackage extends EPackage {
 		EClass CARDINALITY = eINSTANCE.getCardinality();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl <em>Contains</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl
+		 * <em>Contains</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getContains()
 		 * @generated
@@ -1239,9 +1259,11 @@ public interface MultisetsPackage extends EPackage {
 		EClass CONTAINS = eINSTANCE.getContains();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl <em>Cardinality Of</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl
+		 * <em>Cardinality Of</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getCardinalityOf()
 		 * @generated
@@ -1249,9 +1271,10 @@ public interface MultisetsPackage extends EPackage {
 		EClass CARDINALITY_OF = eINSTANCE.getCardinalityOf();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl <em>Add</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl <em>Add</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getAdd()
 		 * @generated
@@ -1259,9 +1282,10 @@ public interface MultisetsPackage extends EPackage {
 		EClass ADD = eINSTANCE.getAdd();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl <em>All</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl <em>All</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getAll()
 		 * @generated
@@ -1269,17 +1293,18 @@ public interface MultisetsPackage extends EPackage {
 		EClass ALL = eINSTANCE.getAll();
 
 		/**
-		 * The meta object literal for the '<em><b>Refsort</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Refsort</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference ALL__REFSORT = eINSTANCE.getAll_Refsort();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl <em>Empty</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl <em>Empty</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getEmpty()
 		 * @generated
@@ -1287,17 +1312,18 @@ public interface MultisetsPackage extends EPackage {
 		EClass EMPTY = eINSTANCE.getEmpty();
 
 		/**
-		 * The meta object literal for the '<em><b>Refsort</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Refsort</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference EMPTY__REFSORT = eINSTANCE.getEmpty_Refsort();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl <em>Number Of</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl <em>Number
+		 * Of</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getNumberOf()
 		 * @generated
@@ -1305,9 +1331,10 @@ public interface MultisetsPackage extends EPackage {
 		EClass NUMBER_OF = eINSTANCE.getNumberOf();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl <em>Subtract</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl
+		 * <em>Subtract</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getSubtract()
 		 * @generated
@@ -1315,9 +1342,10 @@ public interface MultisetsPackage extends EPackage {
 		EClass SUBTRACT = eINSTANCE.getSubtract();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl <em>Scalar Product</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl <em>Scalar
+		 * Product</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl
 		 * @see fr.lip6.move.pnml.pthlpng.multisets.impl.MultisetsPackageImpl#getScalarProduct()
 		 * @generated
@@ -1326,4 +1354,4 @@ public interface MultisetsPackage extends EPackage {
 
 	}
 
-} //MultisetsPackage
+} // MultisetsPackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/NumberOf.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/NumberOf.java
@@ -43,15 +43,19 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Number Of</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Number
+ * Of</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getNumberOf()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.input->size() = 2 and self.input->forAll{c, d | c.oclIsTypeOf(integers::Natural) and d.oclIsKindOf(terms::Sort)} and self.output.oclIsKindOf(terms::MultisetSort)'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='numberof' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.input->size() = 2 and self.input->forAll{c, d |
+ *        c.oclIsTypeOf(integers::Natural) and d.oclIsKindOf(terms::Sort)} and
+ *        self.output.oclIsKindOf(terms::MultisetSort)'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='numberof'
+ *        kind='son'"
  * @generated
  */
 public interface NumberOf extends MultisetOperator {
@@ -66,8 +70,8 @@ public interface NumberOf extends MultisetOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/NumberOf.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/NumberOf.java
@@ -49,13 +49,14 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getNumberOf()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputOutputTypes='self.input->size() = 2 and self.input->forAll{c, d |
- *        c.oclIsTypeOf(integers::Natural) and d.oclIsKindOf(terms::Sort)} and
+ *        inputOutputTypes='self.input-&gt;size() = 2 and
+ *        self.input-&gt;forAll{c, d | c.oclIsTypeOf(integers::Natural) and
+ *        d.oclIsKindOf(terms::Sort)} and
  *        self.output.oclIsKindOf(terms::MultisetSort)'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='numberof'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface NumberOf extends MultisetOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/ScalarProduct.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/ScalarProduct.java
@@ -43,15 +43,19 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Scalar Product</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Scalar
+ * Product</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getScalarProduct()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsKindOf(terms::MultisetSort) and self.input->forAll{c,d | c.oclIsKindOf(integers::Natural) and d.oclIsKindOf(terms::MultisetSort)}'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='scalarproduct' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsKindOf(terms::MultisetSort) and
+ *        self.input->forAll{c,d | c.oclIsKindOf(integers::Natural) and
+ *        d.oclIsKindOf(terms::MultisetSort)}'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='scalarproduct'
+ *        kind='son'"
  * @generated
  */
 public interface ScalarProduct extends MultisetOperator {
@@ -66,8 +70,8 @@ public interface ScalarProduct extends MultisetOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/ScalarProduct.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/ScalarProduct.java
@@ -50,12 +50,12 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getScalarProduct()
  * @model annotation="http://www.pnml.org/models/OCL
  *        inputOutputTypes='self.output.oclIsKindOf(terms::MultisetSort) and
- *        self.input->forAll{c,d | c.oclIsKindOf(integers::Natural) and
+ *        self.input-&gt;forAll{c,d | c.oclIsKindOf(integers::Natural) and
  *        d.oclIsKindOf(terms::MultisetSort)}'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='scalarproduct'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface ScalarProduct extends MultisetOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Subtract.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Subtract.java
@@ -49,11 +49,12 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getSubtract()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputType='self.input->size() = 2 and self.input->forAll{c |
+ *        inputType='self.input-&gt;size() = 2 and self.input-&gt;forAll{c |
  *        c.oclIsKindOf(terms::MultisetSort)}'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputType'" annotation="http://www.pnml.org/models/ToPNML
  *        tag='subtract' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Subtract extends MultisetOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Subtract.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/Subtract.java
@@ -43,15 +43,17 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Subtract</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Subtract</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#getSubtract()
- * @model annotation="http://www.pnml.org/models/OCL inputType='self.input->size() = 2 and self.input->forAll{c | c.oclIsKindOf(terms::MultisetSort)}'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputType'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='subtract' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputType='self.input->size() = 2 and self.input->forAll{c |
+ *        c.oclIsKindOf(terms::MultisetSort)}'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputType'" annotation="http://www.pnml.org/models/ToPNML
+ *        tag='subtract' kind='son'"
  * @generated
  */
 public interface Subtract extends MultisetOperator {
@@ -66,8 +68,8 @@ public interface Subtract extends MultisetOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/AddHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/AddHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class AddHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class AddHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class AddHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Add item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AddHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AddHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AddHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AddHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AddHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AddHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AddHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AddHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AddHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AddHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AddHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AddHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AddHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AddHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAdd();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAdd();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public AddHLAPI(Add lowLevelAPI){
+	public AddHLAPI(Add lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class AddHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Add getContainedItem(){
+	public Add getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(AddHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(AddHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/AllHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/AllHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class AllHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class AllHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,432 +73,348 @@ public class AllHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private All item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public AllHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public AllHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public AllHLAPI(SortHLAPI refsort) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AllHLAPI(SortHLAPI refsort
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AllHLAPI(SortHLAPI refsort
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AllHLAPI(SortHLAPI refsort
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AllHLAPI(SortHLAPI refsort
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AllHLAPI(SortHLAPI refsort
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public AllHLAPI(SortHLAPI refsort
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createAll();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public AllHLAPI(
-		 SortHLAPI refsort
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createAll();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public AllHLAPI(All lowLevelAPI){
+	public AllHLAPI(All lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -507,1666 +422,1549 @@ public class AllHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public All getContainedItem(){
+	public All getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getRefsort(){
+	public Sort getRefsort() {
 		return item.getRefsort();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getRefsortHLAPI(){
-			if(item.getRefsort() == null) return null;
-			Sort object = item.getRefsort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getRefsortHLAPI() {
+		if (item.getRefsort() == null)
+			return null;
+		Sort object = item.getRefsort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Refsort
 	 */
 	public void setRefsortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setRefsort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setRefsort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(AllHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(AllHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/CardinalityHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/CardinalityHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class CardinalityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class CardinalityHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class CardinalityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Cardinality item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinality();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinality();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public CardinalityHLAPI(Cardinality lowLevelAPI){
+	public CardinalityHLAPI(Cardinality lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class CardinalityHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Cardinality getContainedItem(){
+	public Cardinality getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(CardinalityHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(CardinalityHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/CardinalityOfHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/CardinalityOfHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class CardinalityOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class CardinalityOfHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class CardinalityOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private CardinalityOf item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public CardinalityOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public CardinalityOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityOfHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityOfHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityOfHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityOfHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityOfHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityOfHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityOfHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityOfHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityOfHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityOfHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public CardinalityOfHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public CardinalityOfHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createCardinalityOf();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createCardinalityOf();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public CardinalityOfHLAPI(CardinalityOf lowLevelAPI){
+	public CardinalityOfHLAPI(CardinalityOf lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class CardinalityOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public CardinalityOf getContainedItem(){
+	public CardinalityOf getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(CardinalityOfHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(CardinalityOfHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/ContainsHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/ContainsHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class ContainsHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class ContainsHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class ContainsHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Contains item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ContainsHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ContainsHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ContainsHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createContains();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ContainsHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ContainsHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ContainsHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ContainsHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ContainsHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ContainsHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ContainsHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ContainsHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ContainsHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ContainsHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ContainsHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createContains();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createContains();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ContainsHLAPI(Contains lowLevelAPI){
+	public ContainsHLAPI(Contains lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class ContainsHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Contains getContainedItem(){
+	public Contains getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ContainsHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ContainsHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/EmptyHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/EmptyHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class EmptyHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class EmptyHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,432 +73,348 @@ public class EmptyHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Empty item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public EmptyHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, SortHLAPI refsort
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public EmptyHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, SortHLAPI refsort
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public EmptyHLAPI(SortHLAPI refsort
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createEmpty();
+		}
+
+		if (refsort != null)
+			item.setRefsort((Sort) refsort.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public EmptyHLAPI(
-		 SortHLAPI refsort
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createEmpty();}
-	
- 		
- 		if(refsort!=null)
-			item.setRefsort((Sort)refsort.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public EmptyHLAPI(Empty lowLevelAPI){
+	public EmptyHLAPI(Empty lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -507,1666 +422,1549 @@ public class EmptyHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Empty getContainedItem(){
+	public Empty getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getRefsort(){
+	public Sort getRefsort() {
 		return item.getRefsort();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getRefsortHLAPI(){
-			if(item.getRefsort() == null) return null;
-			Sort object = item.getRefsort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getRefsortHLAPI() {
+		if (item.getRefsort() == null)
+			return null;
+		Sort object = item.getRefsort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Refsort
 	 */
 	public void setRefsortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setRefsort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setRefsort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(EmptyHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(EmptyHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/NumberOfHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/NumberOfHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class NumberOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class NumberOfHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class NumberOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private NumberOf item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NumberOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public NumberOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberOfHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberOfHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberOfHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberOfHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberOfHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberOfHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberOfHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberOfHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberOfHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberOfHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public NumberOfHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public NumberOfHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNumberOf();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNumberOf();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NumberOfHLAPI(NumberOf lowLevelAPI){
+	public NumberOfHLAPI(NumberOf lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class NumberOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public NumberOf getContainedItem(){
+	public NumberOf getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NumberOfHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(NumberOfHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/ScalarProductHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/ScalarProductHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class ScalarProductHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class ScalarProductHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class ScalarProductHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private ScalarProduct item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ScalarProductHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ScalarProductHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ScalarProductHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ScalarProductHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ScalarProductHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ScalarProductHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ScalarProductHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ScalarProductHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ScalarProductHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ScalarProductHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ScalarProductHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ScalarProductHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public ScalarProductHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public ScalarProductHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createScalarProduct();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createScalarProduct();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ScalarProductHLAPI(ScalarProduct lowLevelAPI){
+	public ScalarProductHLAPI(ScalarProduct lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class ScalarProductHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public ScalarProduct getContainedItem(){
+	public ScalarProduct getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ScalarProductHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ScalarProductHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/SubtractHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/hlapi/SubtractHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class SubtractHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class SubtractHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,325 +73,269 @@ public class SubtractHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Subtract item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public SubtractHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public SubtractHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public SubtractHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public SubtractHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		MultisetsFactory fact = MultisetsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createSubtract();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createSubtract();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public SubtractHLAPI(Subtract lowLevelAPI){
+	public SubtractHLAPI(Subtract lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -400,1595 +343,1476 @@ public class SubtractHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Subtract getContainedItem(){
+	public Subtract getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(SubtractHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(SubtractHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/AddImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/AddImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Add</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Add</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class AddImpl extends MultisetOperatorImpl implements Add {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AddImpl() {
@@ -81,8 +80,8 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 		return MultisetsPackage.Literals.ADD;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class AddImpl extends MultisetOperatorImpl implements Add {
 		return retour;
 
 	}
-} //AddImpl
+} // AddImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/AllImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/AllImpl.java
@@ -76,13 +76,13 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>All</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>All</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl#getRefsort <em>Refsort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl#getRefsort
+ * <em>Refsort</em>}</li>
  * </ul>
  * </p>
  *
@@ -90,9 +90,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class AllImpl extends MultisetOperatorImpl implements All {
 	/**
-	 * The cached value of the '{@link #getRefsort() <em>Refsort</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getRefsort() <em>Refsort</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRefsort()
 	 * @generated
 	 * @ordered
@@ -100,8 +100,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	protected Sort refsort;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected AllImpl() {
@@ -109,8 +109,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,8 +119,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +129,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetRefsort(Sort newRefsort, NotificationChain msgs) {
@@ -148,8 +148,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -166,12 +166,13 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, MultisetsPackage.ALL__REFSORT, newRefsort, newRefsort));
+			eNotify(new ENotificationImpl(this, Notification.SET, MultisetsPackage.ALL__REFSORT, newRefsort,
+					newRefsort));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,16 +180,16 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 		switch (featureID) {
 		case MultisetsPackage.ALL__REFSORT:
 			if (refsort != null)
-				msgs = ((InternalEObject) refsort).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- MultisetsPackage.ALL__REFSORT, null, msgs);
+				msgs = ((InternalEObject) refsort).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - MultisetsPackage.ALL__REFSORT, null, msgs);
 			return basicSetRefsort((Sort) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -201,8 +202,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -215,8 +216,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -230,8 +231,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -245,8 +246,8 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -258,24 +259,24 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 2
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -293,13 +294,13 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -354,22 +355,22 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//2
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 2
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -592,7 +593,7 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 			if (type.getLocalName().equals("null")) {
 				Bool item;
@@ -602,7 +603,7 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 				item.setContainerAll(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -612,7 +613,7 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 				item.setContainerAll(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("multisetsort")) {
 				MultisetSort item;
@@ -622,7 +623,7 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 				item.setContainerAll(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -632,7 +633,7 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 				item.setContainerAll(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -642,30 +643,30 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 				item.setContainerAll(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 2
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -688,13 +689,13 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -812,4 +813,4 @@ public class AllImpl extends MultisetOperatorImpl implements All {
 		return retour;
 
 	}
-} //AllImpl
+} // AllImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/CardinalityImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/CardinalityImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Cardinality</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Cardinality</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected CardinalityImpl() {
@@ -81,8 +80,8 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 		return MultisetsPackage.Literals.CARDINALITY;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class CardinalityImpl extends BuiltInOperatorImpl implements Cardinality 
 		return retour;
 
 	}
-} //CardinalityImpl
+} // CardinalityImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/CardinalityOfImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/CardinalityOfImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Cardinality Of</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Cardinality Of</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class CardinalityOfImpl extends BuiltInOperatorImpl implements CardinalityOf {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected CardinalityOfImpl() {
@@ -81,8 +80,8 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 		return MultisetsPackage.Literals.CARDINALITY_OF;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class CardinalityOfImpl extends BuiltInOperatorImpl implements Cardinalit
 		return retour;
 
 	}
-} //CardinalityOfImpl
+} // CardinalityOfImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/ContainsImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/ContainsImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Contains</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Contains</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ContainsImpl() {
@@ -81,8 +80,8 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 		return MultisetsPackage.Literals.CONTAINS;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class ContainsImpl extends BuiltInOperatorImpl implements Contains {
 		return retour;
 
 	}
-} //ContainsImpl
+} // ContainsImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/EmptyImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/EmptyImpl.java
@@ -76,13 +76,13 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Empty</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Empty</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl#getRefsort <em>Refsort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl#getRefsort
+ * <em>Refsort</em>}</li>
  * </ul>
  * </p>
  *
@@ -90,9 +90,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	/**
-	 * The cached value of the '{@link #getRefsort() <em>Refsort</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getRefsort() <em>Refsort</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRefsort()
 	 * @generated
 	 * @ordered
@@ -100,8 +100,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	protected Sort refsort;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected EmptyImpl() {
@@ -109,8 +109,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,8 +119,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -129,8 +129,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetRefsort(Sort newRefsort, NotificationChain msgs) {
@@ -148,8 +148,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -171,8 +171,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -180,16 +180,16 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 		switch (featureID) {
 		case MultisetsPackage.EMPTY__REFSORT:
 			if (refsort != null)
-				msgs = ((InternalEObject) refsort).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- MultisetsPackage.EMPTY__REFSORT, null, msgs);
+				msgs = ((InternalEObject) refsort).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - MultisetsPackage.EMPTY__REFSORT, null, msgs);
 			return basicSetRefsort((Sort) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -202,8 +202,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -216,8 +216,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -231,8 +231,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -246,8 +246,8 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -259,24 +259,24 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 2
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -294,13 +294,13 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -355,22 +355,22 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//2
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 2
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -593,7 +593,7 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 			if (type.getLocalName().equals("null")) {
 				Bool item;
@@ -603,7 +603,7 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 				item.setContainerEmpty(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -613,7 +613,7 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 				item.setContainerEmpty(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("multisetsort")) {
 				MultisetSort item;
@@ -623,7 +623,7 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 				item.setContainerEmpty(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -633,7 +633,7 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 				item.setContainerEmpty(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -643,30 +643,30 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 				item.setContainerEmpty(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 2
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 2
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -689,13 +689,13 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -813,4 +813,4 @@ public class EmptyImpl extends MultisetOperatorImpl implements Empty {
 		return retour;
 
 	}
-} //EmptyImpl
+} // EmptyImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/MultisetsFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/MultisetsFactoryImpl.java
@@ -50,16 +50,16 @@ import fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct;
 import fr.lip6.move.pnml.pthlpng.multisets.Subtract;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static MultisetsFactory init() {
@@ -76,9 +76,9 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public MultisetsFactoryImpl() {
@@ -86,8 +86,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -117,8 +117,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -128,8 +128,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -139,8 +139,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -150,8 +150,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -161,8 +161,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -172,8 +172,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -183,8 +183,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -194,8 +194,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -205,8 +205,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -216,8 +216,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -226,8 +226,8 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -236,4 +236,4 @@ public class MultisetsFactoryImpl extends EFactoryImpl implements MultisetsFacto
 		return MultisetsPackage.eINSTANCE;
 	}
 
-} //MultisetsFactoryImpl
+} // MultisetsFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/MultisetsPackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/MultisetsPackageImpl.java
@@ -63,85 +63,85 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass cardinalityEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass containsEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass cardinalityOfEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass addEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass allEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass emptyEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass numberOfEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass subtractEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass scalarProductEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage#eNS_URI
 	 * @see #init()
@@ -152,19 +152,22 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link MultisetsPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link MultisetsPackage#eINSTANCE} when
+	 * that field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -175,29 +178,37 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 			return (MultisetsPackage) EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI);
 
 		// Obtain or create and register package
-		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.get(eNS_URI) : new MultisetsPackageImpl());
+		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
+				.get(eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
+						: new MultisetsPackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
 		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) : BooleansPackage.eINSTANCE);
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(DotsPackage.eNS_URI) : DotsPackage.eINSTANCE);
+				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI)
+						: BooleansPackage.eINSTANCE);
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI)
+						: DotsPackage.eINSTANCE);
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) : HlcorestructurePackage.eINSTANCE);
+				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(HlcorestructurePackage.eNS_URI)
+						: HlcorestructurePackage.eINSTANCE);
 		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) : IntegersPackage.eINSTANCE);
+				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI)
+						: IntegersPackage.eINSTANCE);
 		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) : PartitionsPackage.eINSTANCE);
+				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI)
+						: PartitionsPackage.eINSTANCE);
 		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) : TermsPackage.eINSTANCE);
+				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI)
+						: TermsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theMultisetsPackage.createPackageContents();
@@ -234,8 +245,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -244,8 +255,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -254,8 +265,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -264,8 +275,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -274,8 +285,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -284,8 +295,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -294,8 +305,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -304,8 +315,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -314,8 +325,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -324,8 +335,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -334,8 +345,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -344,8 +355,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -354,17 +365,17 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -395,17 +406,17 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -440,7 +451,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 		initEClass(cardinalityEClass, Cardinality.class, "Cardinality", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(containsEClass, Contains.class, "Contains", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(containsEClass, Contains.class, "Contains", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(cardinalityOfEClass, CardinalityOf.class, "CardinalityOf", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -457,9 +469,11 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 				"refsort", null, 1, 1, Empty.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(numberOfEClass, NumberOf.class, "NumberOf", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(numberOfEClass, NumberOf.class, "NumberOf", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(subtractEClass, Subtract.class, "Subtract", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(subtractEClass, Subtract.class, "Subtract", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		initEClass(scalarProductEClass, ScalarProduct.class, "ScalarProduct", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -479,47 +493,35 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createOCLAnnotations() {
 		String source = "http://www.pnml.org/models/OCL";
 		addAnnotation(cardinalityEClass, source, new String[] { "inputOutputTypes",
 				"self.output.oclIsTypeOf(integers::Natural) and self.input.oclIsKindOf(terms::MultisetSort)" });
-		addAnnotation(
-				containsEClass,
-				source,
-				new String[] {
-						"inputOutputTypes",
-						"self.output.oclIsTypeOf(booleans::Bool) and self.input->size() = 2 and self.input->forAll {c | c.oclIsKindOf(terms::MultisetSort)}" });
+		addAnnotation(containsEClass, source, new String[] { "inputOutputTypes",
+				"self.output.oclIsTypeOf(booleans::Bool) and self.input->size() = 2 and self.input->forAll {c | c.oclIsKindOf(terms::MultisetSort)}" });
 		addAnnotation(cardinalityOfEClass, source, new String[] { "inputOutputTypes",
 				"self.output.oclIsTypeOf(integers::Natural) and self.input.size() = 2" });
 		addAnnotation(addEClass, source, new String[] { "inputType",
 				"self.input->size() >= 2 and self.input->forAll{c | c.oclIsKindOf(terms::MultisetSort)} " });
 		addAnnotation(allEClass, source, new String[] { "inputOutputTypes", "self.input->size() = 0" });
 		addAnnotation(emptyEClass, source, new String[] { "InputSize", "self.input->size = 0" });
-		addAnnotation(
-				numberOfEClass,
-				source,
-				new String[] {
-						"inputOutputTypes",
-						"self.input->size() = 2 and self.input->forAll{c, d | c.oclIsTypeOf(integers::Natural) and d.oclIsKindOf(terms::Sort)} and self.output.oclIsKindOf(terms::MultisetSort)" });
+		addAnnotation(numberOfEClass, source, new String[] { "inputOutputTypes",
+				"self.input->size() = 2 and self.input->forAll{c, d | c.oclIsTypeOf(integers::Natural) and d.oclIsKindOf(terms::Sort)} and self.output.oclIsKindOf(terms::MultisetSort)" });
 		addAnnotation(subtractEClass, source, new String[] { "inputType",
 				"self.input->size() = 2 and self.input->forAll{c | c.oclIsKindOf(terms::MultisetSort)}" });
-		addAnnotation(
-				scalarProductEClass,
-				source,
-				new String[] {
-						"inputOutputTypes",
-						"self.output.oclIsKindOf(terms::MultisetSort) and self.input->forAll{c,d | c.oclIsKindOf(integers::Natural) and d.oclIsKindOf(terms::MultisetSort)}" });
+		addAnnotation(scalarProductEClass, source, new String[] { "inputOutputTypes",
+				"self.output.oclIsKindOf(terms::MultisetSort) and self.input->forAll{c,d | c.oclIsKindOf(integers::Natural) and d.oclIsKindOf(terms::MultisetSort)}" });
 	}
 
 	/**
 	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createEcoreAnnotations() {
@@ -537,8 +539,8 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -557,9 +559,9 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -575,4 +577,4 @@ public class MultisetsPackageImpl extends EPackageImpl implements MultisetsPacka
 		addAnnotation(scalarProductEClass, source, new String[] {});
 	}
 
-} //MultisetsPackageImpl
+} // MultisetsPackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/NumberOfImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/NumberOfImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Number Of</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Number
+ * Of</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NumberOfImpl() {
@@ -81,8 +80,8 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 		return MultisetsPackage.Literals.NUMBER_OF;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class NumberOfImpl extends MultisetOperatorImpl implements NumberOf {
 		return retour;
 
 	}
-} //NumberOfImpl
+} // NumberOfImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/ScalarProductImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/ScalarProductImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Scalar Product</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Scalar
+ * Product</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarProduct {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ScalarProductImpl() {
@@ -81,8 +80,8 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 		return MultisetsPackage.Literals.SCALAR_PRODUCT;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class ScalarProductImpl extends MultisetOperatorImpl implements ScalarPro
 		return retour;
 
 	}
-} //ScalarProductImpl
+} // ScalarProductImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/SubtractImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/impl/SubtractImpl.java
@@ -62,9 +62,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Subtract</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Subtract</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -72,8 +71,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected SubtractImpl() {
@@ -81,8 +80,8 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -90,24 +89,24 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 		return MultisetsPackage.Literals.SUBTRACT;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -125,13 +124,13 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -174,22 +173,22 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		MultisetsFactory fact = MultisetsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -412,30 +411,30 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -458,13 +457,13 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -566,4 +565,4 @@ public class SubtractImpl extends MultisetOperatorImpl implements Subtract {
 		return retour;
 
 	}
-} //SubtractImpl
+} // SubtractImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/util/MultisetsAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/util/MultisetsAdapterFactory.java
@@ -52,26 +52,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Operator;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage
  * @generated
  */
 public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static MultisetsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public MultisetsAdapterFactory() {
@@ -81,10 +80,11 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -100,9 +100,9 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected MultisetsSwitch<Adapter> modelSwitch = new MultisetsSwitch<Adapter>() {
@@ -178,9 +178,9 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -191,11 +191,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.Cardinality <em>Cardinality</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Cardinality
+	 * <em>Cardinality</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Cardinality
 	 * @generated
@@ -205,11 +206,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.Contains <em>Contains</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Contains <em>Contains</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Contains
 	 * @generated
@@ -219,11 +221,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf <em>Cardinality Of</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf <em>Cardinality
+	 * Of</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf
 	 * @generated
@@ -233,11 +236,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.Add <em>Add</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Add <em>Add</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Add
 	 * @generated
@@ -247,11 +251,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.All <em>All</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.All <em>All</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.All
 	 * @generated
@@ -261,11 +266,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty <em>Empty</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty <em>Empty</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Empty
 	 * @generated
@@ -275,11 +281,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.NumberOf <em>Number Of</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.NumberOf <em>Number Of</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.NumberOf
 	 * @generated
@@ -289,11 +296,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.Subtract <em>Subtract</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Subtract <em>Subtract</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.Subtract
 	 * @generated
@@ -303,11 +311,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct <em>Scalar Product</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct <em>Scalar
+	 * Product</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct
 	 * @generated
@@ -317,11 +326,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -331,11 +341,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -345,11 +356,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator
 	 * @generated
@@ -359,11 +371,12 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetOperator <em>Multiset Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetOperator <em>Multiset
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.MultisetOperator
 	 * @generated
@@ -373,10 +386,9 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -384,4 +396,4 @@ public class MultisetsAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //MultisetsAdapterFactory
+} // MultisetsAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/util/MultisetsSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/util/MultisetsSwitch.java
@@ -51,31 +51,28 @@ import fr.lip6.move.pnml.pthlpng.terms.Operator;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage
  * @generated
  */
 public class MultisetsSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static MultisetsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public MultisetsSwitch() {
@@ -85,9 +82,9 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -98,9 +95,10 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -230,13 +228,14 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Cardinality</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Cardinality</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Cardinality</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Cardinality</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -245,13 +244,14 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Contains</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Contains</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Contains</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Contains</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -260,13 +260,14 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Cardinality Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Cardinality Of</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Cardinality Of</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Cardinality Of</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -275,13 +276,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Add</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Add</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Add</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Add</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -290,13 +291,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>All</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>All</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>All</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>All</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -305,13 +306,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Empty</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Empty</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Empty</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Empty</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -320,13 +321,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Number Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Number
+	 * Of</em>'. <!-- begin-user-doc --> This implementation returns null; returning
+	 * a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Number Of</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Number
+	 *         Of</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -335,13 +336,14 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Subtract</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Subtract</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Subtract</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Subtract</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -350,13 +352,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Scalar Product</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Scalar
+	 * Product</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Scalar Product</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Scalar
+	 *         Product</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -365,13 +367,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Term</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Term</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Term</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Term</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -380,13 +382,14 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Operator</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -395,13 +398,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -410,13 +413,13 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Multiset Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Multiset
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Multiset Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Multiset
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -425,13 +428,14 @@ public class MultisetsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -440,4 +444,4 @@ public class MultisetsSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //MultisetsSwitch
+} // MultisetsSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/util/MultisetsValidator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/multisets/util/MultisetsValidator.java
@@ -52,25 +52,25 @@ import fr.lip6.move.pnml.pthlpng.multisets.Subtract;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Validator</b> for the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Validator</b> for the model. <!-- end-user-doc
+ * -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.multisets.MultisetsPackage
  * @generated
  */
 public class MultisetsValidator extends EObjectValidator {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final MultisetsValidator INSTANCE = new MultisetsValidator();
 
 	/**
-	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource() source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode() codes} from this package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource()
+	 * source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode()
+	 * codes} from this package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.common.util.Diagnostic#getSource()
 	 * @see org.eclipse.emf.common.util.Diagnostic#getCode()
 	 * @generated
@@ -78,33 +78,35 @@ public class MultisetsValidator extends EObjectValidator {
 	public static final String DIAGNOSTIC_SOURCE = "fr.lip6.move.pnml.pthlpng.multisets";
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 0;
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
-	 * <!-- begin-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants in a derived class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static final int DIAGNOSTIC_CODE_COUNT = GENERATED_DIAGNOSTIC_CODE_COUNT;
 
 	/**
-	 * The cached base package validator.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached base package validator. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	protected TermsValidator termsValidator;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public MultisetsValidator() {
@@ -113,9 +115,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the package of this validator switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package of this validator switch. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,12 +127,13 @@ public class MultisetsValidator extends EObjectValidator {
 
 	/**
 	 * Calls <code>validateXXX</code> for the corresponding classifier of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		switch (classifierID) {
 		case MultisetsPackage.CARDINALITY:
 			return validateCardinality((Cardinality) value, diagnostics, context);
@@ -156,11 +159,12 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateCardinality(Cardinality cardinality, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateCardinality(Cardinality cardinality, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		if (!validate_NoCircularContainment(cardinality, diagnostics, context))
 			return false;
 		boolean result = validate_EveryMultiplicityConforms(cardinality, diagnostics, context);
@@ -186,9 +190,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Cardinality</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Cardinality</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCardinality_inputOutputTypes(Cardinality cardinality, DiagnosticChain diagnostics,
@@ -199,10 +203,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(cardinality, context) },
-						new Object[] { cardinality }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(cardinality, context) },
+								new Object[] { cardinality }, context));
 			}
 			return false;
 		}
@@ -210,8 +214,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateContains(Contains contains, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -240,9 +244,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Contains</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Contains</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateContains_inputOutputTypes(Contains contains, DiagnosticChain diagnostics,
@@ -253,10 +257,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(contains, context) },
-						new Object[] { contains }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(contains, context) },
+								new Object[] { contains }, context));
 			}
 			return false;
 		}
@@ -264,8 +268,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCardinalityOf(CardinalityOf cardinalityOf, DiagnosticChain diagnostics,
@@ -295,9 +299,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Cardinality Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Cardinality Of</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateCardinalityOf_inputOutputTypes(CardinalityOf cardinalityOf, DiagnosticChain diagnostics,
@@ -308,10 +312,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(cardinalityOf, context) },
-						new Object[] { cardinalityOf }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(cardinalityOf, context) },
+								new Object[] { cardinalityOf }, context));
 			}
 			return false;
 		}
@@ -319,8 +323,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAdd(Add add, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -349,9 +353,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputType constraint of '<em>Add</em>'.
-	 * <!-- begin-user-doc -->
+	 * Validates the inputType constraint of '<em>Add</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAdd_inputType(Add add, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -371,8 +375,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAll(All all, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -401,9 +405,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>All</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>All</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateAll_inputOutputTypes(All all, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -413,10 +417,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(all, context) }, new Object[] { all },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(all, context) }, new Object[] { all },
+								context));
 			}
 			return false;
 		}
@@ -424,8 +428,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateEmpty(Empty empty, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -454,9 +458,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the InputSize constraint of '<em>Empty</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the InputSize constraint of '<em>Empty</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateEmpty_InputSize(Empty empty, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -476,8 +480,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNumberOf(NumberOf numberOf, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -506,9 +510,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Number Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Number Of</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNumberOf_inputOutputTypes(NumberOf numberOf, DiagnosticChain diagnostics,
@@ -519,10 +523,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(numberOf, context) },
-						new Object[] { numberOf }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(numberOf, context) },
+								new Object[] { numberOf }, context));
 			}
 			return false;
 		}
@@ -530,8 +534,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateSubtract(Subtract subtract, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -560,9 +564,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputType constraint of '<em>Subtract</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputType constraint of '<em>Subtract</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateSubtract_inputType(Subtract subtract, DiagnosticChain diagnostics,
@@ -573,10 +577,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputType", getObjectLabel(subtract, context) }, new Object[] { subtract },
-						context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputType", getObjectLabel(subtract, context) },
+								new Object[] { subtract }, context));
 			}
 			return false;
 		}
@@ -584,8 +588,8 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateScalarProduct(ScalarProduct scalarProduct, DiagnosticChain diagnostics,
@@ -615,9 +619,9 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Scalar Product</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Scalar Product</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateScalarProduct_inputOutputTypes(ScalarProduct scalarProduct, DiagnosticChain diagnostics,
@@ -628,10 +632,10 @@ public class MultisetsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(scalarProduct, context) },
-						new Object[] { scalarProduct }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(scalarProduct, context) },
+								new Object[] { scalarProduct }, context));
 			}
 			return false;
 		}
@@ -639,17 +643,18 @@ public class MultisetsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the resource locator that will be used to fetch messages for this validator's diagnostics.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the resource locator that will be used to fetch messages for this
+	 * validator's diagnostics. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public ResourceLocator getResourceLocator() {
 		// TODO
-		// Specialize this to return a resource locator for messages specific to this validator.
+		// Specialize this to return a resource locator for messages specific to this
+		// validator.
 		// Ensure that you remove @generated or mark it @generated NOT
 		return super.getResourceLocator();
 	}
 
-} //MultisetsValidator
+} // MultisetsValidator

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/GreaterThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/GreaterThan.java
@@ -42,14 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Greater Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Greater
+ * Than</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getGreaterThan()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and self.input->size() = 2'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and
+ *        self.input->size() = 2'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='gtp' kind='son'"
  * @generated
  */
@@ -65,8 +67,8 @@ public interface GreaterThan extends PartitionOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/GreaterThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/GreaterThan.java
@@ -49,10 +49,11 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getGreaterThan()
  * @model annotation="http://www.pnml.org/models/OCL
  *        inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and
- *        self.input->size() = 2'"
+ *        self.input-&gt;size() = 2'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='gtp' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface GreaterThan extends PartitionOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/LessThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/LessThan.java
@@ -42,14 +42,16 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Less Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Less
+ * Than</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getLessThan()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and self.input->size() = 2'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and
+ *        self.input->size() = 2'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='ltp' kind='son'"
  * @generated
  */
@@ -65,8 +67,8 @@ public interface LessThan extends PartitionOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/LessThan.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/LessThan.java
@@ -49,10 +49,11 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getLessThan()
  * @model annotation="http://www.pnml.org/models/OCL
  *        inputOutputTypes='self.output.oclIsTypeOf(booleans::Bool) and
- *        self.input->size() = 2'"
+ *        self.input-&gt;size() = 2'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='ltp' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface LessThan extends PartitionOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/Partition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/Partition.java
@@ -60,7 +60,7 @@ import fr.lip6.move.pnml.pthlpng.terms.SortDecl;
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartition()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='partition'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Partition extends SortDecl {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/Partition.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/Partition.java
@@ -45,46 +45,52 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.SortDecl;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Partition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Partition</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements <em>Partitionelements</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef
+ * <em>Def</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements
+ * <em>Partitionelements</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartition()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='partition' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='partition'
+ *        kind='son'"
  * @generated
  */
 public interface Partition extends SortDecl {
 	/**
-	 * Returns the value of the '<em><b>Def</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition <em>Container Partition</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Def</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition
+	 * <em>Container Partition</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Def</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Def</em>' containment reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Def</em>' containment reference.
 	 * @see #setDef(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartition_Def()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition
-	 * @model opposite="containerPartition" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerPartition" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Sort getDef();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Def</em>' containment reference.
 	 * @see #getDef()
 	 * @generated
@@ -92,16 +98,20 @@ public interface Partition extends SortDecl {
 	void setDef(Sort value);
 
 	/**
-	 * Returns the value of the '<em><b>Partitionelements</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition <em>Refpartition</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Partitionelements</b></em>' containment
+	 * reference list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement}. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition
+	 * <em>Refpartition</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Partitionelements</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Partitionelements</em>' containment reference list
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Partitionelements</em>' containment reference list.
+	 * 
+	 * @return the value of the '<em>Partitionelements</em>' containment reference
+	 *         list.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartition_Partitionelements()
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition
 	 * @model opposite="refpartition" containment="true" required="true"
@@ -120,8 +130,8 @@ public interface Partition extends SortDecl {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElement.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElement.java
@@ -45,34 +45,41 @@ import fr.lip6.move.pnml.pthlpng.terms.OperatorDecl;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Partition Element</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Partition Element</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition <em>Refpartition</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants <em>Partitionelementconstants</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition
+ * <em>Refpartition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants
+ * <em>Partitionelementconstants</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElement()
- * @model annotation="http://www.pnml.org/models/OCL constantsType='self.partitionelementconstants->forAll{p | p.sort = self.refpartition.def}'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='constantsType'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='partitionelement' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        constantsType='self.partitionelementconstants->forAll{p | p.sort =
+ *        self.refpartition.def}'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='constantsType'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='partitionelement'
+ *        kind='son'"
  * @generated
  */
 public interface PartitionElement extends OperatorDecl {
 	/**
 	 * Returns the value of the '<em><b>Refpartition</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements <em>Partitionelements</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements
+	 * <em>Partitionelements</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Refpartition</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Refpartition</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Refpartition</em>' container reference.
 	 * @see #setRefpartition(Partition)
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElement_Refpartition()
@@ -83,29 +90,38 @@ public interface PartitionElement extends OperatorDecl {
 	Partition getRefpartition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition <em>Refpartition</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Refpartition</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition
+	 * <em>Refpartition</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Refpartition</em>' container
+	 *              reference.
 	 * @see #getRefpartition()
 	 * @generated
 	 */
 	void setRefpartition(Partition value);
 
 	/**
-	 * Returns the value of the '<em><b>Partitionelementconstants</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.Term}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement <em>Container Partition Element</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Partitionelementconstants</b></em>'
+	 * containment reference list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.terms.Term}. It is bidirectional and its
+	 * opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement
+	 * <em>Container Partition Element</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Partitionelementconstants</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Partitionelementconstants</em>' containment
+	 * reference list isn't clear, there really should be more of a description
+	 * here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Partitionelementconstants</em>' containment reference list.
+	 * 
+	 * @return the value of the '<em>Partitionelementconstants</em>' containment
+	 *         reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElement_Partitionelementconstants()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement
-	 * @model opposite="containerPartitionElement" containment="true" required="true" ordered="false"
+	 * @model opposite="containerPartitionElement" containment="true"
+	 *        required="true" ordered="false"
 	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
 	 * @generated
 	 */
@@ -121,8 +137,8 @@ public interface PartitionElement extends OperatorDecl {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElement.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElement.java
@@ -60,12 +60,12 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElement()
  * @model annotation="http://www.pnml.org/models/OCL
- *        constantsType='self.partitionelementconstants->forAll{p | p.sort =
+ *        constantsType='self.partitionelementconstants-&gt;forAll{p | p.sort =
  *        self.refpartition.def}'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='constantsType'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='partitionelement'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface PartitionElement extends OperatorDecl {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElementOf.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElementOf.java
@@ -55,11 +55,11 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElementOf()
  * @model annotation="http://www.pnml.org/models/OCL
- *        inputOutputTypes='self.input->size() = 1'"
+ *        inputOutputTypes='self.input-&gt;size() = 1'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='inputOutputTypes'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='partitionelementof'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface PartitionElementOf extends PartitionOperator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElementOf.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionElementOf.java
@@ -42,45 +42,51 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Partition Element Of</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Partition Element Of</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition <em>Refpartition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition
+ * <em>Refpartition</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElementOf()
- * @model annotation="http://www.pnml.org/models/OCL inputOutputTypes='self.input->size() = 1'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='inputOutputTypes'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='partitionelementof' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        inputOutputTypes='self.input->size() = 1'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='inputOutputTypes'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='partitionelementof'
+ *        kind='son'"
  * @generated
  */
 public interface PartitionElementOf extends PartitionOperator {
 	/**
-	 * Returns the value of the '<em><b>Refpartition</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Refpartition</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Refpartition</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Refpartition</em>' reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Refpartition</em>' reference.
 	 * @see #setRefpartition(Partition)
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionElementOf_Refpartition()
-	 * @model required="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='refpartition' kind='idref'"
+	 * @model required="true" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='refpartition' kind='idref'"
 	 * @generated
 	 */
 	Partition getRefpartition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition <em>Refpartition</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition
+	 * <em>Refpartition</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @param value the new value of the '<em>Refpartition</em>' reference.
 	 * @see #getRefpartition()
 	 * @generated
@@ -97,8 +103,8 @@ public interface PartitionElementOf extends PartitionOperator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionOperator.java
@@ -43,9 +43,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Partition Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Partition Operator</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#getPartitionOperator()
@@ -58,8 +57,8 @@ public interface PartitionOperator extends BuiltInOperator {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionsFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionsFactory.java
@@ -34,74 +34,73 @@ package fr.lip6.move.pnml.pthlpng.partitions;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage
  * @generated
  */
 public interface PartitionsFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	PartitionsFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Partition</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Partition</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Partition</em>'.
 	 * @generated
 	 */
 	Partition createPartition();
 
 	/**
-	 * Returns a new object of class '<em>Partition Element</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Partition Element</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Partition Element</em>'.
 	 * @generated
 	 */
 	PartitionElement createPartitionElement();
 
 	/**
-	 * Returns a new object of class '<em>Greater Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Greater Than</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Greater Than</em>'.
 	 * @generated
 	 */
 	GreaterThan createGreaterThan();
 
 	/**
-	 * Returns a new object of class '<em>Partition Element Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Partition Element Of</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Partition Element Of</em>'.
 	 * @generated
 	 */
 	PartitionElementOf createPartitionElementOf();
 
 	/**
-	 * Returns a new object of class '<em>Less Than</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Less Than</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Less Than</em>'.
 	 * @generated
 	 */
 	LessThan createLessThan();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	PartitionsPackage getPartitionsPackage();
 
-} //PartitionsFactory
+} // PartitionsFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionsPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/PartitionsPackage.java
@@ -38,57 +38,55 @@ import org.eclipse.emf.ecore.EReference;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsFactory
  * @model kind="package"
  * @generated
  */
 public interface PartitionsPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "partitions";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///pthlpng.partitions.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "partitions";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	PartitionsPackage eINSTANCE = fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl <em>Partition</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl
+	 * <em>Partition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartition()
 	 * @generated
@@ -96,63 +94,65 @@ public interface PartitionsPackage extends EPackage {
 	int PARTITION = 0;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION__ID = TermsPackage.SORT_DECL__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION__NAME = TermsPackage.SORT_DECL__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION__CONTAINER_DECLARATIONS = TermsPackage.SORT_DECL__CONTAINER_DECLARATIONS;
 
 	/**
-	 * The feature id for the '<em><b>Def</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Def</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION__DEF = TermsPackage.SORT_DECL_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Partitionelements</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Partitionelements</b></em>' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION__PARTITIONELEMENTS = TermsPackage.SORT_DECL_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Partition</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Partition</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_FEATURE_COUNT = TermsPackage.SORT_DECL_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl <em>Partition Element</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl
+	 * <em>Partition Element</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartitionElement()
 	 * @generated
@@ -160,27 +160,27 @@ public interface PartitionsPackage extends EPackage {
 	int PARTITION_ELEMENT = 1;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT__ID = TermsPackage.OPERATOR_DECL__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT__NAME = TermsPackage.OPERATOR_DECL__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -188,17 +188,17 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Refpartition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT__REFPARTITION = TermsPackage.OPERATOR_DECL_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Partitionelementconstants</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Partitionelementconstants</b></em>'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -206,17 +206,19 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Partition Element</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_FEATURE_COUNT = TermsPackage.OPERATOR_DECL_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionOperatorImpl <em>Partition Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionOperatorImpl
+	 * <em>Partition Operator</em>}' class. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartitionOperator()
 	 * @generated
@@ -224,63 +226,63 @@ public interface PartitionsPackage extends EPackage {
 	int PARTITION_OPERATOR = 4;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__SORT = TermsPackage.BUILT_IN_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__CONTAINER_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__CONTAINER_NAMED_OPERATOR = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__CONTAINER_HL_MARKING = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__CONTAINER_CONDITION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__CONTAINER_HL_ANNOTATION = TermsPackage.BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -288,26 +290,26 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__SUBTERM = TermsPackage.BUILT_IN_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR__OUTPUT = TermsPackage.BUILT_IN_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -315,17 +317,18 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Partition Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_OPERATOR_FEATURE_COUNT = TermsPackage.BUILT_IN_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl <em>Greater Than</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl <em>Greater
+	 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getGreaterThan()
 	 * @generated
@@ -333,63 +336,63 @@ public interface PartitionsPackage extends EPackage {
 	int GREATER_THAN = 2;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__SORT = PARTITION_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_OPERATOR = PARTITION_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_NAMED_OPERATOR = PARTITION_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_HL_MARKING = PARTITION_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_CONDITION = PARTITION_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__CONTAINER_HL_ANNOTATION = PARTITION_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -397,44 +400,46 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__SUBTERM = PARTITION_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__OUTPUT = PARTITION_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN__INPUT = PARTITION_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Greater Than</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Greater Than</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int GREATER_THAN_FEATURE_COUNT = PARTITION_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl <em>Partition Element Of</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl
+	 * <em>Partition Element Of</em>}' class. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartitionElementOf()
 	 * @generated
@@ -442,63 +447,63 @@ public interface PartitionsPackage extends EPackage {
 	int PARTITION_ELEMENT_OF = 3;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__SORT = PARTITION_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__CONTAINER_OPERATOR = PARTITION_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__CONTAINER_NAMED_OPERATOR = PARTITION_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__CONTAINER_HL_MARKING = PARTITION_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__CONTAINER_CONDITION = PARTITION_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__CONTAINER_HL_ANNOTATION = PARTITION_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -506,53 +511,54 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__SUBTERM = PARTITION_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__OUTPUT = PARTITION_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__INPUT = PARTITION_OPERATOR__INPUT;
 
 	/**
-	 * The feature id for the '<em><b>Refpartition</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Refpartition</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF__REFPARTITION = PARTITION_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Partition Element Of</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Partition Element Of</em>'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PARTITION_ELEMENT_OF_FEATURE_COUNT = PARTITION_OPERATOR_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl <em>Less Than</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl <em>Less
+	 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getLessThan()
 	 * @generated
@@ -560,63 +566,63 @@ public interface PartitionsPackage extends EPackage {
 	int LESS_THAN = 5;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__SORT = PARTITION_OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_OPERATOR = PARTITION_OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_NAMED_OPERATOR = PARTITION_OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_HL_MARKING = PARTITION_OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_CONDITION = PARTITION_OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__CONTAINER_HL_ANNOTATION = PARTITION_OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -624,44 +630,45 @@ public interface PartitionsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__SUBTERM = PARTITION_OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__OUTPUT = PARTITION_OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN__INPUT = PARTITION_OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Less Than</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Less Than</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int LESS_THAN_FEATURE_COUNT = PARTITION_OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition <em>Partition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition <em>Partition</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Partition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.Partition
 	 * @generated
@@ -669,9 +676,10 @@ public interface PartitionsPackage extends EPackage {
 	EClass getPartition();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Def</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef()
 	 * @see #getPartition()
@@ -680,10 +688,12 @@ public interface PartitionsPackage extends EPackage {
 	EReference getPartition_Def();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements <em>Partitionelements</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Partitionelements</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements
+	 * <em>Partitionelements</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Partitionelements</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.Partition#getPartitionelements()
 	 * @see #getPartition()
 	 * @generated
@@ -691,9 +701,10 @@ public interface PartitionsPackage extends EPackage {
 	EReference getPartition_Partitionelements();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement <em>Partition Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement <em>Partition
+	 * Element</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Partition Element</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElement
 	 * @generated
@@ -701,9 +712,10 @@ public interface PartitionsPackage extends EPackage {
 	EClass getPartitionElement();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition <em>Refpartition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition
+	 * <em>Refpartition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the container reference '<em>Refpartition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getRefpartition()
 	 * @see #getPartitionElement()
@@ -712,10 +724,13 @@ public interface PartitionsPackage extends EPackage {
 	EReference getPartitionElement_Refpartition();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants <em>Partitionelementconstants</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Partitionelementconstants</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants
+	 * <em>Partitionelementconstants</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Partitionelementconstants</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants()
 	 * @see #getPartitionElement()
 	 * @generated
@@ -723,9 +738,10 @@ public interface PartitionsPackage extends EPackage {
 	EReference getPartitionElement_Partitionelementconstants();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.partitions.GreaterThan <em>Greater Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.GreaterThan <em>Greater
+	 * Than</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Greater Than</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.GreaterThan
 	 * @generated
@@ -733,9 +749,10 @@ public interface PartitionsPackage extends EPackage {
 	EClass getGreaterThan();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf <em>Partition Element Of</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf <em>Partition
+	 * Element Of</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Partition Element Of</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf
 	 * @generated
@@ -743,9 +760,10 @@ public interface PartitionsPackage extends EPackage {
 	EClass getPartitionElementOf();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition <em>Refpartition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition
+	 * <em>Refpartition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Refpartition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf#getRefpartition()
 	 * @see #getPartitionElementOf()
@@ -754,9 +772,10 @@ public interface PartitionsPackage extends EPackage {
 	EReference getPartitionElementOf_Refpartition();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionOperator <em>Partition Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionOperator <em>Partition
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Partition Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionOperator
 	 * @generated
@@ -764,9 +783,10 @@ public interface PartitionsPackage extends EPackage {
 	EClass getPartitionOperator();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.partitions.LessThan <em>Less Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.LessThan <em>Less Than</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Less Than</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.LessThan
 	 * @generated
@@ -774,31 +794,32 @@ public interface PartitionsPackage extends EPackage {
 	EClass getLessThan();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	PartitionsFactory getPartitionsFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl <em>Partition</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl
+		 * <em>Partition</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartition()
 		 * @generated
@@ -806,25 +827,28 @@ public interface PartitionsPackage extends EPackage {
 		EClass PARTITION = eINSTANCE.getPartition();
 
 		/**
-		 * The meta object literal for the '<em><b>Def</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Def</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PARTITION__DEF = eINSTANCE.getPartition_Def();
 
 		/**
-		 * The meta object literal for the '<em><b>Partitionelements</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Partitionelements</b></em>'
+		 * containment reference list feature. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @generated
 		 */
 		EReference PARTITION__PARTITIONELEMENTS = eINSTANCE.getPartition_Partitionelements();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl <em>Partition Element</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl
+		 * <em>Partition Element</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartitionElement()
 		 * @generated
@@ -832,26 +856,28 @@ public interface PartitionsPackage extends EPackage {
 		EClass PARTITION_ELEMENT = eINSTANCE.getPartitionElement();
 
 		/**
-		 * The meta object literal for the '<em><b>Refpartition</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Refpartition</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PARTITION_ELEMENT__REFPARTITION = eINSTANCE.getPartitionElement_Refpartition();
 
 		/**
-		 * The meta object literal for the '<em><b>Partitionelementconstants</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Partitionelementconstants</b></em>'
+		 * containment reference list feature. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @generated
 		 */
 		EReference PARTITION_ELEMENT__PARTITIONELEMENTCONSTANTS = eINSTANCE
 				.getPartitionElement_Partitionelementconstants();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl <em>Greater Than</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl <em>Greater
+		 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getGreaterThan()
 		 * @generated
@@ -859,9 +885,11 @@ public interface PartitionsPackage extends EPackage {
 		EClass GREATER_THAN = eINSTANCE.getGreaterThan();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl <em>Partition Element Of</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl
+		 * <em>Partition Element Of</em>}' class. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartitionElementOf()
 		 * @generated
@@ -869,17 +897,19 @@ public interface PartitionsPackage extends EPackage {
 		EClass PARTITION_ELEMENT_OF = eINSTANCE.getPartitionElementOf();
 
 		/**
-		 * The meta object literal for the '<em><b>Refpartition</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Refpartition</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PARTITION_ELEMENT_OF__REFPARTITION = eINSTANCE.getPartitionElementOf_Refpartition();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionOperatorImpl <em>Partition Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionOperatorImpl
+		 * <em>Partition Operator</em>}' class. <!-- begin-user-doc --> <!--
+		 * end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getPartitionOperator()
 		 * @generated
@@ -887,9 +917,10 @@ public interface PartitionsPackage extends EPackage {
 		EClass PARTITION_OPERATOR = eINSTANCE.getPartitionOperator();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl <em>Less Than</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl <em>Less
+		 * Than</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl
 		 * @see fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionsPackageImpl#getLessThan()
 		 * @generated
@@ -898,4 +929,4 @@ public interface PartitionsPackage extends EPackage {
 
 	}
 
-} //PartitionsPackage
+} // PartitionsPackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/GreaterThanHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/GreaterThanHLAPI.java
@@ -63,8 +63,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class GreaterThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class GreaterThanHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -72,325 +71,269 @@ public class GreaterThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private fr.lip6.move.pnml.pthlpng.partitions.GreaterThan item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public GreaterThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public GreaterThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public GreaterThanHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public GreaterThanHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createGreaterThan();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createGreaterThan();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public GreaterThanHLAPI(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan lowLevelAPI){
+	public GreaterThanHLAPI(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -398,1595 +341,1476 @@ public class GreaterThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public fr.lip6.move.pnml.pthlpng.partitions.GreaterThan getContainedItem(){
+	public fr.lip6.move.pnml.pthlpng.partitions.GreaterThan getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(GreaterThanHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(GreaterThanHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/LessThanHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/LessThanHLAPI.java
@@ -63,8 +63,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class LessThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class LessThanHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -72,325 +71,269 @@ public class LessThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private fr.lip6.move.pnml.pthlpng.partitions.LessThan item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public LessThanHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public LessThanHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public LessThanHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public LessThanHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createLessThan();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createLessThan();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public LessThanHLAPI(fr.lip6.move.pnml.pthlpng.partitions.LessThan lowLevelAPI){
+	public LessThanHLAPI(fr.lip6.move.pnml.pthlpng.partitions.LessThan lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -398,1595 +341,1476 @@ public class LessThanHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public fr.lip6.move.pnml.pthlpng.partitions.LessThan getContainedItem(){
+	public fr.lip6.move.pnml.pthlpng.partitions.LessThan getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(LessThanHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(LessThanHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/PartitionElementHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/PartitionElementHLAPI.java
@@ -58,8 +58,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorDeclHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermsDeclarationHLAPI;
 
-
-public class PartitionElementHLAPI implements HLAPIClass,TermsDeclarationHLAPI,OperatorDeclHLAPI{
+public class PartitionElementHLAPI implements HLAPIClass, TermsDeclarationHLAPI, OperatorDeclHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -67,113 +66,95 @@ public class PartitionElementHLAPI implements HLAPIClass,TermsDeclarationHLAPI,O
 	private PartitionElement item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PartitionElementHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementHLAPI(java.lang.String id
+
+			, java.lang.String name) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElement();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElement();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, DeclarationsHLAPI containerDeclarations
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, DeclarationsHLAPI containerDeclarations) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElement();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(containerDeclarations!=null)
-			item.setContainerDeclarations((Declarations)containerDeclarations.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElement();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (containerDeclarations != null)
+			item.setContainerDeclarations((Declarations) containerDeclarations.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, PartitionHLAPI refpartition
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, PartitionHLAPI refpartition) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElement();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElement();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
 	}
-
-
-
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PartitionElementHLAPI(PartitionElement lowLevelAPI){
+	public PartitionElementHLAPI(PartitionElement lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -181,1008 +162,897 @@ public class PartitionElementHLAPI implements HLAPIClass,TermsDeclarationHLAPI,O
 	/**
 	 * Return encapsulated object
 	 */
-	public PartitionElement getContainedItem(){
+	public PartitionElement getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getName(){
+	public String getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declarations getContainerDeclarations(){
+	public Declarations getContainerDeclarations() {
 		return item.getContainerDeclarations();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getRefpartition(){
+	public Partition getRefpartition() {
 		return item.getRefpartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getPartitionelementconstants(){
+	public List<Term> getPartitionelementconstants() {
 		return item.getPartitionelementconstants();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI(){
-			if(item.getContainerDeclarations() == null) return null;
-			return new DeclarationsHLAPI(item.getContainerDeclarations());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getRefpartitionHLAPI(){
-			if(item.getRefpartition() == null) return null;
-			return new PartitionHLAPI(item.getRefpartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getPartitionelementconstantsHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getPartitionelementconstants_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getPartitionelementconstants_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getPartitionelementconstants_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getPartitionelementconstants_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getPartitionelementconstants_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getPartitionelementconstants_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getPartitionelementconstants_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getPartitionelementconstants_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getPartitionelementconstants_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getPartitionelementconstants_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getPartitionelementconstants_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getPartitionelementconstants_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getPartitionelementconstants_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getPartitionelementconstants_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getPartitionelementconstants_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getPartitionelementconstants_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getPartitionelementconstants_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getPartitionelementconstants_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getPartitionelementconstants_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getPartitionelementconstants_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getPartitionelementconstants_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getPartitionelementconstants_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getPartitionelementconstants_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getPartitionelementconstants_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getPartitionelementconstants_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getPartitionelementconstants_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getPartitionelementconstants_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getPartitionelementconstants_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getPartitionelementconstants_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getPartitionelementconstants_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getPartitionelementconstants_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getPartitionelementconstants_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getPartitionelementconstants_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getPartitionelementconstants()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI() {
+		if (item.getContainerDeclarations() == null)
+			return null;
+		return new DeclarationsHLAPI(item.getContainerDeclarations());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getRefpartitionHLAPI() {
+		if (item.getRefpartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getRefpartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getPartitionelementconstantsHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getPartitionelementconstants_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getPartitionelementconstants_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getPartitionelementconstants_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getPartitionelementconstants_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getPartitionelementconstants_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getPartitionelementconstants_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getPartitionelementconstants_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getPartitionelementconstants_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getPartitionelementconstants_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getPartitionelementconstants_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getPartitionelementconstants_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getPartitionelementconstants_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getPartitionelementconstants_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getPartitionelementconstants_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getPartitionelementconstants_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getPartitionelementconstants_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getPartitionelementconstants_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getPartitionelementconstants_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getPartitionelementconstants_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getPartitionelementconstants_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getPartitionelementconstants_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getPartitionelementconstants_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getPartitionelementconstants_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getPartitionelementconstants_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getPartitionelementconstants_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getPartitionelementconstants_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getPartitionelementconstants_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getPartitionelementconstants_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getPartitionelementconstants_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getPartitionelementconstants_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getPartitionelementconstants_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getPartitionelementconstants_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getPartitionelementconstants_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getPartitionelementconstants()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setName(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarations
 	 */
 	public void setContainerDeclarationsHLAPI(
-	
-	DeclarationsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarations((Declarations)elem.getContainedItem());
-	
+
+			DeclarationsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarations((Declarations) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Refpartition
 	 */
 	public void setRefpartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setRefpartition((Partition)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addPartitionelementconstantsHLAPI(TermHLAPI unit){
-	
-		item.getPartitionelementconstants().add((Term)unit.getContainedItem());
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setRefpartition((Partition) elem.getContainedItem());
+
 	}
 
-	public void removePartitionelementconstantsHLAPI(TermHLAPI unit){
-		item.getPartitionelementconstants().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(PartitionElementHLAPI item){
+	public void addPartitionelementconstantsHLAPI(TermHLAPI unit) {
+
+		item.getPartitionelementconstants().add((Term) unit.getContainedItem());
+	}
+
+	public void removePartitionelementconstantsHLAPI(TermHLAPI unit) {
+		item.getPartitionelementconstants().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PartitionElementHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/PartitionElementOfHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/PartitionElementOfHLAPI.java
@@ -65,8 +65,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.OperatorHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermHLAPI;
 
-
-public class PartitionElementOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class PartitionElementOfHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -74,432 +73,348 @@ public class PartitionElementOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLA
 	private PartitionElementOf item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionElementOfHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionHLAPI refpartition
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public PartitionElementOfHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionHLAPI refpartition
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition) {// BEGIN CONSTRUCTOR BODY
+		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public PartitionElementOfHLAPI(PartitionHLAPI refpartition
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartitionElementOf();
+		}
+
+		if (refpartition != null)
+			item.setRefpartition((Partition) refpartition.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public PartitionElementOfHLAPI(
-		 PartitionHLAPI refpartition
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartitionElementOf();}
-	
- 		
- 		if(refpartition!=null)
-			item.setRefpartition((Partition)refpartition.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PartitionElementOfHLAPI(PartitionElementOf lowLevelAPI){
+	public PartitionElementOfHLAPI(PartitionElementOf lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -507,1631 +422,1508 @@ public class PartitionElementOfHLAPI implements HLAPIClass,TermHLAPI,OperatorHLA
 	/**
 	 * Return encapsulated object
 	 */
-	public PartitionElementOf getContainedItem(){
+	public PartitionElementOf getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getRefpartition(){
+	public Partition getRefpartition() {
 		return item.getRefpartition();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getRefpartitionHLAPI(){
-			if(item.getRefpartition() == null) return null;
-			return new PartitionHLAPI(item.getRefpartition());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getRefpartitionHLAPI() {
+		if (item.getRefpartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getRefpartition());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Refpartition
 	 */
 	public void setRefpartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setRefpartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setRefpartition((Partition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(PartitionElementOfHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PartitionElementOfHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/PartitionHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/hlapi/PartitionHLAPI.java
@@ -58,8 +58,7 @@ import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortDeclHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.SortHLAPI;
 import fr.lip6.move.pnml.pthlpng.terms.hlapi.TermsDeclarationHLAPI;
 
-
-public class PartitionHLAPI implements HLAPIClass,TermsDeclarationHLAPI,SortDeclHLAPI{
+public class PartitionHLAPI implements HLAPIClass, TermsDeclarationHLAPI, SortDeclHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -67,91 +66,75 @@ public class PartitionHLAPI implements HLAPIClass,TermsDeclarationHLAPI,SortDecl
 	private Partition item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public PartitionHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI def
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PartitionHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI def) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(def!=null)
-			item.setDef((Sort)def.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (def != null)
+			item.setDef((Sort) def.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public PartitionHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI def
-	
-		, DeclarationsHLAPI containerDeclarations
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public PartitionHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI def
+
+			, DeclarationsHLAPI containerDeclarations) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
 		PartitionsFactory fact = PartitionsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createPartition();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(def!=null)
-			item.setDef((Sort)def.getContainedItem());
-		
-	
- 		
- 		if(containerDeclarations!=null)
-			item.setContainerDeclarations((Declarations)containerDeclarations.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createPartition();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (def != null)
+			item.setDef((Sort) def.getContainedItem());
+
+		if (containerDeclarations != null)
+			item.setContainerDeclarations((Declarations) containerDeclarations.getContainedItem());
+
 	}
-
-
-
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public PartitionHLAPI(Partition lowLevelAPI){
+	public PartitionHLAPI(Partition lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -159,248 +142,230 @@ public class PartitionHLAPI implements HLAPIClass,TermsDeclarationHLAPI,SortDecl
 	/**
 	 * Return encapsulated object
 	 */
-	public Partition getContainedItem(){
+	public Partition getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getName(){
+	public String getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declarations getContainerDeclarations(){
+	public Declarations getContainerDeclarations() {
 		return item.getContainerDeclarations();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getDef(){
+	public Sort getDef() {
 		return item.getDef();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<PartitionElement> getPartitionelements(){
+	public List<PartitionElement> getPartitionelements() {
 		return item.getPartitionelements();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI(){
-			if(item.getContainerDeclarations() == null) return null;
-			return new DeclarationsHLAPI(item.getContainerDeclarations());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getDefHLAPI(){
-			if(item.getDef() == null) return null;
-			Sort object = item.getDef();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI() {
+		if (item.getContainerDeclarations() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<PartitionElementHLAPI> getPartitionelementsHLAPI(){
-			java.util.List<PartitionElementHLAPI> retour = new ArrayList<PartitionElementHLAPI>();
-			for (PartitionElement elemnt : getPartitionelements()) {
-				retour.add(new PartitionElementHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
+		return new DeclarationsHLAPI(item.getContainerDeclarations());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getDefHLAPI() {
+		if (item.getDef() == null)
+			return null;
+		Sort object = item.getDef();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<PartitionElementHLAPI> getPartitionelementsHLAPI() {
+		java.util.List<PartitionElementHLAPI> retour = new ArrayList<PartitionElementHLAPI>();
+		for (PartitionElement elemnt : getPartitionelements()) {
+			retour.add(new PartitionElementHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setName(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Def
 	 */
 	public void setDefHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setDef((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setDef((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarations
 	 */
 	public void setContainerDeclarationsHLAPI(
-	
-	DeclarationsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarations((Declarations)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addPartitionelementsHLAPI(PartitionElementHLAPI unit){
-	
-		item.getPartitionelements().add((PartitionElement)unit.getContainedItem());
+			DeclarationsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarations((Declarations) elem.getContainedItem());
+
 	}
 
-	public void removePartitionelementsHLAPI(PartitionElementHLAPI unit){
-		item.getPartitionelements().remove((PartitionElement)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(PartitionHLAPI item){
+	public void addPartitionelementsHLAPI(PartitionElementHLAPI unit) {
+
+		item.getPartitionelements().add((PartitionElement) unit.getContainedItem());
+	}
+
+	public void removePartitionelementsHLAPI(PartitionElementHLAPI unit) {
+		item.getPartitionelements().remove((PartitionElement) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(PartitionHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/GreaterThanImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/GreaterThanImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Greater Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Greater
+ * Than</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterThan {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected GreaterThanImpl() {
@@ -80,8 +79,8 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 		return PartitionsPackage.Literals.GREATER_THAN;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		PartitionsFactory fact = PartitionsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class GreaterThanImpl extends PartitionOperatorImpl implements GreaterTha
 		return retour;
 
 	}
-} //GreaterThanImpl
+} // GreaterThanImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/LessThanImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/LessThanImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Less Than</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Less
+ * Than</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected LessThanImpl() {
@@ -80,8 +79,8 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 		return PartitionsPackage.Literals.LESS_THAN;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		PartitionsFactory fact = PartitionsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class LessThanImpl extends PartitionOperatorImpl implements LessThan {
 		return retour;
 
 	}
-} //LessThanImpl
+} // LessThanImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementImpl.java
@@ -98,14 +98,15 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Partition Element</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Partition Element</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl#getRefpartition <em>Refpartition</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl#getPartitionelementconstants <em>Partitionelementconstants</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl#getRefpartition
+ * <em>Refpartition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl#getPartitionelementconstants
+ * <em>Partitionelementconstants</em>}</li>
  * </ul>
  * </p>
  *
@@ -113,9 +114,10 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class PartitionElementImpl extends OperatorDeclImpl implements PartitionElement {
 	/**
-	 * The cached value of the '{@link #getPartitionelementconstants() <em>Partitionelementconstants</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPartitionelementconstants()
+	 * <em>Partitionelementconstants</em>}' containment reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getPartitionelementconstants()
 	 * @generated
 	 * @ordered
@@ -123,8 +125,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	protected EList<Term> partitionelementconstants;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PartitionElementImpl() {
@@ -132,8 +134,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -142,8 +144,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -154,8 +156,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetRefpartition(Partition newRefpartition, NotificationChain msgs) {
@@ -165,14 +167,15 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setRefpartition(Partition newRefpartition) {
 		if (newRefpartition != eInternalContainer()
-				|| (eContainerFeatureID() != PartitionsPackage.PARTITION_ELEMENT__REFPARTITION && newRefpartition != null)) {
+				|| (eContainerFeatureID() != PartitionsPackage.PARTITION_ELEMENT__REFPARTITION
+						&& newRefpartition != null)) {
 			if (EcoreUtil.isAncestor(this, newRefpartition))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -190,8 +193,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -205,8 +208,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -218,15 +221,15 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				msgs = eBasicRemoveFromContainer(msgs);
 			return basicSetRefpartition((Partition) otherEnd, msgs);
 		case PartitionsPackage.PARTITION_ELEMENT__PARTITIONELEMENTCONSTANTS:
-			return ((InternalEList<InternalEObject>) (InternalEList<?>) getPartitionelementconstants()).basicAdd(
-					otherEnd, msgs);
+			return ((InternalEList<InternalEObject>) (InternalEList<?>) getPartitionelementconstants())
+					.basicAdd(otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -241,8 +244,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -256,8 +259,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -272,8 +275,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -292,8 +295,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -310,8 +313,8 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -330,10 +333,10 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -351,7 +354,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -371,7 +374,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPartitionelementconstants() != null) {
 
@@ -406,16 +409,16 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//1
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 1
+		// 1
 		@SuppressWarnings("unused")
 		PartitionsFactory fact = PartitionsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -423,9 +426,9 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("name")) != null) {
 			try {
@@ -435,7 +438,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -449,7 +452,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("partitionelementof")) {
 				PartitionElementOf item;
@@ -459,7 +462,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("ltp")) {
 				LessThan item;
@@ -469,7 +472,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("equality")) {
 				Equality item;
@@ -479,7 +482,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("inequality")) {
 				Inequality item;
@@ -489,7 +492,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("booleanconstantt")) {
 				BooleanConstant item;
@@ -499,7 +502,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("or")) {
 				Or item;
@@ -509,7 +512,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("and")) {
 				And item;
@@ -519,7 +522,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("imply")) {
 				Imply item;
@@ -529,7 +532,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("not")) {
 				Not item;
@@ -539,7 +542,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dotconstant")) {
 				DotConstant item;
@@ -549,7 +552,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("cardinality")) {
 				Cardinality item;
@@ -559,7 +562,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("contains")) {
 				Contains item;
@@ -569,7 +572,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("cardinalityof")) {
 				CardinalityOf item;
@@ -579,7 +582,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("add")) {
 				Add item;
@@ -589,7 +592,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("all")) {
 				All item;
@@ -599,7 +602,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("empty")) {
 				Empty item;
@@ -609,7 +612,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("numberof")) {
 				NumberOf item;
@@ -619,7 +622,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("subtract")) {
 				Subtract item;
@@ -629,7 +632,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("scalarproduct")) {
 				ScalarProduct item;
@@ -639,7 +642,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("variable")) {
 				Variable item;
@@ -649,7 +652,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("tuple")) {
 				Tuple item;
@@ -659,7 +662,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("useroperator")) {
 				UserOperator item;
@@ -669,7 +672,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 				item.setContainerPartitionElement(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -680,10 +683,10 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -706,7 +709,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -726,7 +729,7 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getPartitionelementconstants() != null) {
 
@@ -812,4 +815,4 @@ public class PartitionElementImpl extends OperatorDeclImpl implements PartitionE
 		return retour;
 
 	}
-} //PartitionElementImpl
+} // PartitionElementImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementOfImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementOfImpl.java
@@ -68,13 +68,13 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Partition Element Of</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Partition Element Of</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl#getRefpartition <em>Refpartition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl#getRefpartition
+ * <em>Refpartition</em>}</li>
  * </ul>
  * </p>
  *
@@ -82,9 +82,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class PartitionElementOfImpl extends PartitionOperatorImpl implements PartitionElementOf {
 	/**
-	 * The cached value of the '{@link #getRefpartition() <em>Refpartition</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getRefpartition() <em>Refpartition</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getRefpartition()
 	 * @generated
 	 * @ordered
@@ -92,8 +92,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	protected Partition refpartition;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PartitionElementOfImpl() {
@@ -101,8 +101,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -111,8 +111,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,8 +130,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public Partition basicGetRefpartition() {
@@ -139,8 +139,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,8 +153,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -169,8 +169,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -184,8 +184,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -199,8 +199,8 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -212,24 +212,24 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -247,7 +247,7 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getRefpartition() != null) {
 			sb.append(" refpartition");
@@ -260,7 +260,7 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -303,18 +303,18 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//1
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 1
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		PartitionsFactory fact = PartitionsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -324,9 +324,9 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -549,7 +549,7 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -561,24 +561,24 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -601,7 +601,7 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getRefpartition() != null) {
 			sb.append(" refpartition");
@@ -614,7 +614,7 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -716,4 +716,4 @@ public class PartitionElementOfImpl extends PartitionOperatorImpl implements Par
 		return retour;
 
 	}
-} //PartitionElementOfImpl
+} // PartitionElementOfImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementOfImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionElementOfImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.DiagnosticChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionImpl.java
@@ -78,14 +78,15 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Partition</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Partition</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl#getDef <em>Def</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl#getPartitionelements <em>Partitionelements</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl#getDef
+ * <em>Def</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl#getPartitionelements
+ * <em>Partitionelements</em>}</li>
  * </ul>
  * </p>
  *
@@ -93,9 +94,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class PartitionImpl extends SortDeclImpl implements Partition {
 	/**
-	 * The cached value of the '{@link #getDef() <em>Def</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDef() <em>Def</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDef()
 	 * @generated
 	 * @ordered
@@ -103,9 +104,10 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	protected Sort def;
 
 	/**
-	 * The cached value of the '{@link #getPartitionelements() <em>Partitionelements</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getPartitionelements()
+	 * <em>Partitionelements</em>}' containment reference list. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #getPartitionelements()
 	 * @generated
 	 * @ordered
@@ -113,8 +115,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	protected EList<PartitionElement> partitionelements;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PartitionImpl() {
@@ -122,8 +124,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -132,8 +134,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -142,8 +144,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetDef(Sort newDef, NotificationChain msgs) {
@@ -161,8 +163,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -183,8 +185,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -197,8 +199,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -207,19 +209,19 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 		switch (featureID) {
 		case PartitionsPackage.PARTITION__DEF:
 			if (def != null)
-				msgs = ((InternalEObject) def).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- PartitionsPackage.PARTITION__DEF, null, msgs);
+				msgs = ((InternalEObject) def).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - PartitionsPackage.PARTITION__DEF, null, msgs);
 			return basicSetDef((Sort) otherEnd, msgs);
 		case PartitionsPackage.PARTITION__PARTITIONELEMENTS:
-			return ((InternalEList<InternalEObject>) (InternalEList<?>) getPartitionelements())
-					.basicAdd(otherEnd, msgs);
+			return ((InternalEList<InternalEObject>) (InternalEList<?>) getPartitionelements()).basicAdd(otherEnd,
+					msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -234,8 +236,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -250,8 +252,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -270,8 +272,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -288,8 +290,8 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -308,10 +310,10 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 2
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 2
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -329,7 +331,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -349,7 +351,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getDef() != null) {
 
@@ -396,16 +398,16 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//1
-		//2
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 1
+		// 2
 		@SuppressWarnings("unused")
 		PartitionsFactory fact = PartitionsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -413,9 +415,9 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("name")) != null) {
 			try {
@@ -425,7 +427,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -439,7 +441,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 				item.setContainerPartition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -449,7 +451,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 				item.setContainerPartition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("multisetsort")) {
 				MultisetSort item;
@@ -459,7 +461,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 				item.setContainerPartition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -469,7 +471,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 				item.setContainerPartition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -479,7 +481,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 				item.setContainerPartition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("partitionelement")) {
 				PartitionElement item;
@@ -489,7 +491,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 				item.setRefpartition(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -500,10 +502,10 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 2
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 2
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -526,7 +528,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -546,7 +548,7 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getDef() != null) {
 
@@ -648,4 +650,4 @@ public class PartitionImpl extends SortDeclImpl implements Partition {
 		return retour;
 
 	}
-} //PartitionImpl
+} // PartitionImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionOperatorImpl.java
@@ -39,9 +39,8 @@ import fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Partition Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Partition Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -49,8 +48,8 @@ import fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl;
  */
 public abstract class PartitionOperatorImpl extends BuiltInOperatorImpl implements PartitionOperator {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PartitionOperatorImpl() {
@@ -58,8 +57,8 @@ public abstract class PartitionOperatorImpl extends BuiltInOperatorImpl implemen
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -69,4 +68,4 @@ public abstract class PartitionOperatorImpl extends BuiltInOperatorImpl implemen
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //PartitionOperatorImpl
+} // PartitionOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionsFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionsFactoryImpl.java
@@ -46,16 +46,16 @@ import fr.lip6.move.pnml.pthlpng.partitions.PartitionsFactory;
 import fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static PartitionsFactory init() {
@@ -72,9 +72,9 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public PartitionsFactoryImpl() {
@@ -82,8 +82,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -105,8 +105,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -116,8 +116,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -127,8 +127,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -138,8 +138,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -149,8 +149,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -160,8 +160,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -170,8 +170,8 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -180,4 +180,4 @@ public class PartitionsFactoryImpl extends EFactoryImpl implements PartitionsFac
 		return PartitionsPackage.eINSTANCE;
 	}
 
-} //PartitionsFactoryImpl
+} // PartitionsFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionsPackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/impl/PartitionsPackageImpl.java
@@ -60,64 +60,64 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass partitionEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass partitionElementEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass greaterThanEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass partitionElementOfEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass partitionOperatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass lessThanEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage#eNS_URI
 	 * @see #init()
@@ -128,19 +128,22 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link PartitionsPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link PartitionsPackage#eINSTANCE} when
+	 * that field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -151,29 +154,37 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 			return (PartitionsPackage) EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI);
 
 		// Obtain or create and register package
-		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.get(eNS_URI) : new PartitionsPackageImpl());
+		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
+				.get(eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
+						: new PartitionsPackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
 		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) : BooleansPackage.eINSTANCE);
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(DotsPackage.eNS_URI) : DotsPackage.eINSTANCE);
+				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI)
+						: BooleansPackage.eINSTANCE);
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI)
+						: DotsPackage.eINSTANCE);
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) : HlcorestructurePackage.eINSTANCE);
+				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(HlcorestructurePackage.eNS_URI)
+						: HlcorestructurePackage.eINSTANCE);
 		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) : IntegersPackage.eINSTANCE);
+				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI)
+						: IntegersPackage.eINSTANCE);
 		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) : MultisetsPackage.eINSTANCE);
+				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI)
+						: MultisetsPackage.eINSTANCE);
 		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(TermsPackage.eNS_URI) : TermsPackage.eINSTANCE);
+				.getEPackage(TermsPackage.eNS_URI) instanceof TermsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI)
+						: TermsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		thePartitionsPackage.createPackageContents();
@@ -210,8 +221,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -220,8 +231,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -230,8 +241,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -240,8 +251,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -250,8 +261,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -260,8 +271,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -270,8 +281,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -280,8 +291,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -290,8 +301,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -300,8 +311,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -310,8 +321,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -320,8 +331,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -330,17 +341,17 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -368,17 +379,17 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -433,13 +444,14 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 		initEClass(partitionElementOfEClass, PartitionElementOf.class, "PartitionElementOf", !IS_ABSTRACT,
 				!IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getPartitionElementOf_Refpartition(), this.getPartition(), null, "refpartition", null, 1, 1,
-				PartitionElementOf.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-				IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				PartitionElementOf.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
+				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(partitionOperatorEClass, PartitionOperator.class, "PartitionOperator", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
 
-		initEClass(lessThanEClass, LessThan.class, "LessThan", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(lessThanEClass, LessThan.class, "LessThan", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 
 		// Create resource
 		createResource(eNS_URI);
@@ -457,8 +469,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -470,15 +482,15 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 		addAnnotation(getPartitionElement_Partitionelementconstants(), source, new String[] { "kind", "follow" });
 		addAnnotation(greaterThanEClass, source, new String[] { "tag", "gtp", "kind", "son" });
 		addAnnotation(partitionElementOfEClass, source, new String[] { "tag", "partitionelementof", "kind", "son" });
-		addAnnotation(getPartitionElementOf_Refpartition(), source, new String[] { "tag", "refpartition", "kind",
-				"idref" });
+		addAnnotation(getPartitionElementOf_Refpartition(), source,
+				new String[] { "tag", "refpartition", "kind", "idref" });
 		addAnnotation(lessThanEClass, source, new String[] { "tag", "ltp", "kind", "son" });
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -491,9 +503,9 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createOCLAnnotations() {
@@ -509,8 +521,8 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 
 	/**
 	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createEcoreAnnotations() {
@@ -521,4 +533,4 @@ public class PartitionsPackageImpl extends EPackageImpl implements PartitionsPac
 		addAnnotation(lessThanEClass, source, new String[] { "constraints", "inputOutputTypes" });
 	}
 
-} //PartitionsPackageImpl
+} // PartitionsPackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/util/PartitionsAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/util/PartitionsAdapterFactory.java
@@ -51,26 +51,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage
  * @generated
  */
 public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static PartitionsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public PartitionsAdapterFactory() {
@@ -80,10 +79,11 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -99,9 +99,9 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected PartitionsSwitch<Adapter> modelSwitch = new PartitionsSwitch<Adapter>() {
@@ -172,9 +172,9 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -185,11 +185,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition <em>Partition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition <em>Partition</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.Partition
 	 * @generated
@@ -199,11 +200,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement <em>Partition Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement <em>Partition
+	 * Element</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElement
 	 * @generated
@@ -213,11 +215,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.partitions.GreaterThan <em>Greater Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.GreaterThan <em>Greater
+	 * Than</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.GreaterThan
 	 * @generated
@@ -227,11 +230,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf <em>Partition Element Of</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf <em>Partition
+	 * Element Of</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf
 	 * @generated
@@ -241,11 +245,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionOperator <em>Partition Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionOperator <em>Partition
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionOperator
 	 * @generated
@@ -255,11 +260,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.partitions.LessThan <em>Less Than</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.LessThan <em>Less Than</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.LessThan
 	 * @generated
@@ -269,11 +275,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration
 	 * @generated
@@ -283,11 +290,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.SortDecl <em>Sort Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.SortDecl <em>Sort Decl</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.SortDecl
 	 * @generated
@@ -297,11 +305,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.OperatorDecl <em>Operator Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.OperatorDecl <em>Operator
+	 * Decl</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.OperatorDecl
 	 * @generated
@@ -311,11 +320,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -325,11 +335,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -339,11 +350,12 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator
 	 * @generated
@@ -353,10 +365,9 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -364,4 +375,4 @@ public class PartitionsAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //PartitionsAdapterFactory
+} // PartitionsAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/util/PartitionsSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/util/PartitionsSwitch.java
@@ -50,31 +50,28 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage
  * @generated
  */
 public class PartitionsSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static PartitionsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public PartitionsSwitch() {
@@ -84,9 +81,9 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -97,9 +94,10 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -192,13 +190,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Partition</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Partition</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Partition</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Partition</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -207,13 +206,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Partition Element</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Partition Element</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Partition Element</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Partition Element</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -222,13 +222,13 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Greater Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Greater
+	 * Than</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Greater Than</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Greater
+	 *         Than</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -237,13 +237,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Partition Element Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Partition Element Of</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Partition Element Of</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Partition Element Of</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -252,13 +253,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Partition Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Partition Operator</em>'. <!-- begin-user-doc --> This implementation
+	 * returns null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Partition Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Partition Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -267,13 +269,13 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Less Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Less
+	 * Than</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Less Than</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Less
+	 *         Than</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -282,13 +284,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Declaration</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Declaration</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Declaration</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Declaration</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -297,13 +300,13 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Sort Decl</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Sort
+	 * Decl</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Sort Decl</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Sort
+	 *         Decl</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -312,13 +315,13 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator Decl</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Operator
+	 * Decl</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator Decl</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Operator
+	 *         Decl</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -327,13 +330,13 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Term</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Term</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Term</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Term</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -342,13 +345,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Operator</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -357,13 +361,13 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -372,13 +376,14 @@ public class PartitionsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -387,4 +392,4 @@ public class PartitionsSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //PartitionsSwitch
+} // PartitionsSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/util/PartitionsValidator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/partitions/util/PartitionsValidator.java
@@ -49,25 +49,25 @@ import fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Validator</b> for the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Validator</b> for the model. <!-- end-user-doc
+ * -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionsPackage
  * @generated
  */
 public class PartitionsValidator extends EObjectValidator {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final PartitionsValidator INSTANCE = new PartitionsValidator();
 
 	/**
-	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource() source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode() codes} from this package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource()
+	 * source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode()
+	 * codes} from this package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.common.util.Diagnostic#getSource()
 	 * @see org.eclipse.emf.common.util.Diagnostic#getCode()
 	 * @generated
@@ -75,33 +75,35 @@ public class PartitionsValidator extends EObjectValidator {
 	public static final String DIAGNOSTIC_SOURCE = "fr.lip6.move.pnml.pthlpng.partitions";
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 0;
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
-	 * <!-- begin-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants in a derived class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static final int DIAGNOSTIC_CODE_COUNT = GENERATED_DIAGNOSTIC_CODE_COUNT;
 
 	/**
-	 * The cached base package validator.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached base package validator. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	protected TermsValidator termsValidator;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public PartitionsValidator() {
@@ -110,9 +112,9 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the package of this validator switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package of this validator switch. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -122,12 +124,13 @@ public class PartitionsValidator extends EObjectValidator {
 
 	/**
 	 * Calls <code>validateXXX</code> for the corresponding classifier of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		switch (classifierID) {
 		case PartitionsPackage.PARTITION:
 			return validatePartition((Partition) value, diagnostics, context);
@@ -147,8 +150,8 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePartition(Partition partition, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -156,8 +159,8 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePartitionElement(PartitionElement partitionElement, DiagnosticChain diagnostics,
@@ -185,9 +188,9 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the constantsType constraint of '<em>Partition Element</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the constantsType constraint of '<em>Partition Element</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePartitionElement_constantsType(PartitionElement partitionElement,
@@ -198,10 +201,10 @@ public class PartitionsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "constantsType", getObjectLabel(partitionElement, context) },
-						new Object[] { partitionElement }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "constantsType", getObjectLabel(partitionElement, context) },
+								new Object[] { partitionElement }, context));
 			}
 			return false;
 		}
@@ -209,11 +212,12 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateGreaterThan(GreaterThan greaterThan, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateGreaterThan(GreaterThan greaterThan, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		if (!validate_NoCircularContainment(greaterThan, diagnostics, context))
 			return false;
 		boolean result = validate_EveryMultiplicityConforms(greaterThan, diagnostics, context);
@@ -239,9 +243,9 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Greater Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Greater Than</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateGreaterThan_inputOutputTypes(GreaterThan greaterThan, DiagnosticChain diagnostics,
@@ -252,10 +256,10 @@ public class PartitionsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(greaterThan, context) },
-						new Object[] { greaterThan }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(greaterThan, context) },
+								new Object[] { greaterThan }, context));
 			}
 			return false;
 		}
@@ -263,8 +267,8 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePartitionElementOf(PartitionElementOf partitionElementOf, DiagnosticChain diagnostics,
@@ -295,8 +299,8 @@ public class PartitionsValidator extends EObjectValidator {
 
 	/**
 	 * Validates the inputOutputTypes constraint of '<em>Partition Element Of</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePartitionElementOf_inputOutputTypes(PartitionElementOf partitionElementOf,
@@ -307,10 +311,10 @@ public class PartitionsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(partitionElementOf, context) },
-						new Object[] { partitionElementOf }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(partitionElementOf, context) },
+								new Object[] { partitionElementOf }, context));
 			}
 			return false;
 		}
@@ -318,8 +322,8 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validatePartitionOperator(PartitionOperator partitionOperator, DiagnosticChain diagnostics,
@@ -347,8 +351,8 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLessThan(LessThan lessThan, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -377,9 +381,9 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the inputOutputTypes constraint of '<em>Less Than</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the inputOutputTypes constraint of '<em>Less Than</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateLessThan_inputOutputTypes(LessThan lessThan, DiagnosticChain diagnostics,
@@ -390,10 +394,10 @@ public class PartitionsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "inputOutputTypes", getObjectLabel(lessThan, context) },
-						new Object[] { lessThan }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "inputOutputTypes", getObjectLabel(lessThan, context) },
+								new Object[] { lessThan }, context));
 			}
 			return false;
 		}
@@ -401,17 +405,18 @@ public class PartitionsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the resource locator that will be used to fetch messages for this validator's diagnostics.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the resource locator that will be used to fetch messages for this
+	 * validator's diagnostics. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public ResourceLocator getResourceLocator() {
 		// TODO
-		// Specialize this to return a resource locator for messages specific to this validator.
+		// Specialize this to return a resource locator for messages specific to this
+		// validator.
 		// Ensure that you remove @generated or mark it @generated NOT
 		return super.getResourceLocator();
 	}
 
-} //PartitionsValidator
+} // PartitionsValidator

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/BuiltInConstant.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/BuiltInConstant.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Built In Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Built In
+ * Constant</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getBuiltInConstant()
@@ -57,8 +56,8 @@ public interface BuiltInConstant extends Operator {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/BuiltInOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/BuiltInOperator.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Built In Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Built In
+ * Operator</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getBuiltInOperator()
@@ -57,8 +56,8 @@ public interface BuiltInOperator extends Operator {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/BuiltInSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/BuiltInSort.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Built In Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Built In
+ * Sort</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getBuiltInSort()
@@ -57,8 +56,8 @@ public interface BuiltInSort extends Sort {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Declarations.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Declarations.java
@@ -45,33 +45,38 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Declarations</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Declarations</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration <em>Declaration</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration <em>Container Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration
+ * <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration
+ * <em>Container Declaration</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getDeclarations()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='declarations' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='declarations'
+ *        kind='son'"
  * @generated
  */
 public interface Declarations extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Declaration</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations <em>Container Declarations</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Declaration</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration}. It is bidirectional
+	 * and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations
+	 * <em>Container Declarations</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Declaration</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Declaration</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Declaration</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getDeclarations_Declaration()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations
@@ -82,15 +87,18 @@ public interface Declarations extends EObject {
 	List<TermsDeclaration> getDeclaration();
 
 	/**
-	 * Returns the value of the '<em><b>Container Declaration</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Declaration</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Declaration</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Declaration</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Declaration</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Declaration</em>' container
+	 *         reference.
 	 * @see #setContainerDeclaration(Declaration)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getDeclarations_ContainerDeclaration()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration#getStructure
@@ -100,10 +108,13 @@ public interface Declarations extends EObject {
 	Declaration getContainerDeclaration();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration <em>Container Declaration</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration
+	 * <em>Container Declaration</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Declaration</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Declaration</em>' container
+	 *              reference.
 	 * @see #getContainerDeclaration()
 	 * @generated
 	 */
@@ -117,8 +128,8 @@ public interface Declarations extends EObject {
 	/**
 	 * set values to conform PNML document
 	 */
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Declarations.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Declarations.java
@@ -60,7 +60,7 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.Declaration;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getDeclarations()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='declarations'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Declarations extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/MultisetOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/MultisetOperator.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Multiset Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Multiset
+ * Operator</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getMultisetOperator()
@@ -57,8 +56,8 @@ public interface MultisetOperator extends Operator {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/MultisetSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/MultisetSort.java
@@ -55,13 +55,14 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getMultisetSort()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='multisetsort'
- *        kind='son'" annotation="http://www.pnml.org/models/methods/SORT
- *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
- *        false;\n\t\tif
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
  *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
- *        {\n\t\t \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
- *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
- *        they have been explicitly named.\n\t\t\t\tisEqual =
+ *        {\n\t\t \tif (this.getContainerNamedSort() !=
+ *        null\n\t\t\t\t\t&amp;&amp; sort.getContainerNamedSort() != null)
+ *        {\n\t\t\t\t// we test them if they have been explicitly
+ *        named.\n\t\t\t\tisEqual =
  *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}
  *        else {\n\t\t\t throw new UnsupportedOperationException(\"Cannot
  *        determine if these two multisets are equal.\"\n\t\t\t + \"You should

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/MultisetSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/MultisetSort.java
@@ -42,32 +42,51 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Multiset Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Multiset
+ * Sort</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis <em>Basis</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis
+ * <em>Basis</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getMultisetSort()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='multisetsort' kind='son'"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t throw new UnsupportedOperationException(\"Cannot determine if these two multisets are equal.\"\n\t\t\t + \"You should override this method.\");\n\t\t\t}\n\t\t}\n\t\treturn isEqual;' documentation='/**\r * Note : there is no implementation available for MultisetSort yet.\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r \052/'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='multisetsort'
+ *        kind='son'" annotation="http://www.pnml.org/models/methods/SORT
+ *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
+ *        false;\n\t\tif
+ *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
+ *        {\n\t\t \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if
+ *        they have been explicitly named.\n\t\t\t\tisEqual =
+ *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}
+ *        else {\n\t\t\t throw new UnsupportedOperationException(\"Cannot
+ *        determine if these two multisets are equal.\"\n\t\t\t + \"You should
+ *        override this method.\");\n\t\t\t}\n\t\t}\n\t\treturn isEqual;'
+ *        documentation='/**\r * Note : there is no implementation available for
+ *        MultisetSort yet.\r * Returns true if this sort and argument sort are
+ *        actually \r * semantically the same sort, even in two different
+ *        objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return
+ *        true if so. \r * @param sort the sort to which we compare this one. \r
+ *        * @throws NullPointerException if according to the model, some\r *
+ *        required reference attributes have not been set.\r \052/'"
  * @generated
  */
 public interface MultisetSort extends Sort {
 	/**
-	 * Returns the value of the '<em><b>Basis</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Basis</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}'. <!--
+	 * begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Basis</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Basis</em>' containment reference.
 	 * @see #setBasis(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getMultisetSort_Basis()
@@ -79,9 +98,11 @@ public interface MultisetSort extends Sort {
 	Sort getBasis();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis <em>Basis</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis
+	 * <em>Basis</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Basis</em>' containment reference.
 	 * @see #getBasis()
 	 * @generated
@@ -98,8 +119,8 @@ public interface MultisetSort extends Sort {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedOperator.java
@@ -58,7 +58,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getNamedOperator()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='namedoperator'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface NamedOperator extends OperatorDecl {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedOperator.java
@@ -43,46 +43,52 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Named Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Named
+ * Operator</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters <em>Parameters</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef
+ * <em>Def</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters
+ * <em>Parameters</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getNamedOperator()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='namedoperator' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='namedoperator'
+ *        kind='son'"
  * @generated
  */
 public interface NamedOperator extends OperatorDecl {
 	/**
-	 * Returns the value of the '<em><b>Def</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator <em>Container Named Operator</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Def</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator
+	 * <em>Container Named Operator</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Def</em>' containment reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Def</em>' containment reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Def</em>' containment reference.
 	 * @see #setDef(Term)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getNamedOperator_Def()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator
-	 * @model opposite="containerNamedOperator" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='def' kind='follow' toBeFollowed='yes'"
+	 * @model opposite="containerNamedOperator" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        tag='def' kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	Term getDef();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Def</em>' containment reference.
 	 * @see #getDef()
 	 * @generated
@@ -90,20 +96,24 @@ public interface NamedOperator extends OperatorDecl {
 	void setDef(Term value);
 
 	/**
-	 * Returns the value of the '<em><b>Parameters</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator <em>Container Named Operator</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Parameters</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl}. It is bidirectional and
+	 * its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator
+	 * <em>Container Named Operator</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Parameters</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Parameters</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Parameters</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getNamedOperator_Parameters()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator
 	 * @model opposite="containerNamedOperator" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='parameter' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='parameter'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	List<VariableDecl> getParameters();
@@ -118,8 +128,8 @@ public interface NamedOperator extends OperatorDecl {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedSort.java
@@ -59,7 +59,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='refSortNotMultiset'"
  *        annotation="http://www.pnml.org/models/ToPNML tag='namedsort'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface NamedSort extends SortDecl {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/NamedSort.java
@@ -42,47 +42,55 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Named Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Named
+ * Sort</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef <em>Sortdef</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef
+ * <em>Sortdef</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getNamedSort()
- * @model annotation="http://www.pnml.org/models/OCL refSortNotMultiset='not(self.sortdef.oclIsTypeOf(MultisetSort))'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='refSortNotMultiset'"
- *        annotation="http://www.pnml.org/models/ToPNML tag='namedsort' kind='son'"
+ * @model annotation="http://www.pnml.org/models/OCL
+ *        refSortNotMultiset='not(self.sortdef.oclIsTypeOf(MultisetSort))'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='refSortNotMultiset'"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='namedsort'
+ *        kind='son'"
  * @generated
  */
 public interface NamedSort extends SortDecl {
 	/**
-	 * Returns the value of the '<em><b>Sortdef</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort <em>Container Named Sort</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Sortdef</b></em>' containment reference. It
+	 * is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort
+	 * <em>Container Named Sort</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Sortdef</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Sortdef</em>' containment reference.
 	 * @see #setSortdef(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getNamedSort_Sortdef()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort
-	 * @model opposite="containerNamedSort" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerNamedSort" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Sort getSortdef();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef <em>Sortdef</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef
+	 * <em>Sortdef</em>}' containment reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Sortdef</em>' containment reference.
 	 * @see #getSortdef()
 	 * @generated
@@ -99,8 +107,8 @@ public interface NamedSort extends SortDecl {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Operator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Operator.java
@@ -63,6 +63,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        sameOperatorNTermSort='self.sort = self.output'"
  *        annotation="http://www.eclipse.org/emf/2002/Ecore
  *        constraints='sameOperatorNTermSort'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Operator extends Term {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Operator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Operator.java
@@ -43,53 +43,60 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Operator</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm <em>Subterm</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput <em>Output</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getInput <em>Input</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm
+ * <em>Subterm</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput
+ * <em>Output</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getInput
+ * <em>Input</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getOperator()
- * @model abstract="true"
- *        annotation="http://www.pnml.org/models/OCL sameOperatorNTermSort='self.sort = self.output'"
- *        annotation="http://www.eclipse.org/emf/2002/Ecore constraints='sameOperatorNTermSort'"
+ * @model abstract="true" annotation="http://www.pnml.org/models/OCL
+ *        sameOperatorNTermSort='self.sort = self.output'"
+ *        annotation="http://www.eclipse.org/emf/2002/Ecore
+ *        constraints='sameOperatorNTermSort'"
  * @generated
  */
 public interface Operator extends Term {
 	/**
-	 * Returns the value of the '<em><b>Subterm</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.Term}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator <em>Container Operator</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Subterm</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.terms.Term}. It is bidirectional and its
+	 * opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator
+	 * <em>Container Operator</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Subterm</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Subterm</em>' containment reference list isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Subterm</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getOperator_Subterm()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator
 	 * @model opposite="containerOperator" containment="true"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='subterm' kind='follow' toBeFollowed='yes'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='subterm'
+	 *        kind='follow' toBeFollowed='yes'"
 	 * @generated
 	 */
 	List<Term> getSubterm();
 
 	/**
-	 * Returns the value of the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Output</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Output</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Output</em>' reference.
 	 * @see #setOutput(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getOperator_Output()
@@ -99,9 +106,10 @@ public interface Operator extends Term {
 	Sort getOutput();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput <em>Output</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput <em>Output</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Output</em>' reference.
 	 * @see #getOutput()
 	 * @generated
@@ -109,14 +117,15 @@ public interface Operator extends Term {
 	void setOutput(Sort value);
 
 	/**
-	 * Returns the value of the '<em><b>Input</b></em>' reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.Sort}.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Input</b></em>' reference list. The list
+	 * contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.Sort}. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Input</em>' reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Input</em>' reference list isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Input</em>' reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getOperator_Input()
 	 * @model derived="true"
@@ -128,8 +137,8 @@ public interface Operator extends Term {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/OperatorDecl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/OperatorDecl.java
@@ -47,7 +47,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getOperatorDecl()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface OperatorDecl extends TermsDeclaration {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/OperatorDecl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/OperatorDecl.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Operator Decl</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Operator
+ * Decl</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getOperatorDecl()
@@ -57,8 +56,8 @@ public interface OperatorDecl extends TermsDeclaration {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/ProductSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/ProductSort.java
@@ -56,12 +56,13 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getProductSort()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='productsort'
- *        kind='son'" annotation="http://www.pnml.org/models/methods/SORT
- *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
- *        false;\n\t\tif
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
  *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
- *        {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
- *        sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual =
+ *        {\n\t\t\tif (this.getContainerNamedSort() !=
+ *        null\n\t\t\t\t\t&amp;&amp; sort.getContainerNamedSort() != null)
+ *        {\n\t\t\t\tisEqual =
  *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}
  *        else {\n\t\t\t\t// Someone may one day inherit from ProductSort, so we
  *        should\n\t\t\t\t// strictly check for ProductSort only. Further
@@ -69,10 +70,10 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *        (\"ProductSort\".equalsIgnoreCase(this.eClass().getName()))
  *        {\n\t\t\t\t\tProductSort mySort = (ProductSort)
  *        this;\n\t\t\t\t\tProductSort thatSort = (ProductSort)
- *        sort;\n\t\t\t\t\tList<Sort> myElements =
- *        mySort.getElementSort();\n\t\t\t\t\tList<Sort> thoseElements =
+ *        sort;\n\t\t\t\t\tList&lt;Sort&gt; myElements =
+ *        mySort.getElementSort();\n\t\t\t\t\tList&lt;Sort&gt; thoseElements =
  *        thatSort.getElementSort();\n\t\t\t\t\tint i = 0;\n\t\t\t\t\tint j =
- *        0;\n\t\t\t\t\tfor (; i < myElements.size() && j <
+ *        0;\n\t\t\t\t\tfor (; i &lt; myElements.size() &amp;&amp; j &lt;
  *        thoseElements.size(); i++, j++) {\n\t\t\t\t\t\tif
  *        (myElements\n\t\t\t\t\t\t\t\t.get(i)\n\t\t\t\t\t\t\t\t.eClass()\n\t\t\t\t\t\t\t\t.getName()\n\t\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t\tthoseElements.get(j).eClass().getName()))
  *        {\n\t\t\t\t\t\t\tisEqual = true;\n\t\t\t\t\t\t} else

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/ProductSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/ProductSort.java
@@ -43,33 +43,62 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Product Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Product
+ * Sort</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort <em>Element Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort
+ * <em>Element Sort</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getProductSort()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='productsort' kind='son'"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t\t// Someone may one day inherit from ProductSort, so we should\n\t\t\t\t// strictly check for ProductSort only. Further sub-classes must \n\t\t\t\t//override this method.\n\t\t\t\tif (\"ProductSort\".equalsIgnoreCase(this.eClass().getName())) {\n\t\t\t\t\tProductSort mySort = (ProductSort) this;\n\t\t\t\t\tProductSort thatSort = (ProductSort) sort;\n\t\t\t\t\tList<Sort> myElements = mySort.getElementSort();\n\t\t\t\t\tList<Sort> thoseElements = thatSort.getElementSort();\n\t\t\t\t\tint i = 0;\n\t\t\t\t\tint j = 0;\n\t\t\t\t\tfor (; i < myElements.size() && j < thoseElements.size(); i++, j++) {\n\t\t\t\t\t\tif (myElements\n\t\t\t\t\t\t\t\t.get(i)\n\t\t\t\t\t\t\t\t.eClass()\n\t\t\t\t\t\t\t\t.getName()\n\t\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t\tthoseElements.get(j).eClass().getName())) {\n\t\t\t\t\t\t\tisEqual = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tisEqual = false;\n\t\t\t\t\t\t\tbreak;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t}\t\t\n\t\t\t}\n\t\t}\n\t\treturn isEqual;' documentation='/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r \052/'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='productsort'
+ *        kind='son'" annotation="http://www.pnml.org/models/methods/SORT
+ *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
+ *        false;\n\t\tif
+ *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
+ *        {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual =
+ *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}
+ *        else {\n\t\t\t\t// Someone may one day inherit from ProductSort, so we
+ *        should\n\t\t\t\t// strictly check for ProductSort only. Further
+ *        sub-classes must \n\t\t\t\t//override this method.\n\t\t\t\tif
+ *        (\"ProductSort\".equalsIgnoreCase(this.eClass().getName()))
+ *        {\n\t\t\t\t\tProductSort mySort = (ProductSort)
+ *        this;\n\t\t\t\t\tProductSort thatSort = (ProductSort)
+ *        sort;\n\t\t\t\t\tList<Sort> myElements =
+ *        mySort.getElementSort();\n\t\t\t\t\tList<Sort> thoseElements =
+ *        thatSort.getElementSort();\n\t\t\t\t\tint i = 0;\n\t\t\t\t\tint j =
+ *        0;\n\t\t\t\t\tfor (; i < myElements.size() && j <
+ *        thoseElements.size(); i++, j++) {\n\t\t\t\t\t\tif
+ *        (myElements\n\t\t\t\t\t\t\t\t.get(i)\n\t\t\t\t\t\t\t\t.eClass()\n\t\t\t\t\t\t\t\t.getName()\n\t\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t\tthoseElements.get(j).eClass().getName()))
+ *        {\n\t\t\t\t\t\t\tisEqual = true;\n\t\t\t\t\t\t} else
+ *        {\n\t\t\t\t\t\t\tisEqual =
+ *        false;\n\t\t\t\t\t\t\tbreak;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t}\t\t\n\t\t\t}\n\t\t}\n\t\treturn
+ *        isEqual;' documentation='/**\r * Returns true if this sort and
+ *        argument sort are actually \r * semantically the same sort, even in
+ *        two different objects.\r * Ex: two FiniteEnumerations or two
+ *        Integers.\r * @return true if so. \r * @param sort the sort to which
+ *        we compare this one. \r \052/'"
  * @generated
  */
 public interface ProductSort extends Sort {
 	/**
-	 * Returns the value of the '<em><b>Element Sort</b></em>' containment reference list.
-	 * The list contents are of type {@link fr.lip6.move.pnml.pthlpng.terms.Sort}.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort <em>Container Product Sort</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Element Sort</b></em>' containment reference
+	 * list. The list contents are of type
+	 * {@link fr.lip6.move.pnml.pthlpng.terms.Sort}. It is bidirectional and its
+	 * opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort
+	 * <em>Container Product Sort</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Element Sort</em>' containment reference list isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Element Sort</em>' containment reference list
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Element Sort</em>' containment reference list.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getProductSort_ElementSort()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort
@@ -89,8 +118,8 @@ public interface ProductSort extends Sort {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Sort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Sort.java
@@ -72,22 +72,18 @@ import fr.lip6.move.pnml.pthlpng.partitions.Partition;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort()
- * @model abstract="true" annotation="http://www.pnml.org/models/methods/SORT
- *        signature='boolean equalSorts(Sort sort)' body='' documentation='/**\n
- *        * Returns true if this sort and argument sort are actually
- *        semantically the\n * same sort, even in two different objects. \n *
- *        <p>
- *        Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or\n * two
- *        Integers I1 and I2.
- *        </p>
- *        \n *
- *        <p>
- *        <strong>Note</strong> : the implementation available for\n *
- *        MultisetSort is not complete. In particular, we just test equality\n *
- *        of the references or of the enclosing NamedSorts (if any). \n * You
- *        should consider overriding it in that case.\n * \n * @return true if
- *        so.\n * @param sort\n * the sort to which we compare this one.\n
- *        \052/'"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='' documentation='/**\n * Returns true if
+ *        this sort and argument sort are actually semantically the\n * same
+ *        sort, even in two different objects. \n * &lt;p&gt;Ex: two
+ *        FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or\n * two Integers
+ *        I1 and I2.&lt;/p&gt; \n * &lt;p&gt;&lt;strong&gt;Note&lt;/strong&gt; :
+ *        the implementation available for\n * MultisetSort is not complete. In
+ *        particular, we just test equality\n * of the references or of the
+ *        enclosing NamedSorts (if any). \n * You should consider overriding it
+ *        in that case.\n * \n * @return true if so.\n * @param sort\n * the
+ *        sort to which we compare this one.\n \052/'"
  * @generated
  */
 public interface Sort extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Sort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Sort.java
@@ -47,39 +47,61 @@ import fr.lip6.move.pnml.pthlpng.multisets.Empty;
 import fr.lip6.move.pnml.pthlpng.partitions.Partition;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Sort</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort <em>Container Named Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl <em>Container Variable Decl</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort <em>Container Product Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container All</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container Empty</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition <em>Container Partition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort
+ * <em>Container Named Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl
+ * <em>Container Variable Decl</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort
+ * <em>Container Product Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType
+ * <em>Container Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container
+ * All</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty
+ * <em>Container Empty</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition
+ * <em>Container Partition</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort()
- * @model abstract="true"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='' documentation='/**\n  * Returns true if this sort and argument sort are actually semantically the\n  * same sort, even in two different objects. \n  * <p>Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or\n  * two Integers I1 and I2.</p> \n  * <p><strong>Note</strong> : the implementation available for\n  * MultisetSort is not complete. In particular, we just test equality\n  * of the references or of the enclosing NamedSorts (if any). \n  * You should consider overriding it in that case.\n  * \n  * @return true if so.\n  * @param sort\n  *            the sort to which we compare this one.\n  \052/'"
+ * @model abstract="true" annotation="http://www.pnml.org/models/methods/SORT
+ *        signature='boolean equalSorts(Sort sort)' body='' documentation='/**\n
+ *        * Returns true if this sort and argument sort are actually
+ *        semantically the\n * same sort, even in two different objects. \n *
+ *        <p>
+ *        Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or\n * two
+ *        Integers I1 and I2.
+ *        </p>
+ *        \n *
+ *        <p>
+ *        <strong>Note</strong> : the implementation available for\n *
+ *        MultisetSort is not complete. In particular, we just test equality\n *
+ *        of the references or of the enclosing NamedSorts (if any). \n * You
+ *        should consider overriding it in that case.\n * \n * @return true if
+ *        so.\n * @param sort\n * the sort to which we compare this one.\n
+ *        \052/'"
  * @generated
  */
 public interface Sort extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Multi</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis <em>Basis</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Multi</b></em>' container reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis
+	 * <em>Basis</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Multi</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Multi</em>' container reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Multi</em>' container reference.
 	 * @see #setMulti(MultisetSort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_Multi()
@@ -90,9 +112,10 @@ public interface Sort extends EObject {
 	MultisetSort getMulti();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti
+	 * <em>Multi</em>}' container reference. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Multi</em>' container reference.
 	 * @see #getMulti()
 	 * @generated
@@ -100,14 +123,16 @@ public interface Sort extends EObject {
 	void setMulti(MultisetSort value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Named Sort</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef <em>Sortdef</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Named Sort</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef
+	 * <em>Sortdef</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Named Sort</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Named Sort</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Named Sort</em>' container reference.
 	 * @see #setContainerNamedSort(NamedSort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerNamedSort()
@@ -118,25 +143,31 @@ public interface Sort extends EObject {
 	NamedSort getContainerNamedSort();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort <em>Container Named Sort</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort
+	 * <em>Container Named Sort</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Named Sort</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Named Sort</em>' container
+	 *              reference.
 	 * @see #getContainerNamedSort()
 	 * @generated
 	 */
 	void setContainerNamedSort(NamedSort value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}'.
+	 * Returns the value of the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Variable Decl</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Variable Decl</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Variable Decl</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Variable Decl</em>' container
+	 *         reference.
 	 * @see #setContainerVariableDecl(VariableDecl)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerVariableDecl()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort
@@ -146,25 +177,31 @@ public interface Sort extends EObject {
 	VariableDecl getContainerVariableDecl();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl <em>Container Variable Decl</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Variable Decl</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl
+	 * <em>Container Variable Decl</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Variable Decl</em>'
+	 *              container reference.
 	 * @see #getContainerVariableDecl()
 	 * @generated
 	 */
 	void setContainerVariableDecl(VariableDecl value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Product Sort</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort <em>Element Sort</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Product Sort</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort
+	 * <em>Element Sort</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Product Sort</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Product Sort</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Product Sort</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Product Sort</em>' container
+	 *         reference.
 	 * @see #setContainerProductSort(ProductSort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerProductSort()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort
@@ -174,24 +211,29 @@ public interface Sort extends EObject {
 	ProductSort getContainerProductSort();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort <em>Container Product Sort</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Product Sort</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort
+	 * <em>Container Product Sort</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Product Sort</em>' container
+	 *              reference.
 	 * @see #getContainerProductSort()
 	 * @generated
 	 */
 	void setContainerProductSort(ProductSort value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Type</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Type</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Type#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Type</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Type</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Type</em>' container reference.
 	 * @see #setContainerType(Type)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerType()
@@ -202,10 +244,13 @@ public interface Sort extends EObject {
 	Type getContainerType();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container Type</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Type</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container
+	 * Type</em>}' container reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @param value the new value of the '<em>Container Type</em>' container
+	 *              reference.
 	 * @see #getContainerType()
 	 * @generated
 	 */
@@ -213,13 +258,15 @@ public interface Sort extends EObject {
 
 	/**
 	 * Returns the value of the '<em><b>Container All</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort <em>Refsort</em>}'.
-	 * <!-- begin-user-doc -->
+	 * It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.All#getRefsort
+	 * <em>Refsort</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container All</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container All</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container All</em>' container reference.
 	 * @see #setContainerAll(All)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerAll()
@@ -230,24 +277,28 @@ public interface Sort extends EObject {
 	All getContainerAll();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container All</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container All</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container
+	 * All</em>}' container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container All</em>' container
+	 *              reference.
 	 * @see #getContainerAll()
 	 * @generated
 	 */
 	void setContainerAll(All value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Empty</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort <em>Refsort</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Empty</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.multisets.Empty#getRefsort
+	 * <em>Refsort</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Empty</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Empty</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Empty</em>' container reference.
 	 * @see #setContainerEmpty(Empty)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerEmpty()
@@ -258,24 +309,29 @@ public interface Sort extends EObject {
 	Empty getContainerEmpty();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container Empty</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Empty</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container
+	 * Empty</em>}' container reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @param value the new value of the '<em>Container Empty</em>' container
+	 *              reference.
 	 * @see #getContainerEmpty()
 	 * @generated
 	 */
 	void setContainerEmpty(Empty value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Partition</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}'.
+	 * Returns the value of the '<em><b>Container Partition</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.Partition#getDef <em>Def</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Partition</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Partition</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Partition</em>' container reference.
 	 * @see #setContainerPartition(Partition)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSort_ContainerPartition()
@@ -286,10 +342,13 @@ public interface Sort extends EObject {
 	Partition getContainerPartition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition <em>Container Partition</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition
+	 * <em>Container Partition</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Partition</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Partition</em>' container
+	 *              reference.
 	 * @see #getContainerPartition()
 	 * @generated
 	 */
@@ -297,8 +356,8 @@ public interface Sort extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 
@@ -306,17 +365,19 @@ public interface Sort extends EObject {
 
 	/**
 	 * Returns true if this sort and argument sort are actually semantically the
-	 * same sort, even in two different objects. 
-	 * <p>Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or
-	 * two Integers I1 and I2.</p> 
-	 * <p><strong>Note</strong> : the implementation available for
-	 * MultisetSort is not complete. In particular, we just test equality
-	 * of the references or of the enclosing NamedSorts (if any). 
-	 * You should consider overriding it in that case.
+	 * same sort, even in two different objects.
+	 * <p>
+	 * Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or two Integers I1
+	 * and I2.
+	 * </p>
+	 * <p>
+	 * <strong>Note</strong> : the implementation available for MultisetSort is not
+	 * complete. In particular, we just test equality of the references or of the
+	 * enclosing NamedSorts (if any). You should consider overriding it in that
+	 * case.
 	 * 
 	 * @return true if so.
-	 * @param sort
-	 *            the sort to which we compare this one.
+	 * @param sort the sort to which we compare this one.
 	 */
 	boolean equalSorts(Sort sort);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/SortDecl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/SortDecl.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Sort Decl</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Sort
+ * Decl</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSortDecl()
@@ -57,8 +56,8 @@ public interface SortDecl extends TermsDeclaration {
 	public abstract String toPNML();
 
 	@Override
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	@Override
 	public abstract void toPNML(FileChannel fc);

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/SortDecl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/SortDecl.java
@@ -47,7 +47,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getSortDecl()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface SortDecl extends TermsDeclaration {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Term.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Term.java
@@ -47,20 +47,25 @@ import fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking;
 import fr.lip6.move.pnml.pthlpng.partitions.PartitionElement;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Term</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Term</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getSort <em>Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator <em>Container Operator</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator <em>Container Named Operator</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking <em>Container HL Marking</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition <em>Container Condition</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation <em>Container HL Annotation</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement <em>Container Partition Element</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getSort <em>Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator
+ * <em>Container Operator</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator
+ * <em>Container Named Operator</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking
+ * <em>Container HL Marking</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition
+ * <em>Container Condition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation
+ * <em>Container HL Annotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement
+ * <em>Container Partition Element</em>}</li>
  * </ul>
  * </p>
  *
@@ -70,13 +75,14 @@ import fr.lip6.move.pnml.pthlpng.partitions.PartitionElement;
  */
 public interface Term extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Sort</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Sort</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Sort</em>' reference isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Sort</em>' reference.
 	 * @see #setSort(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_Sort()
@@ -86,9 +92,9 @@ public interface Term extends EObject {
 	Sort getSort();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getSort <em>Sort</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getSort
+	 * <em>Sort</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Sort</em>' reference.
 	 * @see #getSort()
 	 * @generated
@@ -96,14 +102,16 @@ public interface Term extends EObject {
 	void setSort(Sort value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Operator</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm <em>Subterm</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Operator</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm
+	 * <em>Subterm</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Operator</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Operator</em>' container reference isn't
+	 * clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Operator</em>' container reference.
 	 * @see #setContainerOperator(Operator)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_ContainerOperator()
@@ -114,25 +122,31 @@ public interface Term extends EObject {
 	Operator getContainerOperator();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator <em>Container Operator</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator
+	 * <em>Container Operator</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Operator</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Operator</em>' container
+	 *              reference.
 	 * @see #getContainerOperator()
 	 * @generated
 	 */
 	void setContainerOperator(Operator value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Named Operator</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}'.
+	 * Returns the value of the '<em><b>Container Named Operator</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Named Operator</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Named Operator</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Named Operator</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Named Operator</em>' container
+	 *         reference.
 	 * @see #setContainerNamedOperator(NamedOperator)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_ContainerNamedOperator()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef
@@ -142,24 +156,29 @@ public interface Term extends EObject {
 	NamedOperator getContainerNamedOperator();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator <em>Container Named Operator</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Named Operator</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator
+	 * <em>Container Named Operator</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Named Operator</em>'
+	 *              container reference.
 	 * @see #getContainerNamedOperator()
 	 * @generated
 	 */
 	void setContainerNamedOperator(NamedOperator value);
 
 	/**
-	 * Returns the value of the '<em><b>Container HL Marking</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container HL Marking</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLMarking#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container HL Marking</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container HL Marking</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container HL Marking</em>' container reference.
 	 * @see #setContainerHLMarking(HLMarking)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_ContainerHLMarking()
@@ -170,24 +189,29 @@ public interface Term extends EObject {
 	HLMarking getContainerHLMarking();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking <em>Container HL Marking</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking
+	 * <em>Container HL Marking</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container HL Marking</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container HL Marking</em>' container
+	 *              reference.
 	 * @see #getContainerHLMarking()
 	 * @generated
 	 */
 	void setContainerHLMarking(HLMarking value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Condition</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Condition</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.Condition#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Condition</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Condition</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Container Condition</em>' container reference.
 	 * @see #setContainerCondition(Condition)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_ContainerCondition()
@@ -198,25 +222,31 @@ public interface Term extends EObject {
 	Condition getContainerCondition();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition <em>Container Condition</em>}' container reference.
-	 * <!-- begin-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition
+	 * <em>Container Condition</em>}' container reference. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Condition</em>' container reference.
+	 * 
+	 * @param value the new value of the '<em>Container Condition</em>' container
+	 *              reference.
 	 * @see #getContainerCondition()
 	 * @generated
 	 */
 	void setContainerCondition(Condition value);
 
 	/**
-	 * Returns the value of the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure <em>Structure</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure
+	 * <em>Structure</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container HL Annotation</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container HL Annotation</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container HL Annotation</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container HL Annotation</em>' container
+	 *         reference.
 	 * @see #setContainerHLAnnotation(HLAnnotation)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_ContainerHLAnnotation()
 	 * @see fr.lip6.move.pnml.pthlpng.hlcorestructure.HLAnnotation#getStructure
@@ -226,25 +256,31 @@ public interface Term extends EObject {
 	HLAnnotation getContainerHLAnnotation();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation <em>Container HL Annotation</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container HL Annotation</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation
+	 * <em>Container HL Annotation</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container HL Annotation</em>'
+	 *              container reference.
 	 * @see #getContainerHLAnnotation()
 	 * @generated
 	 */
 	void setContainerHLAnnotation(HLAnnotation value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Partition Element</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants <em>Partitionelementconstants</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Partition Element</b></em>'
+	 * container reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants
+	 * <em>Partitionelementconstants</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Partition Element</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Partition Element</em>' container
+	 * reference isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Partition Element</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Partition Element</em>' container
+	 *         reference.
 	 * @see #setContainerPartitionElement(PartitionElement)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm_ContainerPartitionElement()
 	 * @see fr.lip6.move.pnml.pthlpng.partitions.PartitionElement#getPartitionelementconstants
@@ -254,10 +290,13 @@ public interface Term extends EObject {
 	PartitionElement getContainerPartitionElement();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement <em>Container Partition Element</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Partition Element</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement
+	 * <em>Container Partition Element</em>}' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Partition Element</em>'
+	 *              container reference.
 	 * @see #getContainerPartitionElement()
 	 * @generated
 	 */
@@ -265,8 +304,8 @@ public interface Term extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Term.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Term.java
@@ -70,7 +70,7 @@ import fr.lip6.move.pnml.pthlpng.partitions.PartitionElement;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTerm()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Term extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsDeclaration.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsDeclaration.java
@@ -43,16 +43,18 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Declaration</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Declaration</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId <em>Id</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName <em>Name</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations <em>Container Declarations</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId
+ * <em>Id</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName
+ * <em>Name</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations
+ * <em>Container Declarations</em>}</li>
  * </ul>
  * </p>
  *
@@ -62,13 +64,14 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  */
 public interface TermsDeclaration extends EObject {
 	/**
-	 * Returns the value of the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * -->
 	 * <p>
-	 * If the meaning of the '<em>Id</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Id</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Id</em>' attribute.
 	 * @see #setId(String)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTermsDeclaration_Id()
@@ -79,9 +82,10 @@ public interface TermsDeclaration extends EObject {
 	String getId();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId <em>Id</em>}'
+	 * attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Id</em>' attribute.
 	 * @see #getId()
 	 * @generated
@@ -89,26 +93,29 @@ public interface TermsDeclaration extends EObject {
 	void setId(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Name</b></em>' attribute. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Name</em>' attribute isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Name</em>' attribute isn't clear, there really
+	 * should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Name</em>' attribute.
 	 * @see #setName(String)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTermsDeclaration_Name()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='name' kind='attribute'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='name'
+	 *        kind='attribute'"
 	 * @generated
 	 */
 	String getName();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName
+	 * <em>Name</em>}' attribute. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Name</em>' attribute.
 	 * @see #getName()
 	 * @generated
@@ -116,15 +123,18 @@ public interface TermsDeclaration extends EObject {
 	void setName(String value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Declarations</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Declarations</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Declarations</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Declarations</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Declarations</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Declarations</em>' container
+	 *         reference.
 	 * @see #setContainerDeclarations(Declarations)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTermsDeclaration_ContainerDeclarations()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration
@@ -134,10 +144,13 @@ public interface TermsDeclaration extends EObject {
 	Declarations getContainerDeclarations();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations <em>Container Declarations</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Declarations</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations
+	 * <em>Container Declarations</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Declarations</em>' container
+	 *              reference.
 	 * @see #getContainerDeclarations()
 	 * @generated
 	 */
@@ -145,8 +158,8 @@ public interface TermsDeclaration extends EObject {
 
 	public abstract String toPNML();
 
-	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public abstract void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	public abstract void toPNML(FileChannel fc);
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsDeclaration.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsDeclaration.java
@@ -59,7 +59,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTermsDeclaration()
- * @model abstract="true"
+ * @model abstract="true" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface TermsDeclaration extends EObject {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsFactory.java
@@ -34,119 +34,118 @@ package fr.lip6.move.pnml.pthlpng.terms;
 import org.eclipse.emf.ecore.EFactory;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Factory</b> for the model.
- * It provides a create method for each non-abstract class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Factory</b> for the model. It provides a
+ * create method for each non-abstract class of the model. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage
  * @generated
  */
 public interface TermsFactory extends EFactory {
 	/**
-	 * The singleton instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	TermsFactory eINSTANCE = fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl.init();
 
 	/**
-	 * Returns a new object of class '<em>Declarations</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Declarations</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Declarations</em>'.
 	 * @generated
 	 */
 	Declarations createDeclarations();
 
 	/**
-	 * Returns a new object of class '<em>Multiset Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Multiset Sort</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Multiset Sort</em>'.
 	 * @generated
 	 */
 	MultisetSort createMultisetSort();
 
 	/**
-	 * Returns a new object of class '<em>Variable Decl</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Variable Decl</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Variable Decl</em>'.
 	 * @generated
 	 */
 	VariableDecl createVariableDecl();
 
 	/**
-	 * Returns a new object of class '<em>Variable</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Variable</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Variable</em>'.
 	 * @generated
 	 */
 	Variable createVariable();
 
 	/**
-	 * Returns a new object of class '<em>Product Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Product Sort</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Product Sort</em>'.
 	 * @generated
 	 */
 	ProductSort createProductSort();
 
 	/**
-	 * Returns a new object of class '<em>Tuple</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Tuple</em>'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Tuple</em>'.
 	 * @generated
 	 */
 	Tuple createTuple();
 
 	/**
-	 * Returns a new object of class '<em>Named Sort</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>Named Sort</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Named Sort</em>'.
 	 * @generated
 	 */
 	NamedSort createNamedSort();
 
 	/**
-	 * Returns a new object of class '<em>User Sort</em>'.
-	 * <!-- begin-user-doc -->
+	 * Returns a new object of class '<em>User Sort</em>'. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>User Sort</em>'.
 	 * @generated
 	 */
 	UserSort createUserSort();
 
 	/**
-	 * Returns a new object of class '<em>Named Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>Named Operator</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>Named Operator</em>'.
 	 * @generated
 	 */
 	NamedOperator createNamedOperator();
 
 	/**
-	 * Returns a new object of class '<em>User Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns a new object of class '<em>User Operator</em>'. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @return a new object of class '<em>User Operator</em>'.
 	 * @generated
 	 */
 	UserOperator createUserOperator();
 
 	/**
-	 * Returns the package supported by this factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package supported by this factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the package supported by this factory.
 	 * @generated
 	 */
 	TermsPackage getTermsPackage();
 
-} //TermsFactory
+} // TermsFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsPackage.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/TermsPackage.java
@@ -37,57 +37,55 @@ import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.EReference;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Package</b> for the model.
- * It contains accessors for the meta objects to represent
+ * <!-- begin-user-doc --> The <b>Package</b> for the model. It contains
+ * accessors for the meta objects to represent
  * <ul>
- *   <li>each class,</li>
- *   <li>each feature of each class,</li>
- *   <li>each enum,</li>
- *   <li>and each data type</li>
+ * <li>each class,</li>
+ * <li>each feature of each class,</li>
+ * <li>each enum,</li>
+ * <li>and each data type</li>
  * </ul>
  * <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsFactory
  * @model kind="package"
  * @generated
  */
 public interface TermsPackage extends EPackage {
 	/**
-	 * The package name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNAME = "terms";
 
 	/**
-	 * The package namespace URI.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace URI. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_URI = "http:///pthlpng.terms.ecore";
 
 	/**
-	 * The package namespace name.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The package namespace name. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	String eNS_PREFIX = "terms";
 
 	/**
-	 * The singleton instance of the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The singleton instance of the package. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	TermsPackage eINSTANCE = fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl.init();
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl <em>Declarations</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl
+	 * <em>Declarations</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getDeclarations()
 	 * @generated
@@ -95,36 +93,37 @@ public interface TermsPackage extends EPackage {
 	int DECLARATIONS = 0;
 
 	/**
-	 * The feature id for the '<em><b>Declaration</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Declaration</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATIONS__DECLARATION = 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Declaration</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declaration</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATIONS__CONTAINER_DECLARATION = 1;
 
 	/**
-	 * The number of structural features of the '<em>Declarations</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Declarations</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int DECLARATIONS_FEATURE_COUNT = 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl <em>Declaration</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl
+	 * <em>Declaration</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getTermsDeclaration()
 	 * @generated
@@ -132,45 +131,46 @@ public interface TermsPackage extends EPackage {
 	int TERMS_DECLARATION = 1;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERMS_DECLARATION__ID = 0;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERMS_DECLARATION__NAME = 1;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERMS_DECLARATION__CONTAINER_DECLARATIONS = 2;
 
 	/**
-	 * The number of structural features of the '<em>Declaration</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Declaration</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERMS_DECLARATION_FEATURE_COUNT = 3;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl <em>Sort</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl <em>Sort</em>}' class.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getSort()
 	 * @generated
@@ -178,36 +178,36 @@ public interface TermsPackage extends EPackage {
 	int SORT = 2;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT__MULTI = 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT__CONTAINER_NAMED_SORT = 1;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT__CONTAINER_VARIABLE_DECL = 2;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -215,8 +215,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -224,8 +224,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -233,35 +233,36 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT__CONTAINER_EMPTY = 6;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT__CONTAINER_PARTITION = 7;
 
 	/**
-	 * The number of structural features of the '<em>Sort</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Sort</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT_FEATURE_COUNT = 8;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl <em>Multiset Sort</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl <em>Multiset
+	 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getMultisetSort()
 	 * @generated
@@ -269,36 +270,36 @@ public interface TermsPackage extends EPackage {
 	int MULTISET_SORT = 3;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT__MULTI = SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT__CONTAINER_NAMED_SORT = SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT__CONTAINER_VARIABLE_DECL = SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -306,8 +307,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -315,8 +316,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -324,44 +325,45 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT__CONTAINER_EMPTY = SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT__CONTAINER_PARTITION = SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Basis</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Basis</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT__BASIS = SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Multiset Sort</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Multiset Sort</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_SORT_FEATURE_COUNT = SORT_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl <em>Term</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl <em>Term</em>}' class.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getTerm()
 	 * @generated
@@ -369,81 +371,82 @@ public interface TermsPackage extends EPackage {
 	int TERM = 4;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__SORT = 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__CONTAINER_OPERATOR = 1;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__CONTAINER_NAMED_OPERATOR = 2;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__CONTAINER_HL_MARKING = 3;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__CONTAINER_CONDITION = 4;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__CONTAINER_HL_ANNOTATION = 5;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM__CONTAINER_PARTITION_ELEMENT = 6;
 
 	/**
-	 * The number of structural features of the '<em>Term</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Term</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TERM_FEATURE_COUNT = 7;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl <em>Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl <em>Operator</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getOperator()
 	 * @generated
@@ -451,63 +454,63 @@ public interface TermsPackage extends EPackage {
 	int OPERATOR = 5;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__SORT = TERM__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__CONTAINER_OPERATOR = TERM__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__CONTAINER_NAMED_OPERATOR = TERM__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__CONTAINER_HL_MARKING = TERM__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__CONTAINER_CONDITION = TERM__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__CONTAINER_HL_ANNOTATION = TERM__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -515,44 +518,45 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__SUBTERM = TERM_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__OUTPUT = TERM_FEATURE_COUNT + 1;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR__INPUT = TERM_FEATURE_COUNT + 2;
 
 	/**
-	 * The number of structural features of the '<em>Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Operator</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR_FEATURE_COUNT = TERM_FEATURE_COUNT + 3;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl <em>Variable Decl</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl <em>Variable
+	 * Decl</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getVariableDecl()
 	 * @generated
@@ -560,63 +564,64 @@ public interface TermsPackage extends EPackage {
 	int VARIABLE_DECL = 6;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_DECL__ID = TERMS_DECLARATION__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_DECL__NAME = TERMS_DECLARATION__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_DECL__CONTAINER_DECLARATIONS = TERMS_DECLARATION__CONTAINER_DECLARATIONS;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_DECL__SORT = TERMS_DECLARATION_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_DECL__CONTAINER_NAMED_OPERATOR = TERMS_DECLARATION_FEATURE_COUNT + 1;
 
 	/**
-	 * The number of structural features of the '<em>Variable Decl</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Variable Decl</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_DECL_FEATURE_COUNT = TERMS_DECLARATION_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl <em>Variable</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl <em>Variable</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getVariable()
 	 * @generated
@@ -624,90 +629,91 @@ public interface TermsPackage extends EPackage {
 	int VARIABLE = 7;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__SORT = TERM__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__CONTAINER_OPERATOR = TERM__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__CONTAINER_NAMED_OPERATOR = TERM__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__CONTAINER_HL_MARKING = TERM__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__CONTAINER_CONDITION = TERM__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__CONTAINER_HL_ANNOTATION = TERM__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__CONTAINER_PARTITION_ELEMENT = TERM__CONTAINER_PARTITION_ELEMENT;
 
 	/**
-	 * The feature id for the '<em><b>Variable Decl</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Variable Decl</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE__VARIABLE_DECL = TERM_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Variable</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Variable</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int VARIABLE_FEATURE_COUNT = TERM_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl <em>Built In Sort</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl <em>Built In
+	 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getBuiltInSort()
 	 * @generated
@@ -715,36 +721,36 @@ public interface TermsPackage extends EPackage {
 	int BUILT_IN_SORT = 8;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_SORT__MULTI = SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_SORT__CONTAINER_NAMED_SORT = SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_SORT__CONTAINER_VARIABLE_DECL = SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -752,8 +758,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -761,8 +767,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -770,35 +776,36 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_SORT__CONTAINER_EMPTY = SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_SORT__CONTAINER_PARTITION = SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The number of structural features of the '<em>Built In Sort</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Built In Sort</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_SORT_FEATURE_COUNT = SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl <em>Product Sort</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl <em>Product
+	 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getProductSort()
 	 * @generated
@@ -806,36 +813,36 @@ public interface TermsPackage extends EPackage {
 	int PRODUCT_SORT = 9;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT__MULTI = SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT__CONTAINER_NAMED_SORT = SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT__CONTAINER_VARIABLE_DECL = SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -843,8 +850,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -852,8 +859,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -861,44 +868,45 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT__CONTAINER_EMPTY = SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT__CONTAINER_PARTITION = SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Element Sort</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Element Sort</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT__ELEMENT_SORT = SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Product Sort</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Product Sort</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int PRODUCT_SORT_FEATURE_COUNT = SORT_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl <em>Built In Constant</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl <em>Built In
+	 * Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getBuiltInConstant()
 	 * @generated
@@ -906,63 +914,63 @@ public interface TermsPackage extends EPackage {
 	int BUILT_IN_CONSTANT = 10;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__SORT = OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__CONTAINER_OPERATOR = OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__CONTAINER_NAMED_OPERATOR = OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__CONTAINER_HL_MARKING = OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__CONTAINER_CONDITION = OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__CONTAINER_HL_ANNOTATION = OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -970,26 +978,26 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__SUBTERM = OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT__OUTPUT = OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -997,17 +1005,19 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Built In Constant</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_CONSTANT_FEATURE_COUNT = OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetOperatorImpl <em>Multiset Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetOperatorImpl
+	 * <em>Multiset Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.MultisetOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getMultisetOperator()
 	 * @generated
@@ -1015,63 +1025,63 @@ public interface TermsPackage extends EPackage {
 	int MULTISET_OPERATOR = 11;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__SORT = OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__CONTAINER_OPERATOR = OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__CONTAINER_NAMED_OPERATOR = OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__CONTAINER_HL_MARKING = OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__CONTAINER_CONDITION = OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__CONTAINER_HL_ANNOTATION = OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1079,26 +1089,26 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__SUBTERM = OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR__OUTPUT = OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1106,17 +1116,18 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Multiset Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int MULTISET_OPERATOR_FEATURE_COUNT = OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl <em>Tuple</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl <em>Tuple</em>}'
+	 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getTuple()
 	 * @generated
@@ -1124,63 +1135,63 @@ public interface TermsPackage extends EPackage {
 	int TUPLE = 12;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__SORT = OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__CONTAINER_OPERATOR = OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__CONTAINER_NAMED_OPERATOR = OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__CONTAINER_HL_MARKING = OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__CONTAINER_CONDITION = OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__CONTAINER_HL_ANNOTATION = OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1188,44 +1199,45 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__SUBTERM = OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__OUTPUT = OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE__INPUT = OPERATOR__INPUT;
 
 	/**
-	 * The number of structural features of the '<em>Tuple</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Tuple</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int TUPLE_FEATURE_COUNT = OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl <em>Sort Decl</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl <em>Sort
+	 * Decl</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getSortDecl()
 	 * @generated
@@ -1233,45 +1245,46 @@ public interface TermsPackage extends EPackage {
 	int SORT_DECL = 13;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT_DECL__ID = TERMS_DECLARATION__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT_DECL__NAME = TERMS_DECLARATION__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT_DECL__CONTAINER_DECLARATIONS = TERMS_DECLARATION__CONTAINER_DECLARATIONS;
 
 	/**
-	 * The number of structural features of the '<em>Sort Decl</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Sort Decl</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int SORT_DECL_FEATURE_COUNT = TERMS_DECLARATION_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl <em>Built In Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl <em>Built In
+	 * Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getBuiltInOperator()
 	 * @generated
@@ -1279,63 +1292,63 @@ public interface TermsPackage extends EPackage {
 	int BUILT_IN_OPERATOR = 14;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__SORT = OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__CONTAINER_OPERATOR = OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__CONTAINER_NAMED_OPERATOR = OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__CONTAINER_HL_MARKING = OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__CONTAINER_CONDITION = OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__CONTAINER_HL_ANNOTATION = OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1343,26 +1356,26 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__SUBTERM = OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR__OUTPUT = OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1370,17 +1383,18 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Built In Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int BUILT_IN_OPERATOR_FEATURE_COUNT = OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl <em>Named Sort</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl <em>Named
+	 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getNamedSort()
 	 * @generated
@@ -1388,54 +1402,55 @@ public interface TermsPackage extends EPackage {
 	int NAMED_SORT = 15;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_SORT__ID = SORT_DECL__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_SORT__NAME = SORT_DECL__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_SORT__CONTAINER_DECLARATIONS = SORT_DECL__CONTAINER_DECLARATIONS;
 
 	/**
-	 * The feature id for the '<em><b>Sortdef</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sortdef</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_SORT__SORTDEF = SORT_DECL_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>Named Sort</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Named Sort</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_SORT_FEATURE_COUNT = SORT_DECL_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl <em>User Sort</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl <em>User
+	 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getUserSort()
 	 * @generated
@@ -1443,36 +1458,36 @@ public interface TermsPackage extends EPackage {
 	int USER_SORT = 16;
 
 	/**
-	 * The feature id for the '<em><b>Multi</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Multi</b></em>' container reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT__MULTI = SORT__MULTI;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT__CONTAINER_NAMED_SORT = SORT__CONTAINER_NAMED_SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Variable Decl</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT__CONTAINER_VARIABLE_DECL = SORT__CONTAINER_VARIABLE_DECL;
 
 	/**
-	 * The feature id for the '<em><b>Container Product Sort</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Product Sort</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1480,8 +1495,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Type</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1489,8 +1504,8 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container All</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1498,44 +1513,45 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Container Empty</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT__CONTAINER_EMPTY = SORT__CONTAINER_EMPTY;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT__CONTAINER_PARTITION = SORT__CONTAINER_PARTITION;
 
 	/**
-	 * The feature id for the '<em><b>Declaration</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Declaration</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT__DECLARATION = SORT_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>User Sort</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>User Sort</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_SORT_FEATURE_COUNT = SORT_FEATURE_COUNT + 1;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl <em>Operator Decl</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl <em>Operator
+	 * Decl</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getOperatorDecl()
 	 * @generated
@@ -1543,45 +1559,46 @@ public interface TermsPackage extends EPackage {
 	int OPERATOR_DECL = 17;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR_DECL__ID = TERMS_DECLARATION__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR_DECL__NAME = TERMS_DECLARATION__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR_DECL__CONTAINER_DECLARATIONS = TERMS_DECLARATION__CONTAINER_DECLARATIONS;
 
 	/**
-	 * The number of structural features of the '<em>Operator Decl</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>Operator Decl</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int OPERATOR_DECL_FEATURE_COUNT = TERMS_DECLARATION_FEATURE_COUNT + 0;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl <em>Named Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl <em>Named
+	 * Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getNamedOperator()
 	 * @generated
@@ -1589,45 +1606,45 @@ public interface TermsPackage extends EPackage {
 	int NAMED_OPERATOR = 18;
 
 	/**
-	 * The feature id for the '<em><b>Id</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Id</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_OPERATOR__ID = OPERATOR_DECL__ID;
 
 	/**
-	 * The feature id for the '<em><b>Name</b></em>' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Name</b></em>' attribute. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_OPERATOR__NAME = OPERATOR_DECL__NAME;
 
 	/**
-	 * The feature id for the '<em><b>Container Declarations</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Declarations</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_OPERATOR__CONTAINER_DECLARATIONS = OPERATOR_DECL__CONTAINER_DECLARATIONS;
 
 	/**
-	 * The feature id for the '<em><b>Def</b></em>' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Def</b></em>' containment reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_OPERATOR__DEF = OPERATOR_DECL_FEATURE_COUNT + 0;
 
 	/**
-	 * The feature id for the '<em><b>Parameters</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Parameters</b></em>' containment reference
+	 * list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1635,17 +1652,18 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The number of structural features of the '<em>Named Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int NAMED_OPERATOR_FEATURE_COUNT = OPERATOR_DECL_FEATURE_COUNT + 2;
 
 	/**
-	 * The meta object id for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl <em>User Operator</em>}' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The meta object id for the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl <em>User
+	 * Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl
 	 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getUserOperator()
 	 * @generated
@@ -1653,63 +1671,63 @@ public interface TermsPackage extends EPackage {
 	int USER_OPERATOR = 19;
 
 	/**
-	 * The feature id for the '<em><b>Sort</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Sort</b></em>' reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__SORT = OPERATOR__SORT;
 
 	/**
-	 * The feature id for the '<em><b>Container Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__CONTAINER_OPERATOR = OPERATOR__CONTAINER_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container Named Operator</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Named Operator</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__CONTAINER_NAMED_OPERATOR = OPERATOR__CONTAINER_NAMED_OPERATOR;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Marking</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Marking</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__CONTAINER_HL_MARKING = OPERATOR__CONTAINER_HL_MARKING;
 
 	/**
-	 * The feature id for the '<em><b>Container Condition</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Condition</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__CONTAINER_CONDITION = OPERATOR__CONTAINER_CONDITION;
 
 	/**
-	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container HL Annotation</b></em>' container
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__CONTAINER_HL_ANNOTATION = OPERATOR__CONTAINER_HL_ANNOTATION;
 
 	/**
-	 * The feature id for the '<em><b>Container Partition Element</b></em>' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Container Partition Element</b></em>'
+	 * container reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
@@ -1717,53 +1735,54 @@ public interface TermsPackage extends EPackage {
 
 	/**
 	 * The feature id for the '<em><b>Subterm</b></em>' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__SUBTERM = OPERATOR__SUBTERM;
 
 	/**
-	 * The feature id for the '<em><b>Output</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Output</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__OUTPUT = OPERATOR__OUTPUT;
 
 	/**
-	 * The feature id for the '<em><b>Input</b></em>' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Input</b></em>' reference list. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__INPUT = OPERATOR__INPUT;
 
 	/**
-	 * The feature id for the '<em><b>Declaration</b></em>' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The feature id for the '<em><b>Declaration</b></em>' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR__DECLARATION = OPERATOR_FEATURE_COUNT + 0;
 
 	/**
-	 * The number of structural features of the '<em>User Operator</em>' class.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The number of structural features of the '<em>User Operator</em>' class. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 * @ordered
 	 */
 	int USER_OPERATOR_FEATURE_COUNT = OPERATOR_FEATURE_COUNT + 1;
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations <em>Declarations</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations <em>Declarations</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Declarations</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Declarations
 	 * @generated
@@ -1771,10 +1790,12 @@ public interface TermsPackage extends EPackage {
 	EClass getDeclarations();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Declaration</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Declarations#getDeclaration()
 	 * @see #getDeclarations()
 	 * @generated
@@ -1782,10 +1803,13 @@ public interface TermsPackage extends EPackage {
 	EReference getDeclarations_Declaration();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration <em>Container Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Declaration</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration
+	 * <em>Container Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Declarations#getContainerDeclaration()
 	 * @see #getDeclarations()
 	 * @generated
@@ -1793,9 +1817,10 @@ public interface TermsPackage extends EPackage {
 	EReference getDeclarations_ContainerDeclaration();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration
 	 * @generated
@@ -1803,9 +1828,10 @@ public interface TermsPackage extends EPackage {
 	EClass getTermsDeclaration();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId <em>Id</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId <em>Id</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Id</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getId()
 	 * @see #getTermsDeclaration()
@@ -1814,9 +1840,10 @@ public interface TermsPackage extends EPackage {
 	EAttribute getTermsDeclaration_Id();
 
 	/**
-	 * Returns the meta object for the attribute '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName <em>Name</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the attribute
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName
+	 * <em>Name</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the attribute '<em>Name</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getName()
 	 * @see #getTermsDeclaration()
@@ -1825,10 +1852,13 @@ public interface TermsPackage extends EPackage {
 	EAttribute getTermsDeclaration_Name();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations <em>Container Declarations</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Declarations</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations
+	 * <em>Container Declarations</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Declarations</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration#getContainerDeclarations()
 	 * @see #getTermsDeclaration()
 	 * @generated
@@ -1836,9 +1866,10 @@ public interface TermsPackage extends EPackage {
 	EReference getTermsDeclaration_ContainerDeclarations();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort
 	 * @generated
@@ -1846,9 +1877,10 @@ public interface TermsPackage extends EPackage {
 	EClass getSort();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti <em>Multi</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the container reference '<em>Multi</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getMulti()
 	 * @see #getSort()
@@ -1857,10 +1889,13 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_Multi();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort <em>Container Named Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Named Sort</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort
+	 * <em>Container Named Sort</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Named
+	 *         Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerNamedSort()
 	 * @see #getSort()
 	 * @generated
@@ -1868,10 +1903,13 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerNamedSort();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl <em>Container Variable Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Variable Decl</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl
+	 * <em>Container Variable Decl</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Variable
+	 *         Decl</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl()
 	 * @see #getSort()
 	 * @generated
@@ -1879,10 +1917,13 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerVariableDecl();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort <em>Container Product Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Product Sort</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort
+	 * <em>Container Product Sort</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Product
+	 *         Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerProductSort()
 	 * @see #getSort()
 	 * @generated
@@ -1890,10 +1931,12 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerProductSort();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container Type</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Type</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType <em>Container
+	 * Type</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Type</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerType()
 	 * @see #getSort()
 	 * @generated
@@ -1901,9 +1944,10 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerType();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container All</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll <em>Container
+	 * All</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the container reference '<em>Container All</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerAll()
 	 * @see #getSort()
@@ -1912,10 +1956,12 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerAll();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container Empty</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Empty</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty <em>Container
+	 * Empty</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Empty</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerEmpty()
 	 * @see #getSort()
 	 * @generated
@@ -1923,10 +1969,12 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerEmpty();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition <em>Container Partition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Partition</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition
+	 * <em>Container Partition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Partition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerPartition()
 	 * @see #getSort()
 	 * @generated
@@ -1934,9 +1982,10 @@ public interface TermsPackage extends EPackage {
 	EReference getSort_ContainerPartition();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort <em>Multiset Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort <em>Multiset
+	 * Sort</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Multiset Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.MultisetSort
 	 * @generated
@@ -1944,9 +1993,10 @@ public interface TermsPackage extends EPackage {
 	EClass getMultisetSort();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis <em>Basis</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis
+	 * <em>Basis</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Basis</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.MultisetSort#getBasis()
 	 * @see #getMultisetSort()
@@ -1955,9 +2005,10 @@ public interface TermsPackage extends EPackage {
 	EReference getMultisetSort_Basis();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Term</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -1965,9 +2016,10 @@ public interface TermsPackage extends EPackage {
 	EClass getTerm();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getSort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getSort <em>Sort</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getSort()
 	 * @see #getTerm()
@@ -1976,10 +2028,12 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_Sort();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator <em>Container Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Operator</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator
+	 * <em>Container Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerOperator()
 	 * @see #getTerm()
 	 * @generated
@@ -1987,10 +2041,13 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_ContainerOperator();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator <em>Container Named Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Named Operator</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator
+	 * <em>Container Named Operator</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Named
+	 *         Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerNamedOperator()
 	 * @see #getTerm()
 	 * @generated
@@ -1998,10 +2055,13 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_ContainerNamedOperator();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking <em>Container HL Marking</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container HL Marking</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking
+	 * <em>Container HL Marking</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container HL
+	 *         Marking</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLMarking()
 	 * @see #getTerm()
 	 * @generated
@@ -2009,10 +2069,12 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_ContainerHLMarking();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition <em>Container Condition</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Condition</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition
+	 * <em>Container Condition</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container
+	 *         Condition</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerCondition()
 	 * @see #getTerm()
 	 * @generated
@@ -2020,10 +2082,13 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_ContainerCondition();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation <em>Container HL Annotation</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container HL Annotation</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation
+	 * <em>Container HL Annotation</em>}'. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container HL
+	 *         Annotation</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerHLAnnotation()
 	 * @see #getTerm()
 	 * @generated
@@ -2031,10 +2096,13 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_ContainerHLAnnotation();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement <em>Container Partition Element</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Partition Element</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement
+	 * <em>Container Partition Element</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Partition
+	 *         Element</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term#getContainerPartitionElement()
 	 * @see #getTerm()
 	 * @generated
@@ -2042,9 +2110,10 @@ public interface TermsPackage extends EPackage {
 	EReference getTerm_ContainerPartitionElement();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -2052,10 +2121,12 @@ public interface TermsPackage extends EPackage {
 	EClass getOperator();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm <em>Subterm</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Subterm</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm
+	 * <em>Subterm</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Subterm</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator#getSubterm()
 	 * @see #getOperator()
 	 * @generated
@@ -2063,9 +2134,10 @@ public interface TermsPackage extends EPackage {
 	EReference getOperator_Subterm();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput <em>Output</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput <em>Output</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Output</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator#getOutput()
 	 * @see #getOperator()
@@ -2074,9 +2146,10 @@ public interface TermsPackage extends EPackage {
 	EReference getOperator_Output();
 
 	/**
-	 * Returns the meta object for the reference list '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getInput <em>Input</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator#getInput <em>Input</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference list '<em>Input</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator#getInput()
 	 * @see #getOperator()
@@ -2085,9 +2158,10 @@ public interface TermsPackage extends EPackage {
 	EReference getOperator_Input();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl <em>Variable Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl <em>Variable
+	 * Decl</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Variable Decl</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.VariableDecl
 	 * @generated
@@ -2095,9 +2169,10 @@ public interface TermsPackage extends EPackage {
 	EClass getVariableDecl();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort()
 	 * @see #getVariableDecl()
@@ -2106,10 +2181,13 @@ public interface TermsPackage extends EPackage {
 	EReference getVariableDecl_Sort();
 
 	/**
-	 * Returns the meta object for the container reference '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator <em>Container Named Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the container reference '<em>Container Named Operator</em>'.
+	 * Returns the meta object for the container reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator
+	 * <em>Container Named Operator</em>}'. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
+	 * @return the meta object for the container reference '<em>Container Named
+	 *         Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator()
 	 * @see #getVariableDecl()
 	 * @generated
@@ -2117,9 +2195,10 @@ public interface TermsPackage extends EPackage {
 	EReference getVariableDecl_ContainerNamedOperator();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.Variable <em>Variable</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Variable <em>Variable</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Variable</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Variable
 	 * @generated
@@ -2127,9 +2206,10 @@ public interface TermsPackage extends EPackage {
 	EClass getVariable();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl <em>Variable Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl <em>Variable
+	 * Decl</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Variable Decl</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl()
 	 * @see #getVariable()
@@ -2138,9 +2218,10 @@ public interface TermsPackage extends EPackage {
 	EReference getVariable_VariableDecl();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Built In Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInSort
 	 * @generated
@@ -2148,9 +2229,10 @@ public interface TermsPackage extends EPackage {
 	EClass getBuiltInSort();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort <em>Product Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort <em>Product Sort</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Product Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.ProductSort
 	 * @generated
@@ -2158,10 +2240,12 @@ public interface TermsPackage extends EPackage {
 	EClass getProductSort();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort <em>Element Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Element Sort</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort
+	 * <em>Element Sort</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list '<em>Element
+	 *         Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.ProductSort#getElementSort()
 	 * @see #getProductSort()
 	 * @generated
@@ -2169,9 +2253,10 @@ public interface TermsPackage extends EPackage {
 	EReference getProductSort_ElementSort();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In
+	 * Constant</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Built In Constant</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant
 	 * @generated
@@ -2179,9 +2264,10 @@ public interface TermsPackage extends EPackage {
 	EClass getBuiltInConstant();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetOperator <em>Multiset Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetOperator <em>Multiset
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Multiset Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.MultisetOperator
 	 * @generated
@@ -2189,9 +2275,10 @@ public interface TermsPackage extends EPackage {
 	EClass getMultisetOperator();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.Tuple <em>Tuple</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Tuple <em>Tuple</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Tuple</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Tuple
 	 * @generated
@@ -2199,9 +2286,10 @@ public interface TermsPackage extends EPackage {
 	EClass getTuple();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.SortDecl <em>Sort Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.SortDecl <em>Sort Decl</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Sort Decl</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.SortDecl
 	 * @generated
@@ -2209,9 +2297,10 @@ public interface TermsPackage extends EPackage {
 	EClass getSortDecl();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Built In Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator
 	 * @generated
@@ -2219,9 +2308,10 @@ public interface TermsPackage extends EPackage {
 	EClass getBuiltInOperator();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort <em>Named Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort <em>Named Sort</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Named Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedSort
 	 * @generated
@@ -2229,9 +2319,10 @@ public interface TermsPackage extends EPackage {
 	EClass getNamedSort();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef <em>Sortdef</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef
+	 * <em>Sortdef</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Sortdef</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedSort#getSortdef()
 	 * @see #getNamedSort()
@@ -2240,9 +2331,10 @@ public interface TermsPackage extends EPackage {
 	EReference getNamedSort_Sortdef();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort <em>User Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort <em>User Sort</em>}'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>User Sort</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.UserSort
 	 * @generated
@@ -2250,9 +2342,10 @@ public interface TermsPackage extends EPackage {
 	EClass getUserSort();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration()
 	 * @see #getUserSort()
@@ -2261,9 +2354,10 @@ public interface TermsPackage extends EPackage {
 	EReference getUserSort_Declaration();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.OperatorDecl <em>Operator Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.OperatorDecl <em>Operator
+	 * Decl</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Operator Decl</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.OperatorDecl
 	 * @generated
@@ -2271,9 +2365,10 @@ public interface TermsPackage extends EPackage {
 	EClass getOperatorDecl();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator <em>Named Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator <em>Named
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>Named Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedOperator
 	 * @generated
@@ -2281,9 +2376,10 @@ public interface TermsPackage extends EPackage {
 	EClass getNamedOperator();
 
 	/**
-	 * Returns the meta object for the containment reference '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the containment reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef <em>Def</em>}'.
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the containment reference '<em>Def</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getDef()
 	 * @see #getNamedOperator()
@@ -2292,10 +2388,12 @@ public interface TermsPackage extends EPackage {
 	EReference getNamedOperator_Def();
 
 	/**
-	 * Returns the meta object for the containment reference list '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters <em>Parameters</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @return the meta object for the containment reference list '<em>Parameters</em>'.
+	 * Returns the meta object for the containment reference list
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters
+	 * <em>Parameters</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
+	 * @return the meta object for the containment reference list
+	 *         '<em>Parameters</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters()
 	 * @see #getNamedOperator()
 	 * @generated
@@ -2303,9 +2401,10 @@ public interface TermsPackage extends EPackage {
 	EReference getNamedOperator_Parameters();
 
 	/**
-	 * Returns the meta object for class '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator <em>User Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator <em>User
+	 * Operator</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for class '<em>User Operator</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.UserOperator
 	 * @generated
@@ -2313,9 +2412,10 @@ public interface TermsPackage extends EPackage {
 	EClass getUserOperator();
 
 	/**
-	 * Returns the meta object for the reference '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the meta object for the reference
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the meta object for the reference '<em>Declaration</em>'.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration()
 	 * @see #getUserOperator()
@@ -2324,31 +2424,32 @@ public interface TermsPackage extends EPackage {
 	EReference getUserOperator_Declaration();
 
 	/**
-	 * Returns the factory that creates the instances of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the factory that creates the instances of the model. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @return the factory that creates the instances of the model.
 	 * @generated
 	 */
 	TermsFactory getTermsFactory();
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * Defines literals for the meta objects that represent
+	 * <!-- begin-user-doc --> Defines literals for the meta objects that represent
 	 * <ul>
-	 *   <li>each class,</li>
-	 *   <li>each feature of each class,</li>
-	 *   <li>each enum,</li>
-	 *   <li>and each data type</li>
+	 * <li>each class,</li>
+	 * <li>each feature of each class,</li>
+	 * <li>each enum,</li>
+	 * <li>and each data type</li>
 	 * </ul>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	interface Literals {
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl <em>Declarations</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl
+		 * <em>Declarations</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getDeclarations()
 		 * @generated
@@ -2356,25 +2457,26 @@ public interface TermsPackage extends EPackage {
 		EClass DECLARATIONS = eINSTANCE.getDeclarations();
 
 		/**
-		 * The meta object literal for the '<em><b>Declaration</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Declaration</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DECLARATIONS__DECLARATION = eINSTANCE.getDeclarations_Declaration();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Declaration</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Declaration</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference DECLARATIONS__CONTAINER_DECLARATION = eINSTANCE.getDeclarations_ContainerDeclaration();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl <em>Declaration</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl
+		 * <em>Declaration</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getTermsDeclaration()
 		 * @generated
@@ -2382,33 +2484,34 @@ public interface TermsPackage extends EPackage {
 		EClass TERMS_DECLARATION = eINSTANCE.getTermsDeclaration();
 
 		/**
-		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Id</b></em>' attribute feature. <!--
+		 * begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute TERMS_DECLARATION__ID = eINSTANCE.getTermsDeclaration_Id();
 
 		/**
 		 * The meta object literal for the '<em><b>Name</b></em>' attribute feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EAttribute TERMS_DECLARATION__NAME = eINSTANCE.getTermsDeclaration_Name();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Declarations</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Declarations</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERMS_DECLARATION__CONTAINER_DECLARATIONS = eINSTANCE.getTermsDeclaration_ContainerDeclarations();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl <em>Sort</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl <em>Sort</em>}' class.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getSort()
 		 * @generated
@@ -2416,73 +2519,74 @@ public interface TermsPackage extends EPackage {
 		EClass SORT = eINSTANCE.getSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Multi</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Multi</b></em>' container reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__MULTI = eINSTANCE.getSort_Multi();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Named Sort</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Named Sort</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_NAMED_SORT = eINSTANCE.getSort_ContainerNamedSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Variable Decl</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Variable Decl</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_VARIABLE_DECL = eINSTANCE.getSort_ContainerVariableDecl();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Product Sort</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Product Sort</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_PRODUCT_SORT = eINSTANCE.getSort_ContainerProductSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Type</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Type</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_TYPE = eINSTANCE.getSort_ContainerType();
 
 		/**
-		 * The meta object literal for the '<em><b>Container All</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container All</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_ALL = eINSTANCE.getSort_ContainerAll();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Empty</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Empty</b></em>' container
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_EMPTY = eINSTANCE.getSort_ContainerEmpty();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Partition</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Partition</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference SORT__CONTAINER_PARTITION = eINSTANCE.getSort_ContainerPartition();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl <em>Multiset Sort</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl <em>Multiset
+		 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getMultisetSort()
 		 * @generated
@@ -2490,17 +2594,18 @@ public interface TermsPackage extends EPackage {
 		EClass MULTISET_SORT = eINSTANCE.getMultisetSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Basis</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Basis</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference MULTISET_SORT__BASIS = eINSTANCE.getMultisetSort_Basis();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl <em>Term</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl <em>Term</em>}' class.
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getTerm()
 		 * @generated
@@ -2509,64 +2614,65 @@ public interface TermsPackage extends EPackage {
 
 		/**
 		 * The meta object literal for the '<em><b>Sort</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__SORT = eINSTANCE.getTerm_Sort();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Operator</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Operator</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__CONTAINER_OPERATOR = eINSTANCE.getTerm_ContainerOperator();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Named Operator</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Named Operator</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__CONTAINER_NAMED_OPERATOR = eINSTANCE.getTerm_ContainerNamedOperator();
 
 		/**
-		 * The meta object literal for the '<em><b>Container HL Marking</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container HL Marking</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__CONTAINER_HL_MARKING = eINSTANCE.getTerm_ContainerHLMarking();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Condition</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Condition</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__CONTAINER_CONDITION = eINSTANCE.getTerm_ContainerCondition();
 
 		/**
-		 * The meta object literal for the '<em><b>Container HL Annotation</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container HL Annotation</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__CONTAINER_HL_ANNOTATION = eINSTANCE.getTerm_ContainerHLAnnotation();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Partition Element</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Partition Element</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference TERM__CONTAINER_PARTITION_ELEMENT = eINSTANCE.getTerm_ContainerPartitionElement();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl <em>Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl <em>Operator</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getOperator()
 		 * @generated
@@ -2574,33 +2680,34 @@ public interface TermsPackage extends EPackage {
 		EClass OPERATOR = eINSTANCE.getOperator();
 
 		/**
-		 * The meta object literal for the '<em><b>Subterm</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Subterm</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference OPERATOR__SUBTERM = eINSTANCE.getOperator_Subterm();
 
 		/**
 		 * The meta object literal for the '<em><b>Output</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference OPERATOR__OUTPUT = eINSTANCE.getOperator_Output();
 
 		/**
-		 * The meta object literal for the '<em><b>Input</b></em>' reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Input</b></em>' reference list
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference OPERATOR__INPUT = eINSTANCE.getOperator_Input();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl <em>Variable Decl</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl <em>Variable
+		 * Decl</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getVariableDecl()
 		 * @generated
@@ -2608,25 +2715,26 @@ public interface TermsPackage extends EPackage {
 		EClass VARIABLE_DECL = eINSTANCE.getVariableDecl();
 
 		/**
-		 * The meta object literal for the '<em><b>Sort</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Sort</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference VARIABLE_DECL__SORT = eINSTANCE.getVariableDecl_Sort();
 
 		/**
-		 * The meta object literal for the '<em><b>Container Named Operator</b></em>' container reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Container Named Operator</b></em>'
+		 * container reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference VARIABLE_DECL__CONTAINER_NAMED_OPERATOR = eINSTANCE.getVariableDecl_ContainerNamedOperator();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl <em>Variable</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl <em>Variable</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getVariable()
 		 * @generated
@@ -2634,17 +2742,18 @@ public interface TermsPackage extends EPackage {
 		EClass VARIABLE = eINSTANCE.getVariable();
 
 		/**
-		 * The meta object literal for the '<em><b>Variable Decl</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Variable Decl</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference VARIABLE__VARIABLE_DECL = eINSTANCE.getVariable_VariableDecl();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl <em>Built In Sort</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl <em>Built In
+		 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInSortImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getBuiltInSort()
 		 * @generated
@@ -2652,9 +2761,10 @@ public interface TermsPackage extends EPackage {
 		EClass BUILT_IN_SORT = eINSTANCE.getBuiltInSort();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl <em>Product Sort</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl <em>Product
+		 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getProductSort()
 		 * @generated
@@ -2662,17 +2772,18 @@ public interface TermsPackage extends EPackage {
 		EClass PRODUCT_SORT = eINSTANCE.getProductSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Element Sort</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Element Sort</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference PRODUCT_SORT__ELEMENT_SORT = eINSTANCE.getProductSort_ElementSort();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl <em>Built In Constant</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl <em>Built In
+		 * Constant</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInConstantImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getBuiltInConstant()
 		 * @generated
@@ -2680,9 +2791,11 @@ public interface TermsPackage extends EPackage {
 		EClass BUILT_IN_CONSTANT = eINSTANCE.getBuiltInConstant();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetOperatorImpl <em>Multiset Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetOperatorImpl
+		 * <em>Multiset Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc
+		 * -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.MultisetOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getMultisetOperator()
 		 * @generated
@@ -2690,9 +2803,10 @@ public interface TermsPackage extends EPackage {
 		EClass MULTISET_OPERATOR = eINSTANCE.getMultisetOperator();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl <em>Tuple</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl <em>Tuple</em>}'
+		 * class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getTuple()
 		 * @generated
@@ -2700,9 +2814,10 @@ public interface TermsPackage extends EPackage {
 		EClass TUPLE = eINSTANCE.getTuple();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl <em>Sort Decl</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl <em>Sort
+		 * Decl</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.SortDeclImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getSortDecl()
 		 * @generated
@@ -2710,9 +2825,10 @@ public interface TermsPackage extends EPackage {
 		EClass SORT_DECL = eINSTANCE.getSortDecl();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl <em>Built In Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl <em>Built In
+		 * Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.BuiltInOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getBuiltInOperator()
 		 * @generated
@@ -2720,9 +2836,10 @@ public interface TermsPackage extends EPackage {
 		EClass BUILT_IN_OPERATOR = eINSTANCE.getBuiltInOperator();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl <em>Named Sort</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl <em>Named
+		 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getNamedSort()
 		 * @generated
@@ -2730,17 +2847,18 @@ public interface TermsPackage extends EPackage {
 		EClass NAMED_SORT = eINSTANCE.getNamedSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Sortdef</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Sortdef</b></em>' containment
+		 * reference feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NAMED_SORT__SORTDEF = eINSTANCE.getNamedSort_Sortdef();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl <em>User Sort</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl <em>User
+		 * Sort</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getUserSort()
 		 * @generated
@@ -2748,17 +2866,18 @@ public interface TermsPackage extends EPackage {
 		EClass USER_SORT = eINSTANCE.getUserSort();
 
 		/**
-		 * The meta object literal for the '<em><b>Declaration</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Declaration</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference USER_SORT__DECLARATION = eINSTANCE.getUserSort_Declaration();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl <em>Operator Decl</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl <em>Operator
+		 * Decl</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.OperatorDeclImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getOperatorDecl()
 		 * @generated
@@ -2766,9 +2885,10 @@ public interface TermsPackage extends EPackage {
 		EClass OPERATOR_DECL = eINSTANCE.getOperatorDecl();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl <em>Named Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl <em>Named
+		 * Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getNamedOperator()
 		 * @generated
@@ -2776,25 +2896,26 @@ public interface TermsPackage extends EPackage {
 		EClass NAMED_OPERATOR = eINSTANCE.getNamedOperator();
 
 		/**
-		 * The meta object literal for the '<em><b>Def</b></em>' containment reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Def</b></em>' containment reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NAMED_OPERATOR__DEF = eINSTANCE.getNamedOperator_Def();
 
 		/**
-		 * The meta object literal for the '<em><b>Parameters</b></em>' containment reference list feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Parameters</b></em>' containment
+		 * reference list feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference NAMED_OPERATOR__PARAMETERS = eINSTANCE.getNamedOperator_Parameters();
 
 		/**
-		 * The meta object literal for the '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl <em>User Operator</em>}' class.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the
+		 * '{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl <em>User
+		 * Operator</em>}' class. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl
 		 * @see fr.lip6.move.pnml.pthlpng.terms.impl.TermsPackageImpl#getUserOperator()
 		 * @generated
@@ -2802,13 +2923,13 @@ public interface TermsPackage extends EPackage {
 		EClass USER_OPERATOR = eINSTANCE.getUserOperator();
 
 		/**
-		 * The meta object literal for the '<em><b>Declaration</b></em>' reference feature.
-		 * <!-- begin-user-doc -->
-		 * <!-- end-user-doc -->
+		 * The meta object literal for the '<em><b>Declaration</b></em>' reference
+		 * feature. <!-- begin-user-doc --> <!-- end-user-doc -->
+		 * 
 		 * @generated
 		 */
 		EReference USER_OPERATOR__DECLARATION = eINSTANCE.getUserOperator_Declaration();
 
 	}
 
-} //TermsPackage
+} // TermsPackage

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Tuple.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Tuple.java
@@ -42,9 +42,8 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Tuple</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Tuple</b></em>'. <!-- end-user-doc -->
  *
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTuple()
@@ -63,8 +62,8 @@ public interface Tuple extends Operator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Tuple.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Tuple.java
@@ -48,6 +48,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getTuple()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='tuple' kind='son'"
+ *        annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Tuple extends Operator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserOperator.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getUserOperator()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='useroperator'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface UserOperator extends Operator {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserOperator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserOperator.java
@@ -42,43 +42,48 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>User Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>User
+ * Operator</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getUserOperator()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='useroperator' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='useroperator'
+ *        kind='son'"
  * @generated
  */
 public interface UserOperator extends Operator {
 	/**
-	 * Returns the value of the '<em><b>Declaration</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Declaration</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Declaration</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Declaration</em>' reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Declaration</em>' reference.
 	 * @see #setDeclaration(OperatorDecl)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getUserOperator_Declaration()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='declaration' kind='idref'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='declaration'
+	 *        kind='idref'"
 	 * @generated
 	 */
 	OperatorDecl getDeclaration();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration <em>Declaration</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator#getDeclaration
+	 * <em>Declaration</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @param value the new value of the '<em>Declaration</em>' reference.
 	 * @see #getDeclaration()
 	 * @generated
@@ -95,8 +100,8 @@ public interface UserOperator extends Operator {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserSort.java
@@ -42,44 +42,65 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>User Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>User
+ * Sort</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getUserSort()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='usersort' kind='son'"
- *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t\t//further sub-classes must override this method.\n\t\t\t\tif (\"UserSort\".equalsIgnoreCase(this.eClass().getName())) {\n\t\t\t\t\tisEqual = ((UserSort) this).getDeclaration().getName()\n\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t((UserSort) sort).getDeclaration()\n\t\t\t\t\t\t\t\t\t\t\t.getName());\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t\treturn isEqual;' documentation='/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r \052/'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='usersort'
+ *        kind='son'" annotation="http://www.pnml.org/models/methods/SORT
+ *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
+ *        false;\n\t\tif
+ *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
+ *        {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
+ *        sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual =
+ *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}
+ *        else {\n\t\t\t\t//further sub-classes must override this
+ *        method.\n\t\t\t\tif
+ *        (\"UserSort\".equalsIgnoreCase(this.eClass().getName()))
+ *        {\n\t\t\t\t\tisEqual = ((UserSort)
+ *        this).getDeclaration().getName()\n\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t((UserSort)
+ *        sort).getDeclaration()\n\t\t\t\t\t\t\t\t\t\t\t.getName());\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t\treturn
+ *        isEqual;' documentation='/**\r * Returns true if this sort and
+ *        argument sort are actually \r * semantically the same sort, even in
+ *        two different objects.\r * Ex: two FiniteEnumerations or two
+ *        Integers.\r * @return true if so. \r * @param sort the sort to which
+ *        we compare this one. \r \052/'"
  * @generated
  */
 public interface UserSort extends Sort {
 	/**
-	 * Returns the value of the '<em><b>Declaration</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Declaration</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Declaration</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Declaration</em>' reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Declaration</em>' reference.
 	 * @see #setDeclaration(SortDecl)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getUserSort_Declaration()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='declaration' kind='idref'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='declaration'
+	 *        kind='idref'"
 	 * @generated
 	 */
 	SortDecl getDeclaration();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration <em>Declaration</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort#getDeclaration
+	 * <em>Declaration</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @param value the new value of the '<em>Declaration</em>' reference.
 	 * @see #getDeclaration()
 	 * @generated
@@ -96,8 +117,8 @@ public interface UserSort extends Sort {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserSort.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/UserSort.java
@@ -55,12 +55,13 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getUserSort()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='usersort'
- *        kind='son'" annotation="http://www.pnml.org/models/methods/SORT
- *        signature='boolean equalSorts(Sort sort)' body='boolean isEqual =
- *        false;\n\t\tif
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/methods/SORT signature='boolean
+ *        equalSorts(Sort sort)' body='boolean isEqual = false;\n\t\tif
  *        (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName()))
- *        {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&&
- *        sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual =
+ *        {\n\t\t\tif (this.getContainerNamedSort() !=
+ *        null\n\t\t\t\t\t&amp;&amp; sort.getContainerNamedSort() != null)
+ *        {\n\t\t\t\tisEqual =
  *        this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t}
  *        else {\n\t\t\t\t//further sub-classes must override this
  *        method.\n\t\t\t\tif

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Variable.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Variable.java
@@ -42,43 +42,47 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Variable</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object
+ * '<em><b>Variable</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl <em>Variable Decl</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl
+ * <em>Variable Decl</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariable()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='variable' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='variable'
+ *        kind='son'"
  * @generated
  */
 public interface Variable extends Term {
 	/**
-	 * Returns the value of the '<em><b>Variable Decl</b></em>' reference.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Variable Decl</b></em>' reference. <!--
+	 * begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Variable Decl</em>' reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Variable Decl</em>' reference isn't clear, there
+	 * really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Variable Decl</em>' reference.
 	 * @see #setVariableDecl(VariableDecl)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariable_VariableDecl()
 	 * @model required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML tag='refvariable' kind='idref'"
+	 *        annotation="http://www.pnml.org/models/ToPNML tag='refvariable'
+	 *        kind='idref'"
 	 * @generated
 	 */
 	VariableDecl getVariableDecl();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl <em>Variable Decl</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Variable#getVariableDecl <em>Variable
+	 * Decl</em>}' reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Variable Decl</em>' reference.
 	 * @see #getVariableDecl()
 	 * @generated
@@ -95,8 +99,8 @@ public interface Variable extends Term {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Variable.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/Variable.java
@@ -55,7 +55,7 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariable()
  * @model annotation="http://www.pnml.org/models/ToPNML tag='variable'
- *        kind='son'"
+ *        kind='son'" annotation="http://www.pnml.org/models/HLAPI"
  * @generated
  */
 public interface Variable extends Term {

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/VariableDecl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/VariableDecl.java
@@ -42,46 +42,52 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 
 /**
- * <!-- begin-user-doc -->
- * A representation of the model object '<em><b>Variable Decl</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> A representation of the model object '<em><b>Variable
+ * Decl</b></em>'. <!-- end-user-doc -->
  *
  * <p>
  * The following features are supported:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator <em>Container Named Operator</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort
+ * <em>Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator
+ * <em>Container Named Operator</em>}</li>
  * </ul>
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariableDecl()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='variabledecl' kind='son'"
+ * @model annotation="http://www.pnml.org/models/ToPNML tag='variabledecl'
+ *        kind='son'"
  * @generated
  */
 public interface VariableDecl extends TermsDeclaration {
 	/**
-	 * Returns the value of the '<em><b>Sort</b></em>' containment reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl <em>Container Variable Decl</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Sort</b></em>' containment reference. It is
+	 * bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl
+	 * <em>Container Variable Decl</em>}'. <!-- begin-user-doc -->
 	 * <p>
 	 * If the meaning of the '<em>Sort</em>' containment reference isn't clear,
 	 * there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return the value of the '<em>Sort</em>' containment reference.
 	 * @see #setSort(Sort)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariableDecl_Sort()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort#getContainerVariableDecl
-	 * @model opposite="containerVariableDecl" containment="true" required="true" ordered="false"
-	 *        annotation="http://www.pnml.org/models/ToPNML kind='follow'"
+	 * @model opposite="containerVariableDecl" containment="true" required="true"
+	 *        ordered="false" annotation="http://www.pnml.org/models/ToPNML
+	 *        kind='follow'"
 	 * @generated
 	 */
 	Sort getSort();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getSort <em>Sort</em>}'
+	 * containment reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @param value the new value of the '<em>Sort</em>' containment reference.
 	 * @see #getSort()
 	 * @generated
@@ -89,15 +95,18 @@ public interface VariableDecl extends TermsDeclaration {
 	void setSort(Sort value);
 
 	/**
-	 * Returns the value of the '<em><b>Container Named Operator</b></em>' container reference.
-	 * It is bidirectional and its opposite is '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters <em>Parameters</em>}'.
-	 * <!-- begin-user-doc -->
+	 * Returns the value of the '<em><b>Container Named Operator</b></em>' container
+	 * reference. It is bidirectional and its opposite is
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters
+	 * <em>Parameters</em>}'. <!-- begin-user-doc -->
 	 * <p>
-	 * If the meaning of the '<em>Container Named Operator</em>' container reference isn't clear,
-	 * there really should be more of a description here...
+	 * If the meaning of the '<em>Container Named Operator</em>' container reference
+	 * isn't clear, there really should be more of a description here...
 	 * </p>
 	 * <!-- end-user-doc -->
-	 * @return the value of the '<em>Container Named Operator</em>' container reference.
+	 * 
+	 * @return the value of the '<em>Container Named Operator</em>' container
+	 *         reference.
 	 * @see #setContainerNamedOperator(NamedOperator)
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariableDecl_ContainerNamedOperator()
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedOperator#getParameters
@@ -107,10 +116,13 @@ public interface VariableDecl extends TermsDeclaration {
 	NamedOperator getContainerNamedOperator();
 
 	/**
-	 * Sets the value of the '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator <em>Container Named Operator</em>}' container reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @param value the new value of the '<em>Container Named Operator</em>' container reference.
+	 * Sets the value of the
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl#getContainerNamedOperator
+	 * <em>Container Named Operator</em>}' container reference. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
+	 * @param value the new value of the '<em>Container Named Operator</em>'
+	 *              container reference.
 	 * @see #getContainerNamedOperator()
 	 * @generated
 	 */
@@ -126,8 +138,8 @@ public interface VariableDecl extends TermsDeclaration {
 	 * set values to conform PNML document
 	 */
 	@Override
-	public void fromPNML(OMElement subRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException;
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException;
 
 	/**
 	 * Write the PNML xml tree of this object into file

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/VariableDecl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/VariableDecl.java
@@ -56,7 +56,8 @@ import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
  * </p>
  *
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#getVariableDecl()
- * @model annotation="http://www.pnml.org/models/ToPNML tag='variabledecl'
+ * @model annotation="http://www.pnml.org/models/HLAPI"
+ *        annotation="http://www.pnml.org/models/ToPNML tag='variabledecl'
  *        kind='son'"
  * @generated
  */

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/DeclarationsHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/DeclarationsHLAPI.java
@@ -52,8 +52,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration;
 import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class DeclarationsHLAPI implements HLAPIClass{
+public class DeclarationsHLAPI implements HLAPIClass {
 
 	/**
 	 * The contained LLAPI element.
@@ -61,41 +60,37 @@ public class DeclarationsHLAPI implements HLAPIClass{
 	private Declarations item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public DeclarationsHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public DeclarationsHLAPI() {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclarations();}
-	
+		synchronized (fact) {
+			item = fact.createDeclarations();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public DeclarationsHLAPI(
-		 DeclarationHLAPI containerDeclaration
-	){//BEGIN CONSTRUCTOR BODY
+
+	public DeclarationsHLAPI(DeclarationHLAPI containerDeclaration) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createDeclarations();}
-	
- 		
- 		if(containerDeclaration!=null)
-			item.setContainerDeclaration((Declaration)containerDeclaration.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createDeclarations();
+		}
+
+		if (containerDeclaration != null)
+			item.setContainerDeclaration((Declaration) containerDeclaration.getContainedItem());
+
 	}
-
-
-
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public DeclarationsHLAPI(Declarations lowLevelAPI){
+	public DeclarationsHLAPI(Declarations lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -103,250 +98,221 @@ public class DeclarationsHLAPI implements HLAPIClass{
 	/**
 	 * Return encapsulated object
 	 */
-	public Declarations getContainedItem(){
+	public Declarations getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<TermsDeclaration> getDeclaration(){
+	public List<TermsDeclaration> getDeclaration() {
 		return item.getDeclaration();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declaration getContainerDeclaration(){
+	public Declaration getContainerDeclaration() {
 		return item.getContainerDeclaration();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermsDeclarationHLAPI> getDeclarationHLAPI(){
-			java.util.List<TermsDeclarationHLAPI> retour = new ArrayList<TermsDeclarationHLAPI>();
-			for (TermsDeclaration elemnt : getDeclaration()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.VariableDecl)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.NamedSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.NamedOperator)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.Partition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElement)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationHLAPI getContainerDeclarationHLAPI(){
-			if(item.getContainerDeclaration() == null) return null;
-			return new DeclarationHLAPI(item.getContainerDeclaration());
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableDeclHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI> getDeclaration_terms_VariableDeclHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI>();
-			for (TermsDeclaration elemnt : getDeclaration()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.VariableDecl)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NamedSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI> getDeclaration_terms_NamedSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI>();
-			for (TermsDeclaration elemnt : getDeclaration()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.NamedSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NamedOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI> getDeclaration_terms_NamedOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI>();
-			for (TermsDeclaration elemnt : getDeclaration()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.NamedOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI> getDeclaration_partitions_PartitionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI>();
-			for (TermsDeclaration elemnt : getDeclaration()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.Partition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI> getDeclaration_partitions_PartitionElementHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI>();
-			for (TermsDeclaration elemnt : getDeclaration()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElement)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public java.util.List<TermsDeclarationHLAPI> getDeclarationHLAPI() {
+		java.util.List<TermsDeclarationHLAPI> retour = new ArrayList<TermsDeclarationHLAPI>();
+		for (TermsDeclaration elemnt : getDeclaration()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.VariableDecl) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.NamedSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.NamedOperator) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.Partition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElement) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public DeclarationHLAPI getContainerDeclarationHLAPI() {
+		if (item.getContainerDeclaration() == null)
+			return null;
+		return new DeclarationHLAPI(item.getContainerDeclaration());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * VariableDeclHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI> getDeclaration_terms_VariableDeclHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI>();
+		for (TermsDeclaration elemnt : getDeclaration()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableDeclHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.VariableDecl) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NamedSortHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI> getDeclaration_terms_NamedSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI>();
+		for (TermsDeclaration elemnt : getDeclaration()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.NamedSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NamedOperatorHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI> getDeclaration_terms_NamedOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI>();
+		for (TermsDeclaration elemnt : getDeclaration()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.NamedOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI> getDeclaration_partitions_PartitionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI>();
+		for (TermsDeclaration elemnt : getDeclaration()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.Partition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI> getDeclaration_partitions_PartitionElementHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI>();
+		for (TermsDeclaration elemnt : getDeclaration()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElement) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set ContainerDeclaration
 	 */
 	public void setContainerDeclarationHLAPI(
-	
-	DeclarationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclaration((Declaration)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addDeclarationHLAPI(TermsDeclarationHLAPI unit){
-	
-		item.getDeclaration().add((TermsDeclaration)unit.getContainedItem());
+			DeclarationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclaration((Declaration) elem.getContainedItem());
+
 	}
 
-	public void removeDeclarationHLAPI(TermsDeclarationHLAPI unit){
-		item.getDeclaration().remove((TermsDeclaration)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(DeclarationsHLAPI item){
+	public void addDeclarationHLAPI(TermsDeclarationHLAPI unit) {
+
+		item.getDeclaration().add((TermsDeclaration) unit.getContainedItem());
+	}
+
+	public void removeDeclarationHLAPI(TermsDeclarationHLAPI unit) {
+		item.getDeclaration().remove((TermsDeclaration) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(DeclarationsHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/MultisetSortHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/MultisetSortHLAPI.java
@@ -59,8 +59,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class MultisetSortHLAPI implements HLAPIClass,SortHLAPI{
+public class MultisetSortHLAPI implements HLAPIClass, SortHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -68,230 +67,192 @@ public class MultisetSortHLAPI implements HLAPIClass,SortHLAPI{
 	private MultisetSort item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public MultisetSortHLAPI(
-		 SortHLAPI basis
-	
-		, PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public MultisetSortHLAPI(SortHLAPI basis
+
+			, PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createMultisetSort();}
-	
- 		
- 		if(basis!=null)
-			item.setBasis((Sort)basis.getContainedItem());
-		
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createMultisetSort();
+		}
+
+		if (basis != null)
+			item.setBasis((Sort) basis.getContainedItem());
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public MultisetSortHLAPI(MultisetSort lowLevelAPI){
+	public MultisetSortHLAPI(MultisetSort lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -299,415 +260,379 @@ public class MultisetSortHLAPI implements HLAPIClass,SortHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public MultisetSort getContainedItem(){
+	public MultisetSort getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getBasis(){
+	public Sort getBasis() {
 		return item.getBasis();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getBasisHLAPI(){
-			if(item.getBasis() == null) return null;
-			Sort object = item.getBasis();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
 			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getBasisHLAPI() {
+		if (item.getBasis() == null)
+			return null;
+		Sort object = item.getBasis();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
 		}
-		
-	
-	
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Basis
 	 */
 	public void setBasisHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setBasis((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setBasis((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(MultisetSortHLAPI item){
+	// equals method
+	public boolean equals(MultisetSortHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/NamedOperatorHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/NamedOperatorHLAPI.java
@@ -54,8 +54,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class NamedOperatorHLAPI implements HLAPIClass,TermsDeclarationHLAPI,OperatorDeclHLAPI{
+public class NamedOperatorHLAPI implements HLAPIClass, TermsDeclarationHLAPI, OperatorDeclHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -63,91 +62,75 @@ public class NamedOperatorHLAPI implements HLAPIClass,TermsDeclarationHLAPI,Oper
 	private NamedOperator item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NamedOperatorHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, TermHLAPI def
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public NamedOperatorHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, TermHLAPI def) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNamedOperator();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(def!=null)
-			item.setDef((Term)def.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNamedOperator();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (def != null)
+			item.setDef((Term) def.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NamedOperatorHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, TermHLAPI def
-	
-		, DeclarationsHLAPI containerDeclarations
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public NamedOperatorHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, TermHLAPI def
+
+			, DeclarationsHLAPI containerDeclarations) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNamedOperator();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(def!=null)
-			item.setDef((Term)def.getContainedItem());
-		
-	
- 		
- 		if(containerDeclarations!=null)
-			item.setContainerDeclarations((Declarations)containerDeclarations.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNamedOperator();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (def != null)
+			item.setDef((Term) def.getContainedItem());
+
+		if (containerDeclarations != null)
+			item.setContainerDeclarations((Declarations) containerDeclarations.getContainedItem());
+
 	}
-
-
-
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NamedOperatorHLAPI(NamedOperator lowLevelAPI){
+	public NamedOperatorHLAPI(NamedOperator lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -155,348 +138,354 @@ public class NamedOperatorHLAPI implements HLAPIClass,TermsDeclarationHLAPI,Oper
 	/**
 	 * Return encapsulated object
 	 */
-	public NamedOperator getContainedItem(){
+	public NamedOperator getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getName(){
+	public String getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declarations getContainerDeclarations(){
+	public Declarations getContainerDeclarations() {
 		return item.getContainerDeclarations();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Term getDef(){
+	public Term getDef() {
 		return item.getDef();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<VariableDecl> getParameters(){
+	public List<VariableDecl> getParameters() {
 		return item.getParameters();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI(){
-			if(item.getContainerDeclarations() == null) return null;
-			return new DeclarationsHLAPI(item.getContainerDeclarations());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public TermHLAPI getDefHLAPI(){
-			if(item.getDef() == null) return null;
-			Term object = item.getDef();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI((fr.lip6.move.pnml.pthlpng.terms.Variable)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI() {
+		if (item.getContainerDeclarations() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		public java.util.List<VariableDeclHLAPI> getParametersHLAPI(){
-			java.util.List<VariableDeclHLAPI> retour = new ArrayList<VariableDeclHLAPI>();
-			for (VariableDecl elemnt : getParameters()) {
-				retour.add(new VariableDeclHLAPI(elemnt));
-			}
-			return retour;
-		}
-	
-	
-	
+		return new DeclarationsHLAPI(item.getContainerDeclarations());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public TermHLAPI getDefHLAPI() {
+		if (item.getDef() == null)
+			return null;
+		Term object = item.getDef();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.Variable) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<VariableDeclHLAPI> getParametersHLAPI() {
+		java.util.List<VariableDeclHLAPI> retour = new ArrayList<VariableDeclHLAPI>();
+		for (VariableDecl elemnt : getParameters()) {
+			retour.add(new VariableDeclHLAPI(elemnt));
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setName(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Def
 	 */
 	public void setDefHLAPI(
-	
-	TermHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setDef((Term)elem.getContainedItem());
-	
+
+			TermHLAPI elem) {
+
+		if (elem != null)
+			item.setDef((Term) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarations
 	 */
 	public void setContainerDeclarationsHLAPI(
-	
-	DeclarationsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarations((Declarations)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addParametersHLAPI(VariableDeclHLAPI unit){
-	
-		item.getParameters().add((VariableDecl)unit.getContainedItem());
+			DeclarationsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarations((Declarations) elem.getContainedItem());
+
 	}
 
-	public void removeParametersHLAPI(VariableDeclHLAPI unit){
-		item.getParameters().remove((VariableDecl)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NamedOperatorHLAPI item){
+	public void addParametersHLAPI(VariableDeclHLAPI unit) {
+
+		item.getParameters().add((VariableDecl) unit.getContainedItem());
+	}
+
+	public void removeParametersHLAPI(VariableDeclHLAPI unit) {
+		item.getParameters().remove((VariableDecl) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(NamedOperatorHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/NamedSortHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/NamedSortHLAPI.java
@@ -51,8 +51,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class NamedSortHLAPI implements HLAPIClass,TermsDeclarationHLAPI,SortDeclHLAPI{
+public class NamedSortHLAPI implements HLAPIClass, TermsDeclarationHLAPI, SortDeclHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -60,91 +59,75 @@ public class NamedSortHLAPI implements HLAPIClass,TermsDeclarationHLAPI,SortDecl
 	private NamedSort item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public NamedSortHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI sortdef
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public NamedSortHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI sortdef) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNamedSort();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(sortdef!=null)
-			item.setSortdef((Sort)sortdef.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNamedSort();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (sortdef != null)
+			item.setSortdef((Sort) sortdef.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public NamedSortHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI sortdef
-	
-		, DeclarationsHLAPI containerDeclarations
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public NamedSortHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI sortdef
+
+			, DeclarationsHLAPI containerDeclarations) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createNamedSort();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(sortdef!=null)
-			item.setSortdef((Sort)sortdef.getContainedItem());
-		
-	
- 		
- 		if(containerDeclarations!=null)
-			item.setContainerDeclarations((Declarations)containerDeclarations.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createNamedSort();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (sortdef != null)
+			item.setSortdef((Sort) sortdef.getContainedItem());
+
+		if (containerDeclarations != null)
+			item.setContainerDeclarations((Declarations) containerDeclarations.getContainedItem());
+
 	}
-
-
-
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public NamedSortHLAPI(NamedSort lowLevelAPI){
+	public NamedSortHLAPI(NamedSort lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -152,213 +135,201 @@ public class NamedSortHLAPI implements HLAPIClass,TermsDeclarationHLAPI,SortDecl
 	/**
 	 * Return encapsulated object
 	 */
-	public NamedSort getContainedItem(){
+	public NamedSort getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getName(){
+	public String getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declarations getContainerDeclarations(){
+	public Declarations getContainerDeclarations() {
 		return item.getContainerDeclarations();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSortdef(){
+	public Sort getSortdef() {
 		return item.getSortdef();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI(){
-			if(item.getContainerDeclarations() == null) return null;
-			return new DeclarationsHLAPI(item.getContainerDeclarations());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortdefHLAPI(){
-			if(item.getSortdef() == null) return null;
-			Sort object = item.getSortdef();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI() {
+		if (item.getContainerDeclarations() == null)
 			return null;
+		return new DeclarationsHLAPI(item.getContainerDeclarations());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getSortdefHLAPI() {
+		if (item.getSortdef() == null)
+			return null;
+		Sort object = item.getSortdef();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
 		}
-		
-	
-	
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setName(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Sortdef
 	 */
 	public void setSortdefHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSortdef((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSortdef((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarations
 	 */
 	public void setContainerDeclarationsHLAPI(
-	
-	DeclarationsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarations((Declarations)elem.getContainedItem());
-	
+
+			DeclarationsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarations((Declarations) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(NamedSortHLAPI item){
+	// equals method
+	public boolean equals(NamedSortHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/OperatorDeclHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/OperatorDeclHLAPI.java
@@ -38,72 +38,54 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Declarations;
 
-public interface OperatorDeclHLAPI extends HLAPIClass,TermsDeclarationHLAPI{
+public interface OperatorDeclHLAPI extends HLAPIClass, TermsDeclarationHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public String getName();
-	
+
 	/**
 	 *
 	 */
 	public Declarations getContainerDeclarations();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	java.lang.String elem);
-	
+	public void setNameHLAPI(java.lang.String elem);
+
 	/**
 	 * set ContainerDeclarations
 	 */
-	public void setContainerDeclarationsHLAPI(
-	DeclarationsHLAPI elem);
-	
+	public void setContainerDeclarationsHLAPI(DeclarationsHLAPI elem);
 
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/OperatorHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/OperatorHLAPI.java
@@ -49,542 +49,445 @@ import fr.lip6.move.pnml.pthlpng.terms.Operator;
 import fr.lip6.move.pnml.pthlpng.terms.Sort;
 import fr.lip6.move.pnml.pthlpng.terms.Term;
 
-public interface OperatorHLAPI extends HLAPIClass,TermHLAPI{
+public interface OperatorHLAPI extends HLAPIClass, TermHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public Sort getSort();
-	
+
 	/**
 	 *
 	 */
 	public Operator getContainerOperator();
-	
+
 	/**
 	 *
 	 */
 	public NamedOperator getContainerNamedOperator();
-	
+
 	/**
 	 *
 	 */
 	public HLMarking getContainerHLMarking();
-	
+
 	/**
 	 *
 	 */
 	public Condition getContainerCondition();
-	
+
 	/**
 	 *
 	 */
 	public HLAnnotation getContainerHLAnnotation();
-	
+
 	/**
 	 *
 	 */
 	public PartitionElement getContainerPartitionElement();
-	
+
 	/**
 	 *
 	 */
 	public List<Term> getSubterm();
-	
+
 	/**
 	 *
 	 */
 	public Sort getOutput();
-	
+
 	/**
 	 *
 	 */
 	public List<Sort> getInput();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		
-		public java.util.List<TermHLAPI> getSubtermHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-		
-		public java.util.List<SortHLAPI> getInputHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public SortHLAPI getSortHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public SortHLAPI getOutputHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
-	public void setSortHLAPI(
-	SortHLAPI elem);
-	
+	public void setSortHLAPI(SortHLAPI elem);
+
 	/**
 	 * set Output
 	 */
-	public void setOutputHLAPI(
-	SortHLAPI elem);
-	
+	public void setOutputHLAPI(SortHLAPI elem);
+
 	/**
 	 * set ContainerOperator
 	 */
-	public void setContainerOperatorHLAPI(
-	OperatorHLAPI elem);
-	
+	public void setContainerOperatorHLAPI(OperatorHLAPI elem);
+
 	/**
 	 * set ContainerNamedOperator
 	 */
-	public void setContainerNamedOperatorHLAPI(
-	NamedOperatorHLAPI elem);
-	
+	public void setContainerNamedOperatorHLAPI(NamedOperatorHLAPI elem);
+
 	/**
 	 * set ContainerHLMarking
 	 */
-	public void setContainerHLMarkingHLAPI(
-	HLMarkingHLAPI elem);
-	
+	public void setContainerHLMarkingHLAPI(HLMarkingHLAPI elem);
+
 	/**
 	 * set ContainerCondition
 	 */
-	public void setContainerConditionHLAPI(
-	ConditionHLAPI elem);
-	
+	public void setContainerConditionHLAPI(ConditionHLAPI elem);
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
-	public void setContainerHLAnnotationHLAPI(
-	HLAnnotationHLAPI elem);
-	
+	public void setContainerHLAnnotationHLAPI(HLAnnotationHLAPI elem);
+
 	/**
 	 * set ContainerPartitionElement
 	 */
-	public void setContainerPartitionElementHLAPI(
-	PartitionElementHLAPI elem);
-	
+	public void setContainerPartitionElementHLAPI(PartitionElementHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI();
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI();
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI();
-		
-	
-	
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI();
 
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI();
 
-	//setters/remover for lists.
-	
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI();
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI();
+
+	// setters/remover for lists.
+
 	public void addSubtermHLAPI(TermHLAPI unit);
-	public void removeSubtermHLAPI(TermHLAPI unit);
-	
 
-	//equals method
+	public void removeSubtermHLAPI(TermHLAPI unit);
+
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/ProductSortHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/ProductSortHLAPI.java
@@ -61,8 +61,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class ProductSortHLAPI implements HLAPIClass,SortHLAPI{
+public class ProductSortHLAPI implements HLAPIClass, SortHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -70,150 +69,133 @@ public class ProductSortHLAPI implements HLAPIClass,SortHLAPI{
 	private ProductSort item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public ProductSortHLAPI(){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI() {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public ProductSortHLAPI(
-		 PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public ProductSortHLAPI(PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createProductSort();}
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createProductSort();
+		}
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public ProductSortHLAPI(ProductSort lowLevelAPI){
+	public ProductSortHLAPI(ProductSort lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -221,574 +203,506 @@ public class ProductSortHLAPI implements HLAPIClass,SortHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public ProductSort getContainedItem(){
+	public ProductSort getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getElementSort(){
+	public List<Sort> getElementSort() {
 		return item.getElementSort();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getElementSortHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getElementSort_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getElementSort_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getElementSort_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getElementSort_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getElementSort_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getElementSort_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getElementSort_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getElementSort_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getElementSort()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
+			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getElementSortHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getElementSort_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getElementSort_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getElementSort_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getElementSort_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getElementSort_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getElementSort_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getElementSort_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getElementSort_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getElementSort()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addElementSortHLAPI(SortHLAPI unit){
-	
-		item.getElementSort().add((Sort)unit.getContainedItem());
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
 
-	public void removeElementSortHLAPI(SortHLAPI unit){
-		item.getElementSort().remove((Sort)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(ProductSortHLAPI item){
+	public void addElementSortHLAPI(SortHLAPI unit) {
+
+		item.getElementSort().add((Sort) unit.getContainedItem());
+	}
+
+	public void removeElementSortHLAPI(SortHLAPI unit) {
+		item.getElementSort().remove((Sort) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(ProductSortHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/SortDeclHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/SortDeclHLAPI.java
@@ -38,72 +38,54 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Declarations;
 
-public interface SortDeclHLAPI extends HLAPIClass,TermsDeclarationHLAPI{
+public interface SortDeclHLAPI extends HLAPIClass, TermsDeclarationHLAPI {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public String getName();
-	
+
 	/**
 	 *
 	 */
 	public Declarations getContainerDeclarations();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	java.lang.String elem);
-	
+	public void setNameHLAPI(java.lang.String elem);
+
 	/**
 	 * set ContainerDeclarations
 	 */
-	public void setContainerDeclarationsHLAPI(
-	DeclarationsHLAPI elem);
-	
+	public void setContainerDeclarationsHLAPI(DeclarationsHLAPI elem);
 
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/SortHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/SortHLAPI.java
@@ -47,209 +47,153 @@ import fr.lip6.move.pnml.pthlpng.terms.NamedSort;
 import fr.lip6.move.pnml.pthlpng.terms.ProductSort;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 
-public interface SortHLAPI extends HLAPIClass{
+public interface SortHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public MultisetSort getMulti();
-	
+
 	/**
 	 *
 	 */
 	public NamedSort getContainerNamedSort();
-	
+
 	/**
 	 *
 	 */
 	public VariableDecl getContainerVariableDecl();
-	
+
 	/**
 	 *
 	 */
 	public ProductSort getContainerProductSort();
-	
+
 	/**
 	 *
 	 */
 	public Type getContainerType();
-	
+
 	/**
 	 *
 	 */
 	public All getContainerAll();
-	
+
 	/**
 	 *
 	 */
 	public Empty getContainerEmpty();
-	
+
 	/**
 	 *
 	 */
 	public Partition getContainerPartition();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public MultisetSortHLAPI getMultiHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public AllHLAPI getContainerAllHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Multi
 	 */
-	public void setMultiHLAPI(
-	MultisetSortHLAPI elem);
-	
+	public void setMultiHLAPI(MultisetSortHLAPI elem);
+
 	/**
 	 * set ContainerNamedSort
 	 */
-	public void setContainerNamedSortHLAPI(
-	NamedSortHLAPI elem);
-	
+	public void setContainerNamedSortHLAPI(NamedSortHLAPI elem);
+
 	/**
 	 * set ContainerVariableDecl
 	 */
-	public void setContainerVariableDeclHLAPI(
-	VariableDeclHLAPI elem);
-	
+	public void setContainerVariableDeclHLAPI(VariableDeclHLAPI elem);
+
 	/**
 	 * set ContainerProductSort
 	 */
-	public void setContainerProductSortHLAPI(
-	ProductSortHLAPI elem);
-	
+	public void setContainerProductSortHLAPI(ProductSortHLAPI elem);
+
 	/**
 	 * set ContainerType
 	 */
-	public void setContainerTypeHLAPI(
-	TypeHLAPI elem);
-	
+	public void setContainerTypeHLAPI(TypeHLAPI elem);
+
 	/**
 	 * set ContainerAll
 	 */
-	public void setContainerAllHLAPI(
-	AllHLAPI elem);
-	
+	public void setContainerAllHLAPI(AllHLAPI elem);
+
 	/**
 	 * set ContainerEmpty
 	 */
-	public void setContainerEmptyHLAPI(
-	EmptyHLAPI elem);
-	
+	public void setContainerEmptyHLAPI(EmptyHLAPI elem);
+
 	/**
 	 * set ContainerPartition
 	 */
-	public void setContainerPartitionHLAPI(
-	PartitionHLAPI elem);
-	
+	public void setContainerPartitionHLAPI(PartitionHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/TermHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/TermHLAPI.java
@@ -46,188 +46,136 @@ import fr.lip6.move.pnml.pthlpng.terms.NamedOperator;
 import fr.lip6.move.pnml.pthlpng.terms.Operator;
 import fr.lip6.move.pnml.pthlpng.terms.Sort;
 
-public interface TermHLAPI extends HLAPIClass{
+public interface TermHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public Sort getSort();
-	
+
 	/**
 	 *
 	 */
 	public Operator getContainerOperator();
-	
+
 	/**
 	 *
 	 */
 	public NamedOperator getContainerNamedOperator();
-	
+
 	/**
 	 *
 	 */
 	public HLMarking getContainerHLMarking();
-	
+
 	/**
 	 *
 	 */
 	public Condition getContainerCondition();
-	
+
 	/**
 	 *
 	 */
 	public HLAnnotation getContainerHLAnnotation();
-	
+
 	/**
 	 *
 	 */
 	public PartitionElement getContainerPartitionElement();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI();
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public SortHLAPI getSortHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI();
+
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
-	public void setSortHLAPI(
-	SortHLAPI elem);
-	
+	public void setSortHLAPI(SortHLAPI elem);
+
 	/**
 	 * set ContainerOperator
 	 */
-	public void setContainerOperatorHLAPI(
-	OperatorHLAPI elem);
-	
+	public void setContainerOperatorHLAPI(OperatorHLAPI elem);
+
 	/**
 	 * set ContainerNamedOperator
 	 */
-	public void setContainerNamedOperatorHLAPI(
-	NamedOperatorHLAPI elem);
-	
+	public void setContainerNamedOperatorHLAPI(NamedOperatorHLAPI elem);
+
 	/**
 	 * set ContainerHLMarking
 	 */
-	public void setContainerHLMarkingHLAPI(
-	HLMarkingHLAPI elem);
-	
+	public void setContainerHLMarkingHLAPI(HLMarkingHLAPI elem);
+
 	/**
 	 * set ContainerCondition
 	 */
-	public void setContainerConditionHLAPI(
-	ConditionHLAPI elem);
-	
+	public void setContainerConditionHLAPI(ConditionHLAPI elem);
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
-	public void setContainerHLAnnotationHLAPI(
-	HLAnnotationHLAPI elem);
-	
+	public void setContainerHLAnnotationHLAPI(HLAnnotationHLAPI elem);
+
 	/**
 	 * set ContainerPartitionElement
 	 */
-	public void setContainerPartitionElementHLAPI(
-	PartitionElementHLAPI elem);
-	
+	public void setContainerPartitionElementHLAPI(PartitionElementHLAPI elem);
 
-	
-	
-	
-	
-	
-	
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/TermsDeclarationHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/TermsDeclarationHLAPI.java
@@ -38,72 +38,54 @@ import fr.lip6.move.pnml.framework.utils.exception.InvalidIDException;
 import fr.lip6.move.pnml.framework.utils.exception.VoidRepositoryException;
 import fr.lip6.move.pnml.pthlpng.terms.Declarations;
 
-public interface TermsDeclarationHLAPI extends HLAPIClass{
+public interface TermsDeclarationHLAPI extends HLAPIClass {
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 *
 	 */
 	public String getId();
-	
+
 	/**
 	 *
 	 */
 	public String getName();
-	
+
 	/**
 	 *
 	 */
 	public Declarations getContainerDeclarations();
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automaticaly encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI();
-		
-	
-	
+	// getters giving HLAPI object
 
-	//setters (including container setter if aviable)
-	
-	
+	/**
+	 * This accessor automaticaly encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI();
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
-	public void setIdHLAPI(
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException;
-	
+	public void setIdHLAPI(java.lang.String elem) throws InvalidIDException, VoidRepositoryException;
+
 	/**
 	 * set Name
 	 */
-	public void setNameHLAPI(
-	java.lang.String elem);
-	
+	public void setNameHLAPI(java.lang.String elem);
+
 	/**
 	 * set ContainerDeclarations
 	 */
-	public void setContainerDeclarationsHLAPI(
-	DeclarationsHLAPI elem);
-	
+	public void setContainerDeclarationsHLAPI(DeclarationsHLAPI elem);
 
-	
-	
+	// setters/remover for lists.
 
-
-	//setters/remover for lists.
-	
-
-	//equals method
+	// equals method
 	public boolean equals(Object item);
 
 }

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/TupleHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/TupleHLAPI.java
@@ -61,8 +61,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.Tuple;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class TupleHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class TupleHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -70,325 +69,269 @@ public class TupleHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private Tuple item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public TupleHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public TupleHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TupleHLAPI(OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
+		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
 
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TupleHLAPI(
-		 OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
-		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TupleHLAPI(
-		 NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TupleHLAPI(NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TupleHLAPI(
-		 HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TupleHLAPI(HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TupleHLAPI(
-		 ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TupleHLAPI(ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TupleHLAPI(
-		 HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TupleHLAPI(HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public TupleHLAPI(
-		 PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public TupleHLAPI(PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createTuple();}
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createTuple();
+		}
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public TupleHLAPI(Tuple lowLevelAPI){
+	public TupleHLAPI(Tuple lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -396,1595 +339,1476 @@ public class TupleHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Tuple getContainedItem(){
+	public Tuple getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(TupleHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(TupleHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/UserOperatorHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/UserOperatorHLAPI.java
@@ -62,8 +62,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.UserOperator;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class UserOperatorHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
+public class UserOperatorHLAPI implements HLAPIClass, TermHLAPI, OperatorHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -71,432 +70,348 @@ public class UserOperatorHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	private UserOperator item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserOperatorHLAPI(
-		 SortHLAPI sort
-	
-		, SortHLAPI output
-	
-		, OperatorDeclHLAPI declaration
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserOperatorHLAPI(SortHLAPI sort
+
+			, SortHLAPI output
+
+			, OperatorDeclHLAPI declaration
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(output!=null)
-			item.setOutput((Sort)output.getContainedItem());
-		
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (output != null)
+			item.setOutput((Sort) output.getContainedItem());
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration) {// BEGIN CONSTRUCTOR BODY
+		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public UserOperatorHLAPI(OperatorDeclHLAPI declaration
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserOperator();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((OperatorDecl) declaration.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public UserOperatorHLAPI(
-		 OperatorDeclHLAPI declaration
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserOperator();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((OperatorDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public UserOperatorHLAPI(UserOperator lowLevelAPI){
+	public UserOperatorHLAPI(UserOperator lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -504,1642 +419,1520 @@ public class UserOperatorHLAPI implements HLAPIClass,TermHLAPI,OperatorHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public UserOperator getContainedItem(){
+	public UserOperator getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Term> getSubterm(){
+	public List<Term> getSubterm() {
 		return item.getSubterm();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getOutput(){
+	public Sort getOutput() {
 		return item.getOutput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public List<Sort> getInput(){
+	public List<Sort> getInput() {
 		return item.getInput();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public OperatorDecl getDeclaration(){
+	public OperatorDecl getDeclaration() {
 		return item.getDeclaration();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<TermHLAPI> getSubtermHLAPI(){
-			java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getOutputHLAPI(){
-			if(item.getOutput() == null) return null;
-			Sort object = item.getOutput();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate all elements of the selected sublist.
-		 * WARNING : this can creates a lot of new object in memory.
-		 */
-		
-			
-		public java.util.List<SortHLAPI> getInputHLAPI(){
-			java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-					continue;
-				}
-				
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-					continue;
-				}
-				
-			}
-			return retour;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorDeclHLAPI getDeclarationHLAPI(){
-			if(item.getDeclaration() == null) return null;
-			OperatorDecl object = item.getDeclaration();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.NamedOperator)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElement)object);
-			}
-			
-			return null;
-		}
-		
-	
-	
+	// getters giving HLAPI object
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of VariableHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Variable)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of TupleHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.Tuple)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserOperatorHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserOperator)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Equality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of InequalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Inequality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BooleanConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Or)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AndHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.And)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Imply)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Not)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.DotConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberConstantHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Addition)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Subtraction)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultiplicationHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Multiplication)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Division)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Modulo)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanOrEqualHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Contains)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of CardinalityOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AddHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Add)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of AllHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.All)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Empty)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.Subtract)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ScalarProductHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
-						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of GreaterThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PartitionElementOfHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
-			for (Term elemnt : getSubterm()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
-						(fr.lip6.move.pnml.pthlpng.partitions.LessThan)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of MultisetSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of ProductSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.ProductSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
-						(fr.lip6.move.pnml.pthlpng.terms.UserSort)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of BoolHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
-						(fr.lip6.move.pnml.pthlpng.booleans.Bool)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of DotHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI(
-						(fr.lip6.move.pnml.pthlpng.dots.Dot)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Natural)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.Positive)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-		
-		/**
-		 * This accessor return a list of encapsulated subelement, only of HLIntegerHLAPI kind.
-		 * WARNING : this method can creates a lot of new object in memory.
-		 */
-		public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI(){
-			java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
-			for (Sort elemnt : getInput()) {
-				if(elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-					retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
-						(fr.lip6.move.pnml.pthlpng.integers.HLInteger)elemnt
-						));
-				}
-			}
-			return retour;
-		}
-		
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
+			return null;
+		Operator object = item.getContainerOperator();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<TermHLAPI> getSubtermHLAPI() {
+		java.util.List<TermHLAPI> retour = new ArrayList<TermHLAPI>();
+		for (Term elemnt : getSubterm()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getOutputHLAPI() {
+		if (item.getOutput() == null)
+			return null;
+		Sort object = item.getOutput();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate all elements of the selected sublist.
+	 * WARNING : this can creates a lot of new object in memory.
+	 */
+
+	public java.util.List<SortHLAPI> getInputHLAPI() {
+		java.util.List<SortHLAPI> retour = new ArrayList<SortHLAPI>();
+		for (Sort elemnt : getInput()) {
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+				continue;
+			}
+
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+				continue;
+			}
+
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorDeclHLAPI getDeclarationHLAPI() {
+		if (item.getDeclaration() == null)
+			return null;
+		OperatorDecl object = item.getDeclaration();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.NamedOperator) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElement) object);
+		}
+
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of VariableHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> getSubterm_terms_VariableHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.VariableHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Variable) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of TupleHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> getSubterm_terms_TupleHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.Tuple) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * UserOperatorHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> getSubterm_terms_UserOperatorHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserOperator) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EqualityHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> getSubterm_booleans_EqualityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Equality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * InequalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> getSubterm_booleans_InequalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Inequality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * BooleanConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> getSubterm_booleans_BooleanConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of OrHLAPI kind.
+	 * WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> getSubterm_booleans_OrHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Or) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AndHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> getSubterm_booleans_AndHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.And) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ImplyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> getSubterm_booleans_ImplyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Imply) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> getSubterm_booleans_NotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Not) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * DotConstantHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> getSubterm_dots_DotConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.dots.DotConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * NumberConstantHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> getSubterm_integers_NumberConstantHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AdditionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> getSubterm_integers_AdditionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Addition) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * SubtractionHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> getSubterm_integers_SubtractionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Subtraction) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultiplicationHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> getSubterm_integers_MultiplicationHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Multiplication) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DivisionHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> getSubterm_integers_DivisionHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Division) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ModuloHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> getSubterm_integers_ModuloHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Modulo) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> getSubterm_integers_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> getSubterm_integers_GreaterThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> getSubterm_integers_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * LessThanOrEqualHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> getSubterm_integers_LessThanOrEqualHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> getSubterm_multisets_CardinalityHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of ContainsHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> getSubterm_multisets_ContainsHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Contains) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * CardinalityOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> getSubterm_multisets_CardinalityOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AddHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> getSubterm_multisets_AddHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Add) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of AllHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> getSubterm_multisets_AllHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.All) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of EmptyHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> getSubterm_multisets_EmptyHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Empty) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NumberOfHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> getSubterm_multisets_NumberOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of SubtractHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> getSubterm_multisets_SubtractHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.Subtract) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ScalarProductHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> getSubterm_multisets_ScalarProductHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+						(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * GreaterThanHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> getSubterm_partitions_GreaterThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * PartitionElementOfHLAPI kind. WARNING : this method can creates a lot of new
+	 * object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> getSubterm_partitions_PartitionElementOfHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of LessThanHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> getSubterm_partitions_LessThanHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI>();
+		for (Term elemnt : getSubterm()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+						(fr.lip6.move.pnml.pthlpng.partitions.LessThan) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * MultisetSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> getInput_terms_MultisetSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * ProductSortHLAPI kind. WARNING : this method can creates a lot of new object
+	 * in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> getInput_terms_ProductSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.ProductSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of UserSortHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> getInput_terms_UserSortHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+						(fr.lip6.move.pnml.pthlpng.terms.UserSort) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of BoolHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> getInput_booleans_BoolHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+						(fr.lip6.move.pnml.pthlpng.booleans.Bool) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of DotHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> getInput_dots_DotHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+				retour.add(
+						new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of NaturalHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> getInput_integers_NaturalHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Natural) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of PositiveHLAPI
+	 * kind. WARNING : this method can creates a lot of new object in memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> getInput_integers_PositiveHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.Positive) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	/**
+	 * This accessor return a list of encapsulated subelement, only of
+	 * HLIntegerHLAPI kind. WARNING : this method can creates a lot of new object in
+	 * memory.
+	 */
+	public java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> getInput_integers_HLIntegerHLAPI() {
+		java.util.List<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI> retour = new ArrayList<fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI>();
+		for (Sort elemnt : getInput()) {
+			if (elemnt.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+				retour.add(new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+						(fr.lip6.move.pnml.pthlpng.integers.HLInteger) elemnt));
+			}
+		}
+		return retour;
+	}
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Output
 	 */
 	public void setOutputHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setOutput((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setOutput((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Declaration
 	 */
 	public void setDeclarationHLAPI(
-	
-	OperatorDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setDeclaration((OperatorDecl)elem.getContainedItem());
-	
+
+			OperatorDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setDeclaration((OperatorDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
-	}
-	
 
-	//setters/remover for lists.
-	
-	
-	public void addSubtermHLAPI(TermHLAPI unit){
-	
-		item.getSubterm().add((Term)unit.getContainedItem());
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
 
-	public void removeSubtermHLAPI(TermHLAPI unit){
-		item.getSubterm().remove((Term)unit.getContainedItem());
-	}
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(UserOperatorHLAPI item){
+	public void addSubtermHLAPI(TermHLAPI unit) {
+
+		item.getSubterm().add((Term) unit.getContainedItem());
+	}
+
+	public void removeSubtermHLAPI(TermHLAPI unit) {
+		item.getSubterm().remove((Term) unit.getContainedItem());
+	}
+
+	// equals method
+	public boolean equals(UserOperatorHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/UserSortHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/UserSortHLAPI.java
@@ -60,8 +60,7 @@ import fr.lip6.move.pnml.pthlpng.terms.UserSort;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class UserSortHLAPI implements HLAPIClass,SortHLAPI{
+public class UserSortHLAPI implements HLAPIClass, SortHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -69,230 +68,192 @@ public class UserSortHLAPI implements HLAPIClass,SortHLAPI{
 	private UserSort item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, MultisetSortHLAPI multi
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, MultisetSortHLAPI multi) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(multi!=null)
-			item.setMulti((MultisetSort)multi.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (multi != null)
+			item.setMulti((MultisetSort) multi.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, NamedSortHLAPI containerNamedSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, NamedSortHLAPI containerNamedSort) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerNamedSort!=null)
-			item.setContainerNamedSort((NamedSort)containerNamedSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerNamedSort != null)
+			item.setContainerNamedSort((NamedSort) containerNamedSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, VariableDeclHLAPI containerVariableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, VariableDeclHLAPI containerVariableDecl) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerVariableDecl!=null)
-			item.setContainerVariableDecl((VariableDecl)containerVariableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerVariableDecl != null)
+			item.setContainerVariableDecl((VariableDecl) containerVariableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, ProductSortHLAPI containerProductSort
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, ProductSortHLAPI containerProductSort) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerProductSort!=null)
-			item.setContainerProductSort((ProductSort)containerProductSort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerProductSort != null)
+			item.setContainerProductSort((ProductSort) containerProductSort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, TypeHLAPI containerType
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, TypeHLAPI containerType) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerType!=null)
-			item.setContainerType((Type)containerType.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerType != null)
+			item.setContainerType((Type) containerType.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, AllHLAPI containerAll
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, AllHLAPI containerAll) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerAll!=null)
-			item.setContainerAll((All)containerAll.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerAll != null)
+			item.setContainerAll((All) containerAll.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, EmptyHLAPI containerEmpty
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, EmptyHLAPI containerEmpty) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerEmpty!=null)
-			item.setContainerEmpty((Empty)containerEmpty.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerEmpty != null)
+			item.setContainerEmpty((Empty) containerEmpty.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public UserSortHLAPI(
-		 SortDeclHLAPI declaration
-	
-		, PartitionHLAPI containerPartition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public UserSortHLAPI(SortDeclHLAPI declaration
+
+			, PartitionHLAPI containerPartition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createUserSort();}
-	
- 		
- 		if(declaration!=null)
-			item.setDeclaration((SortDecl)declaration.getContainedItem());
-		
-	
- 		
- 		if(containerPartition!=null)
-			item.setContainerPartition((Partition)containerPartition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createUserSort();
+		}
+
+		if (declaration != null)
+			item.setDeclaration((SortDecl) declaration.getContainedItem());
+
+		if (containerPartition != null)
+			item.setContainerPartition((Partition) containerPartition.getContainedItem());
+
 	}
-
-
-
-	
-	
-	
-	
-	
-	
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public UserSortHLAPI(UserSort lowLevelAPI){
+	public UserSortHLAPI(UserSort lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -300,391 +261,350 @@ public class UserSortHLAPI implements HLAPIClass,SortHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public UserSort getContainedItem(){
+	public UserSort getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public MultisetSort getMulti(){
+	public MultisetSort getMulti() {
 		return item.getMulti();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedSort getContainerNamedSort(){
+	public NamedSort getContainerNamedSort() {
 		return item.getContainerNamedSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getContainerVariableDecl(){
+	public VariableDecl getContainerVariableDecl() {
 		return item.getContainerVariableDecl();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public ProductSort getContainerProductSort(){
+	public ProductSort getContainerProductSort() {
 		return item.getContainerProductSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Type getContainerType(){
+	public Type getContainerType() {
 		return item.getContainerType();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public All getContainerAll(){
+	public All getContainerAll() {
 		return item.getContainerAll();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Empty getContainerEmpty(){
+	public Empty getContainerEmpty() {
 		return item.getContainerEmpty();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Partition getContainerPartition(){
+	public Partition getContainerPartition() {
 		return item.getContainerPartition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public SortDecl getDeclaration(){
+	public SortDecl getDeclaration() {
 		return item.getDeclaration();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public MultisetSortHLAPI getMultiHLAPI(){
-			if(item.getMulti() == null) return null;
-			return new MultisetSortHLAPI(item.getMulti());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedSortHLAPI getContainerNamedSortHLAPI(){
-			if(item.getContainerNamedSort() == null) return null;
-			return new NamedSortHLAPI(item.getContainerNamedSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getContainerVariableDeclHLAPI(){
-			if(item.getContainerVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getContainerVariableDecl());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ProductSortHLAPI getContainerProductSortHLAPI(){
-			if(item.getContainerProductSort() == null) return null;
-			return new ProductSortHLAPI(item.getContainerProductSort());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public TypeHLAPI getContainerTypeHLAPI(){
-			if(item.getContainerType() == null) return null;
-			return new TypeHLAPI(item.getContainerType());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public AllHLAPI getContainerAllHLAPI(){
-			if(item.getContainerAll() == null) return null;
-			return new AllHLAPI(item.getContainerAll());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public EmptyHLAPI getContainerEmptyHLAPI(){
-			if(item.getContainerEmpty() == null) return null;
-			return new EmptyHLAPI(item.getContainerEmpty());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionHLAPI getContainerPartitionHLAPI(){
-			if(item.getContainerPartition() == null) return null;
-			return new PartitionHLAPI(item.getContainerPartition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortDeclHLAPI getDeclarationHLAPI(){
-			if(item.getDeclaration() == null) return null;
-			SortDecl object = item.getDeclaration();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.NamedSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI((fr.lip6.move.pnml.pthlpng.partitions.Partition)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public MultisetSortHLAPI getMultiHLAPI() {
+		if (item.getMulti() == null)
 			return null;
+		return new MultisetSortHLAPI(item.getMulti());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedSortHLAPI getContainerNamedSortHLAPI() {
+		if (item.getContainerNamedSort() == null)
+			return null;
+		return new NamedSortHLAPI(item.getContainerNamedSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getContainerVariableDeclHLAPI() {
+		if (item.getContainerVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getContainerVariableDecl());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ProductSortHLAPI getContainerProductSortHLAPI() {
+		if (item.getContainerProductSort() == null)
+			return null;
+		return new ProductSortHLAPI(item.getContainerProductSort());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public TypeHLAPI getContainerTypeHLAPI() {
+		if (item.getContainerType() == null)
+			return null;
+		return new TypeHLAPI(item.getContainerType());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public AllHLAPI getContainerAllHLAPI() {
+		if (item.getContainerAll() == null)
+			return null;
+		return new AllHLAPI(item.getContainerAll());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public EmptyHLAPI getContainerEmptyHLAPI() {
+		if (item.getContainerEmpty() == null)
+			return null;
+		return new EmptyHLAPI(item.getContainerEmpty());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionHLAPI getContainerPartitionHLAPI() {
+		if (item.getContainerPartition() == null)
+			return null;
+		return new PartitionHLAPI(item.getContainerPartition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortDeclHLAPI getDeclarationHLAPI() {
+		if (item.getDeclaration() == null)
+			return null;
+		SortDecl object = item.getDeclaration();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.NamedSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.NamedSort) object);
 		}
-		
-	
-	
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.Partition) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		return null;
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Declaration
 	 */
 	public void setDeclarationHLAPI(
-	
-	SortDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setDeclaration((SortDecl)elem.getContainedItem());
-	
+
+			SortDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setDeclaration((SortDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set Multi
 	 */
 	public void setMultiHLAPI(
-	
-	MultisetSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setMulti((MultisetSort)elem.getContainedItem());
-	
+
+			MultisetSortHLAPI elem) {
+
+		if (elem != null)
+			item.setMulti((MultisetSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedSort
 	 */
 	public void setContainerNamedSortHLAPI(
-	
-	NamedSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedSort((NamedSort)elem.getContainedItem());
-	
+
+			NamedSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedSort((NamedSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerVariableDecl
 	 */
 	public void setContainerVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerProductSort
 	 */
 	public void setContainerProductSortHLAPI(
-	
-	ProductSortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerProductSort((ProductSort)elem.getContainedItem());
-	
+
+			ProductSortHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerProductSort((ProductSort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerType
 	 */
 	public void setContainerTypeHLAPI(
-	
-	TypeHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerType((Type)elem.getContainedItem());
-	
+
+			TypeHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerType((Type) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerAll
 	 */
 	public void setContainerAllHLAPI(
-	
-	AllHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerAll((All)elem.getContainedItem());
-	
+
+			AllHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerAll((All) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerEmpty
 	 */
 	public void setContainerEmptyHLAPI(
-	
-	EmptyHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerEmpty((Empty)elem.getContainedItem());
-	
+
+			EmptyHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerEmpty((Empty) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartition
 	 */
 	public void setContainerPartitionHLAPI(
-	
-	PartitionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartition((Partition)elem.getContainedItem());
-	
+
+			PartitionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartition((Partition) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(UserSortHLAPI item){
+	// equals method
+	public boolean equals(UserSortHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/VariableDeclHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/VariableDeclHLAPI.java
@@ -52,8 +52,7 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsFactory;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class VariableDeclHLAPI implements HLAPIClass,TermsDeclarationHLAPI{
+public class VariableDeclHLAPI implements HLAPIClass, TermsDeclarationHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -61,134 +60,112 @@ public class VariableDeclHLAPI implements HLAPIClass,TermsDeclarationHLAPI{
 	private VariableDecl item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public VariableDeclHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI sort
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public VariableDeclHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI sort) throws InvalidIDException, VoidRepositoryException {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariableDecl();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariableDecl();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableDeclHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI sort
-	
-		, DeclarationsHLAPI containerDeclarations
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public VariableDeclHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI sort
+
+			, DeclarationsHLAPI containerDeclarations) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																											// CONSTRUCTOR
+																											// BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariableDecl();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(containerDeclarations!=null)
-			item.setContainerDeclarations((Declarations)containerDeclarations.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariableDecl();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (containerDeclarations != null)
+			item.setContainerDeclarations((Declarations) containerDeclarations.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableDeclHLAPI(
-		 java.lang.String id
-	
-		, java.lang.String name
-	
-		, SortHLAPI sort
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	) throws InvalidIDException ,VoidRepositoryException {//BEGIN CONSTRUCTOR BODY
+
+	public VariableDeclHLAPI(java.lang.String id
+
+			, java.lang.String name
+
+			, SortHLAPI sort
+
+			, NamedOperatorHLAPI containerNamedOperator) throws InvalidIDException, VoidRepositoryException {// BEGIN
+																												// CONSTRUCTOR
+																												// BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariableDecl();}
-	
- 		
-			if(id!=null){
-			
-				item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
-			}
-		
-	
- 		
-			if(name!=null){
-			
-				item.setName(name);
-			}
-		
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariableDecl();
+		}
+
+		if (id != null) {
+
+			item.setId(ModelRepository.getInstance().getCurrentIdRepository().checkId(id, this));
+		}
+
+		if (name != null) {
+
+			item.setName(name);
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-
-
-
-	
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public VariableDeclHLAPI(VariableDecl lowLevelAPI){
+	public VariableDeclHLAPI(VariableDecl lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -196,249 +173,233 @@ public class VariableDeclHLAPI implements HLAPIClass,TermsDeclarationHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public VariableDecl getContainedItem(){
+	public VariableDecl getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getId(){
+	public String getId() {
 		return item.getId();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public String getName(){
+	public String getName() {
 		return item.getName();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Declarations getContainerDeclarations(){
+	public Declarations getContainerDeclarations() {
 		return item.getContainerDeclarations();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public DeclarationsHLAPI getContainerDeclarationsHLAPI(){
-			if(item.getContainerDeclarations() == null) return null;
-			return new DeclarationsHLAPI(item.getContainerDeclarations());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public DeclarationsHLAPI getContainerDeclarationsHLAPI() {
+		if (item.getContainerDeclarations() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
+		return new DeclarationsHLAPI(item.getContainerDeclarations());
+	}
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
 
-	//setters (including container setter if aviable)
-	
-	
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
+			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Id
 	 */
 	public void setIdHLAPI(
-	
-	java.lang.String elem) throws InvalidIDException ,VoidRepositoryException   {
-	
-	
-		if(elem!=null){
-		
-			try{
-			item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
-			}catch (OtherException e){
-			ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
+
+			java.lang.String elem) throws InvalidIDException, VoidRepositoryException {
+
+		if (elem != null) {
+
+			try {
+				item.setId(ModelRepository.getInstance().getCurrentIdRepository().changeId(this, elem));
+			} catch (OtherException e) {
+				ModelRepository.getInstance().getCurrentIdRepository().checkId(elem, this);
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Name
 	 */
 	public void setNameHLAPI(
-	
-	java.lang.String elem){
-	
-	
-		if(elem!=null){
-		
+
+			java.lang.String elem) {
+
+		if (elem != null) {
+
 			item.setName(elem);
 		}
-	
+
 	}
-	
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerDeclarations
 	 */
 	public void setContainerDeclarationsHLAPI(
-	
-	DeclarationsHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerDeclarations((Declarations)elem.getContainedItem());
-	
+
+			DeclarationsHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerDeclarations((Declarations) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(VariableDeclHLAPI item){
+	// equals method
+	public boolean equals(VariableDeclHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/VariableHLAPI.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/hlapi/VariableHLAPI.java
@@ -59,8 +59,7 @@ import fr.lip6.move.pnml.pthlpng.terms.Variable;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.impl.TermsFactoryImpl;
 
-
-public class VariableHLAPI implements HLAPIClass,TermHLAPI{
+public class VariableHLAPI implements HLAPIClass, TermHLAPI {
 
 	/**
 	 * The contained LLAPI element.
@@ -68,383 +67,313 @@ public class VariableHLAPI implements HLAPIClass,TermHLAPI{
 	private Variable item;
 
 	/**
-	 * this constructor allows you to set all 'settable' values
-	 * excepted container.
+	 * this constructor allows you to set all 'settable' values excepted container.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl
+
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
 
 	/**
-	 * this constructor allows you to set all 'settable' values, including container if any.
+	 * this constructor allows you to set all 'settable' values, including container
+	 * if any.
 	 */
-	
-	public VariableHLAPI(
-		 SortHLAPI sort
-	
-		, VariableDeclHLAPI variableDecl
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
+
+	public VariableHLAPI(SortHLAPI sort
+
+			, VariableDeclHLAPI variableDecl
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(sort!=null)
-			item.setSort((Sort)sort.getContainedItem());
-		
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (sort != null)
+			item.setSort((Sort) sort.getContainedItem());
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (not container if any)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl) {// BEGIN CONSTRUCTOR BODY
+		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+	}
 
 	/**
-    * This constructor give access to required stuff only (not container if any)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl
+
+			, OperatorHLAPI containerOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerOperator != null)
+			item.setContainerOperator((Operator) containerOperator.getContainedItem());
+
 	}
 
+	/**
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl
 
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	
-		, OperatorHLAPI containerOperator
-	){//BEGIN CONSTRUCTOR BODY
+			, NamedOperatorHLAPI containerNamedOperator) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerOperator!=null)
-			item.setContainerOperator((Operator)containerOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerNamedOperator != null)
+			item.setContainerNamedOperator((NamedOperator) containerNamedOperator.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	
-		, NamedOperatorHLAPI containerNamedOperator
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl
+
+			, HLMarkingHLAPI containerHLMarking) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerNamedOperator!=null)
-			item.setContainerNamedOperator((NamedOperator)containerNamedOperator.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerHLMarking != null)
+			item.setContainerHLMarking((HLMarking) containerHLMarking.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	
-		, HLMarkingHLAPI containerHLMarking
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl
+
+			, ConditionHLAPI containerCondition) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerHLMarking!=null)
-			item.setContainerHLMarking((HLMarking)containerHLMarking.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerCondition != null)
+			item.setContainerCondition((Condition) containerCondition.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	
-		, ConditionHLAPI containerCondition
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl
+
+			, HLAnnotationHLAPI containerHLAnnotation) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerCondition!=null)
-			item.setContainerCondition((Condition)containerCondition.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerHLAnnotation != null)
+			item.setContainerHLAnnotation((HLAnnotation) containerHLAnnotation.getContainedItem());
+
 	}
-	
-	
+
 	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	
-		, HLAnnotationHLAPI containerHLAnnotation
-	){//BEGIN CONSTRUCTOR BODY
+	 * This constructor give access to required stuff only (and container)
+	 */
+	public VariableHLAPI(VariableDeclHLAPI variableDecl
+
+			, PartitionElementHLAPI containerPartitionElement) {// BEGIN CONSTRUCTOR BODY
 		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerHLAnnotation!=null)
-			item.setContainerHLAnnotation((HLAnnotation)containerHLAnnotation.getContainedItem());
-		
-	
+		synchronized (fact) {
+			item = fact.createVariable();
+		}
+
+		if (variableDecl != null)
+			item.setVariableDecl((VariableDecl) variableDecl.getContainedItem());
+
+		if (containerPartitionElement != null)
+			item.setContainerPartitionElement((PartitionElement) containerPartitionElement.getContainedItem());
+
 	}
-	
-	
-	/**
-    * This constructor give access to required stuff only (and container)
-    */
-	public VariableHLAPI(
-		 VariableDeclHLAPI variableDecl
-	
-		, PartitionElementHLAPI containerPartitionElement
-	){//BEGIN CONSTRUCTOR BODY
-		TermsFactory fact = TermsFactoryImpl.eINSTANCE;
-		synchronized(fact){item = fact.createVariable();}
-	
- 		
- 		if(variableDecl!=null)
-			item.setVariableDecl((VariableDecl)variableDecl.getContainedItem());
-		
-	
- 		
- 		if(containerPartitionElement!=null)
-			item.setContainerPartitionElement((PartitionElement)containerPartitionElement.getContainedItem());
-		
-	
-	}
-	
 
 	/**
 	 * This constructor encapsulate a low level API object in HLAPI.
 	 */
-	public VariableHLAPI(Variable lowLevelAPI){
+	public VariableHLAPI(Variable lowLevelAPI) {
 		item = lowLevelAPI;
 	}
 
@@ -452,510 +381,507 @@ public class VariableHLAPI implements HLAPIClass,TermHLAPI{
 	/**
 	 * Return encapsulated object
 	 */
-	public Variable getContainedItem(){
+	public Variable getContainedItem() {
 		return item;
 	}
 
-	//getters giving LLAPI object
-	
+	// getters giving LLAPI object
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Sort getSort(){
+	public Sort getSort() {
 		return item.getSort();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Operator getContainerOperator(){
+	public Operator getContainerOperator() {
 		return item.getContainerOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public NamedOperator getContainerNamedOperator(){
+	public NamedOperator getContainerNamedOperator() {
 		return item.getContainerNamedOperator();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLMarking getContainerHLMarking(){
+	public HLMarking getContainerHLMarking() {
 		return item.getContainerHLMarking();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public Condition getContainerCondition(){
+	public Condition getContainerCondition() {
 		return item.getContainerCondition();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public HLAnnotation getContainerHLAnnotation(){
+	public HLAnnotation getContainerHLAnnotation() {
 		return item.getContainerHLAnnotation();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public PartitionElement getContainerPartitionElement(){
+	public PartitionElement getContainerPartitionElement() {
 		return item.getContainerPartitionElement();
 	}
-	
+
 	/**
 	 * Return the encapsulate Low Level API object.
 	 */
-	public VariableDecl getVariableDecl(){
+	public VariableDecl getVariableDecl() {
 		return item.getVariableDecl();
 	}
-	
 
-	//getters giving HLAPI object
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public SortHLAPI getSortHLAPI(){
-			if(item.getSort() == null) return null;
-			Sort object = item.getSort();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.MultisetSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.ProductSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserSort)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Bool)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI((fr.lip6.move.pnml.pthlpng.integers.Natural)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI((fr.lip6.move.pnml.pthlpng.integers.Positive)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI((fr.lip6.move.pnml.pthlpng.integers.HLInteger)object);
-			}
-			
+	// getters giving HLAPI object
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public SortHLAPI getSortHLAPI() {
+		if (item.getSort() == null)
 			return null;
+		Sort object = item.getSort();
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.MultisetSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.MultisetSort) object);
 		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		
-		public OperatorHLAPI getContainerOperatorHLAPI(){
-			if(item.getContainerOperator() == null) return null;
-			Operator object = item.getContainerOperator();
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI((fr.lip6.move.pnml.pthlpng.terms.UserOperator)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Equality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Inequality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI((fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI((fr.lip6.move.pnml.pthlpng.booleans.And)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Imply)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Not)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI((fr.lip6.move.pnml.pthlpng.dots.DotConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI((fr.lip6.move.pnml.pthlpng.integers.NumberConstant)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Addition)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Subtraction)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI((fr.lip6.move.pnml.pthlpng.integers.Multiplication)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI((fr.lip6.move.pnml.pthlpng.integers.Division)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI((fr.lip6.move.pnml.pthlpng.integers.Modulo)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI((fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Cardinality)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Contains)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Add)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI((fr.lip6.move.pnml.pthlpng.multisets.All)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Empty)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI((fr.lip6.move.pnml.pthlpng.multisets.NumberOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI((fr.lip6.move.pnml.pthlpng.multisets.Subtract)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI((fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.GreaterThan)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI((fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf)object);
-			}
-			
-			if(object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)){
-				return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI((fr.lip6.move.pnml.pthlpng.partitions.LessThan)object);
-			}
-			
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.ProductSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.ProductSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserSortHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserSort) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BoolImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BoolHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Bool) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotHLAPI((fr.lip6.move.pnml.pthlpng.dots.Dot) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NaturalImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NaturalHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Natural) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.PositiveImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.PositiveHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Positive) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.HLIntegerImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.HLIntegerHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.HLInteger) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public OperatorHLAPI getContainerOperatorHLAPI() {
+		if (item.getContainerOperator() == null)
 			return null;
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public NamedOperatorHLAPI getContainerNamedOperatorHLAPI(){
-			if(item.getContainerNamedOperator() == null) return null;
-			return new NamedOperatorHLAPI(item.getContainerNamedOperator());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLMarkingHLAPI getContainerHLMarkingHLAPI(){
-			if(item.getContainerHLMarking() == null) return null;
-			return new HLMarkingHLAPI(item.getContainerHLMarking());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public ConditionHLAPI getContainerConditionHLAPI(){
-			if(item.getContainerCondition() == null) return null;
-			return new ConditionHLAPI(item.getContainerCondition());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public HLAnnotationHLAPI getContainerHLAnnotationHLAPI(){
-			if(item.getContainerHLAnnotation() == null) return null;
-			return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public PartitionElementHLAPI getContainerPartitionElementHLAPI(){
-			if(item.getContainerPartitionElement() == null) return null;
-			return new PartitionElementHLAPI(item.getContainerPartitionElement());
-		}
-		
-	
-	
-	
-	
-		/**
-		 * This accessor automatically encapsulate an element of the current object.
-		 * WARNING : this creates a new object in memory.
-		 * @return : null if the element is null
-		 */
-		
-		public VariableDeclHLAPI getVariableDeclHLAPI(){
-			if(item.getVariableDecl() == null) return null;
-			return new VariableDeclHLAPI(item.getVariableDecl());
-		}
-		
-	
-	
+		Operator object = item.getContainerOperator();
 
-	//Special getter for list of generics object, return only one object type.
-	
-	
-	
-	
-	
-	
-	
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.TupleImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.TupleHLAPI((fr.lip6.move.pnml.pthlpng.terms.Tuple) object);
+		}
 
-	//setters (including container setter if aviable)
-	
-	
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.terms.hlapi.UserOperatorHLAPI(
+					(fr.lip6.move.pnml.pthlpng.terms.UserOperator) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.EqualityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.EqualityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Equality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.InequalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.InequalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Inequality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.BooleanConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.BooleanConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.BooleanConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.OrImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.OrHLAPI((fr.lip6.move.pnml.pthlpng.booleans.Or) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.AndImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.AndHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.And) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.ImplyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.ImplyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Imply) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.booleans.impl.NotImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.booleans.hlapi.NotHLAPI(
+					(fr.lip6.move.pnml.pthlpng.booleans.Not) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.dots.impl.DotConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.dots.hlapi.DotConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.dots.DotConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.NumberConstantImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.NumberConstantHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.NumberConstant) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.AdditionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.AdditionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Addition) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.SubtractionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.SubtractionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Subtraction) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.MultiplicationImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.MultiplicationHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Multiplication) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.DivisionImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.DivisionHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Division) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.ModuloImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.ModuloHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.Modulo) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.GreaterThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.GreaterThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.GreaterThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.integers.impl.LessThanOrEqualImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.integers.hlapi.LessThanOrEqualHLAPI(
+					(fr.lip6.move.pnml.pthlpng.integers.LessThanOrEqual) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Cardinality) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ContainsImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ContainsHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Contains) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.CardinalityOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.CardinalityOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.CardinalityOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AddImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AddHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Add) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.AllImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.AllHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.All) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.EmptyImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.EmptyHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Empty) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.NumberOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.NumberOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.NumberOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.SubtractImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.SubtractHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.Subtract) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.multisets.impl.ScalarProductImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.multisets.hlapi.ScalarProductHLAPI(
+					(fr.lip6.move.pnml.pthlpng.multisets.ScalarProduct) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.GreaterThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.GreaterThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.GreaterThan) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.PartitionElementOfImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.PartitionElementOfHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.PartitionElementOf) object);
+		}
+
+		if (object.getClass().equals(fr.lip6.move.pnml.pthlpng.partitions.impl.LessThanImpl.class)) {
+			return new fr.lip6.move.pnml.pthlpng.partitions.hlapi.LessThanHLAPI(
+					(fr.lip6.move.pnml.pthlpng.partitions.LessThan) object);
+		}
+
+		return null;
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public NamedOperatorHLAPI getContainerNamedOperatorHLAPI() {
+		if (item.getContainerNamedOperator() == null)
+			return null;
+		return new NamedOperatorHLAPI(item.getContainerNamedOperator());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLMarkingHLAPI getContainerHLMarkingHLAPI() {
+		if (item.getContainerHLMarking() == null)
+			return null;
+		return new HLMarkingHLAPI(item.getContainerHLMarking());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public ConditionHLAPI getContainerConditionHLAPI() {
+		if (item.getContainerCondition() == null)
+			return null;
+		return new ConditionHLAPI(item.getContainerCondition());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public HLAnnotationHLAPI getContainerHLAnnotationHLAPI() {
+		if (item.getContainerHLAnnotation() == null)
+			return null;
+		return new HLAnnotationHLAPI(item.getContainerHLAnnotation());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public PartitionElementHLAPI getContainerPartitionElementHLAPI() {
+		if (item.getContainerPartitionElement() == null)
+			return null;
+		return new PartitionElementHLAPI(item.getContainerPartitionElement());
+	}
+
+	/**
+	 * This accessor automatically encapsulate an element of the current object.
+	 * WARNING : this creates a new object in memory.
+	 * 
+	 * @return : null if the element is null
+	 */
+
+	public VariableDeclHLAPI getVariableDeclHLAPI() {
+		if (item.getVariableDecl() == null)
+			return null;
+		return new VariableDeclHLAPI(item.getVariableDecl());
+	}
+
+	// Special getter for list of generics object, return only one object type.
+
+	// setters (including container setter if aviable)
+
 	/**
 	 * set Sort
 	 */
 	public void setSortHLAPI(
-	
-	SortHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setSort((Sort)elem.getContainedItem());
-	
+
+			SortHLAPI elem) {
+
+		if (elem != null)
+			item.setSort((Sort) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set VariableDecl
 	 */
 	public void setVariableDeclHLAPI(
-	
-	VariableDeclHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setVariableDecl((VariableDecl)elem.getContainedItem());
-	
+
+			VariableDeclHLAPI elem) {
+
+		if (elem != null)
+			item.setVariableDecl((VariableDecl) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerOperator
 	 */
 	public void setContainerOperatorHLAPI(
-	
-	OperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerOperator((Operator)elem.getContainedItem());
-	
+
+			OperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerOperator((Operator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerNamedOperator
 	 */
 	public void setContainerNamedOperatorHLAPI(
-	
-	NamedOperatorHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerNamedOperator((NamedOperator)elem.getContainedItem());
-	
+
+			NamedOperatorHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerNamedOperator((NamedOperator) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLMarking
 	 */
 	public void setContainerHLMarkingHLAPI(
-	
-	HLMarkingHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLMarking((HLMarking)elem.getContainedItem());
-	
+
+			HLMarkingHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLMarking((HLMarking) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerCondition
 	 */
 	public void setContainerConditionHLAPI(
-	
-	ConditionHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerCondition((Condition)elem.getContainedItem());
-	
+
+			ConditionHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerCondition((Condition) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerHLAnnotation
 	 */
 	public void setContainerHLAnnotationHLAPI(
-	
-	HLAnnotationHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerHLAnnotation((HLAnnotation)elem.getContainedItem());
-	
+
+			HLAnnotationHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerHLAnnotation((HLAnnotation) elem.getContainedItem());
+
 	}
-	
+
 	/**
 	 * set ContainerPartitionElement
 	 */
 	public void setContainerPartitionElementHLAPI(
-	
-	PartitionElementHLAPI elem){
-	
-	
- 		if(elem!=null)
-			item.setContainerPartitionElement((PartitionElement)elem.getContainedItem());
-	
+
+			PartitionElementHLAPI elem) {
+
+		if (elem != null)
+			item.setContainerPartitionElement((PartitionElement) elem.getContainedItem());
+
 	}
-	
 
-	//setters/remover for lists.
-	
+	// setters/remover for lists.
 
-	//equals method
-	public boolean equals(VariableHLAPI item){
+	// equals method
+	public boolean equals(VariableHLAPI item) {
 		return item.getContainedItem().equals(getContainedItem());
 	}
 
-	//PNML
-	
+	// PNML
+
 	/**
 	 * Returns the PNML xml tree for this object.
 	 */
-	public String toPNML(){
+	public String toPNML() {
 		return item.toPNML();
 	}
-	
+
 	/**
 	 * Writes the PNML XML tree of this object into file channel.
 	 */
-	public void toPNML(FileChannel fc){
-		 item.toPNML(fc);
+	public void toPNML(FileChannel fc) {
+		item.toPNML(fc);
 	}
 
 	/**
 	 * creates an object from the xml nodes.(symetric work of toPNML)
 	 */
-	public void fromPNML(OMElement subRoot,IdRefLinker idr) throws InnerBuildException, InvalidIDException, VoidRepositoryException{
-		item.fromPNML(subRoot,idr);
+	public void fromPNML(OMElement subRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		item.fromPNML(subRoot, idr);
 	}
-	
 
-	public boolean validateOCL(DiagnosticChain diagnostics){
+	public boolean validateOCL(DiagnosticChain diagnostics) {
 		return item.validateOCL(diagnostics);
 	}
 

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/BuiltInConstantImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/BuiltInConstantImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Built In Constant</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Built
+ * In Constant</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class BuiltInConstantImpl extends OperatorImpl implements BuiltInConstant {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BuiltInConstantImpl() {
@@ -57,8 +56,8 @@ public abstract class BuiltInConstantImpl extends OperatorImpl implements BuiltI
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class BuiltInConstantImpl extends OperatorImpl implements BuiltI
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //BuiltInConstantImpl
+} // BuiltInConstantImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/BuiltInOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/BuiltInOperatorImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Built In Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Built
+ * In Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class BuiltInOperatorImpl extends OperatorImpl implements BuiltInOperator {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BuiltInOperatorImpl() {
@@ -57,8 +56,8 @@ public abstract class BuiltInOperatorImpl extends OperatorImpl implements BuiltI
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class BuiltInOperatorImpl extends OperatorImpl implements BuiltI
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //BuiltInOperatorImpl
+} // BuiltInOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/BuiltInSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/BuiltInSortImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.terms.BuiltInSort;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Built In Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Built
+ * In Sort</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class BuiltInSortImpl extends SortImpl implements BuiltInSort {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected BuiltInSortImpl() {
@@ -57,8 +56,8 @@ public abstract class BuiltInSortImpl extends SortImpl implements BuiltInSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class BuiltInSortImpl extends SortImpl implements BuiltInSort {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //BuiltInSortImpl
+} // BuiltInSortImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/DeclarationsImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/DeclarationsImpl.java
@@ -75,14 +75,15 @@ import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Declarations</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Declarations</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl#getDeclaration <em>Declaration</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl#getContainerDeclaration <em>Container Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl#getDeclaration
+ * <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.DeclarationsImpl#getContainerDeclaration
+ * <em>Container Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -90,9 +91,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations {
 	/**
-	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDeclaration()
 	 * @generated
 	 * @ordered
@@ -100,8 +101,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	protected EList<TermsDeclaration> declaration;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected DeclarationsImpl() {
@@ -109,8 +110,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,8 +120,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -133,8 +134,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -145,8 +146,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerDeclaration(Declaration newContainerDeclaration, NotificationChain msgs) {
@@ -156,14 +157,15 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerDeclaration(Declaration newContainerDeclaration) {
 		if (newContainerDeclaration != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.DECLARATIONS__CONTAINER_DECLARATION && newContainerDeclaration != null)) {
+				|| (eContainerFeatureID() != TermsPackage.DECLARATIONS__CONTAINER_DECLARATION
+						&& newContainerDeclaration != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerDeclaration))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -181,8 +183,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -200,8 +202,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -216,8 +218,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -231,8 +233,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -247,8 +249,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -267,8 +269,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -285,8 +287,8 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -305,10 +307,10 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -326,13 +328,13 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getDeclaration() != null) {
 
@@ -367,22 +369,22 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -396,7 +398,7 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 				item.setContainerDeclarations(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("namedsort")) {
 				NamedSort item;
@@ -406,7 +408,7 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 				item.setContainerDeclarations(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("namedoperator")) {
 				NamedOperator item;
@@ -416,7 +418,7 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 				item.setContainerDeclarations(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("partition")) {
 				Partition item;
@@ -426,7 +428,7 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 				item.setContainerDeclarations(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("partitionelement")) {
 				PartitionElement item;
@@ -436,7 +438,7 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 				item.setContainerDeclarations(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -447,10 +449,10 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -473,13 +475,13 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getDeclaration() != null) {
 
@@ -565,4 +567,4 @@ public class DeclarationsImpl extends MinimalEObjectImpl implements Declarations
 		return retour;
 
 	}
-} //DeclarationsImpl
+} // DeclarationsImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/MultisetOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/MultisetOperatorImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.terms.MultisetOperator;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Multiset Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Multiset Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class MultisetOperatorImpl extends OperatorImpl implements MultisetOperator {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected MultisetOperatorImpl() {
@@ -57,8 +56,8 @@ public abstract class MultisetOperatorImpl extends OperatorImpl implements Multi
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class MultisetOperatorImpl extends OperatorImpl implements Multi
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //MultisetOperatorImpl
+} // MultisetOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/MultisetSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/MultisetSortImpl.java
@@ -67,13 +67,13 @@ import fr.lip6.move.pnml.pthlpng.terms.UserSort;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Multiset Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Multiset Sort</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl#getBasis <em>Basis</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.MultisetSortImpl#getBasis
+ * <em>Basis</em>}</li>
  * </ul>
  * </p>
  *
@@ -81,9 +81,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	/**
-	 * The cached value of the '{@link #getBasis() <em>Basis</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getBasis() <em>Basis</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getBasis()
 	 * @generated
 	 * @ordered
@@ -91,8 +91,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	protected Sort basis;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected MultisetSortImpl() {
@@ -100,8 +100,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -110,8 +110,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -120,8 +120,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetBasis(Sort newBasis, NotificationChain msgs) {
@@ -139,8 +139,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -155,12 +155,13 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, TermsPackage.MULTISET_SORT__BASIS, newBasis, newBasis));
+			eNotify(new ENotificationImpl(this, Notification.SET, TermsPackage.MULTISET_SORT__BASIS, newBasis,
+					newBasis));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -168,16 +169,16 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 		switch (featureID) {
 		case TermsPackage.MULTISET_SORT__BASIS:
 			if (basis != null)
-				msgs = ((InternalEObject) basis).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- TermsPackage.MULTISET_SORT__BASIS, null, msgs);
+				msgs = ((InternalEObject) basis).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - TermsPackage.MULTISET_SORT__BASIS, null, msgs);
 			return basicSetBasis((Sort) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -190,8 +191,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -204,8 +205,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -219,8 +220,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -234,8 +235,8 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -252,10 +253,10 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -273,13 +274,13 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getBasis() != null) {
 
@@ -313,22 +314,22 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -342,7 +343,7 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 				item.setMulti(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -352,7 +353,7 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 				item.setMulti(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -362,7 +363,7 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 				item.setMulti(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("null")) {
 				Bool item;
@@ -372,7 +373,7 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 				item.setMulti(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -382,7 +383,7 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 				item.setMulti(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -393,10 +394,10 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -419,13 +420,13 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getBasis() != null) {
 
@@ -508,12 +509,12 @@ public class MultisetSortImpl extends SortImpl implements MultisetSort {
 				isEqual = this.getContainerNamedSort().getName()
 						.equalsIgnoreCase(sort.getContainerNamedSort().getName());
 			} else {
-				throw new UnsupportedOperationException("Cannot determine if these two multisets are equal."
-						+ "You should override this method.");
+				throw new UnsupportedOperationException(
+						"Cannot determine if these two multisets are equal." + "You should override this method.");
 			}
 		}
 		return isEqual;
 
 	}
 
-} //MultisetSortImpl
+} // MultisetSortImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedOperatorImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedOperatorImpl.java
@@ -72,14 +72,15 @@ import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Named Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Named
+ * Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl#getDef <em>Def</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl#getParameters <em>Parameters</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl#getDef
+ * <em>Def</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedOperatorImpl#getParameters
+ * <em>Parameters</em>}</li>
  * </ul>
  * </p>
  *
@@ -87,9 +88,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator {
 	/**
-	 * The cached value of the '{@link #getDef() <em>Def</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDef() <em>Def</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDef()
 	 * @generated
 	 * @ordered
@@ -97,9 +98,9 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	protected Term def;
 
 	/**
-	 * The cached value of the '{@link #getParameters() <em>Parameters</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getParameters() <em>Parameters</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getParameters()
 	 * @generated
 	 * @ordered
@@ -107,8 +108,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	protected EList<VariableDecl> parameters;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NamedOperatorImpl() {
@@ -116,8 +117,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -126,8 +127,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -136,8 +137,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetDef(Term newDef, NotificationChain msgs) {
@@ -155,8 +156,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -177,8 +178,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -191,8 +192,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -201,8 +202,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 		switch (featureID) {
 		case TermsPackage.NAMED_OPERATOR__DEF:
 			if (def != null)
-				msgs = ((InternalEObject) def).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- TermsPackage.NAMED_OPERATOR__DEF, null, msgs);
+				msgs = ((InternalEObject) def).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - TermsPackage.NAMED_OPERATOR__DEF, null, msgs);
 			return basicSetDef((Term) otherEnd, msgs);
 		case TermsPackage.NAMED_OPERATOR__PARAMETERS:
 			return ((InternalEList<InternalEObject>) (InternalEList<?>) getParameters()).basicAdd(otherEnd, msgs);
@@ -211,8 +212,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -227,8 +228,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -243,8 +244,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -263,8 +264,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -281,8 +282,8 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -301,10 +302,10 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 2
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 2
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -322,7 +323,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -342,7 +343,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getDef() != null) {
 
@@ -405,16 +406,16 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//1
-		//2
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 1
+		// 2
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -422,9 +423,9 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("name")) != null) {
 			try {
@@ -434,7 +435,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -657,7 +658,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 			if (type.getLocalName().equals("parameter")) {
 
@@ -678,7 +679,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -689,10 +690,10 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 2
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 2
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -715,7 +716,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -735,7 +736,7 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getDef() != null) {
 
@@ -861,4 +862,4 @@ public class NamedOperatorImpl extends OperatorDeclImpl implements NamedOperator
 		return retour;
 
 	}
-} //NamedOperatorImpl
+} // NamedOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedSortImpl.java
@@ -70,13 +70,13 @@ import fr.lip6.move.pnml.pthlpng.terms.UserSort;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Named Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Named
+ * Sort</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl#getSortdef <em>Sortdef</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.NamedSortImpl#getSortdef
+ * <em>Sortdef</em>}</li>
  * </ul>
  * </p>
  *
@@ -84,9 +84,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	/**
-	 * The cached value of the '{@link #getSortdef() <em>Sortdef</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSortdef() <em>Sortdef</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSortdef()
 	 * @generated
 	 * @ordered
@@ -94,8 +94,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	protected Sort sortdef;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected NamedSortImpl() {
@@ -103,8 +103,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -113,8 +113,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -123,8 +123,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetSortdef(Sort newSortdef, NotificationChain msgs) {
@@ -142,8 +142,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -165,8 +165,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -174,16 +174,16 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 		switch (featureID) {
 		case TermsPackage.NAMED_SORT__SORTDEF:
 			if (sortdef != null)
-				msgs = ((InternalEObject) sortdef).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- TermsPackage.NAMED_SORT__SORTDEF, null, msgs);
+				msgs = ((InternalEObject) sortdef).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - TermsPackage.NAMED_SORT__SORTDEF, null, msgs);
 			return basicSetSortdef((Sort) otherEnd, msgs);
 		}
 		return super.eInverseAdd(otherEnd, featureID, msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -196,8 +196,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -210,8 +210,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -225,8 +225,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -240,8 +240,8 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -258,10 +258,10 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -279,7 +279,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -299,7 +299,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSortdef() != null) {
 
@@ -333,16 +333,16 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//1
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 1
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -350,9 +350,9 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("name")) != null) {
 			try {
@@ -362,7 +362,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -376,7 +376,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 				item.setContainerNamedSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -386,7 +386,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 				item.setContainerNamedSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -396,7 +396,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 				item.setContainerNamedSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("null")) {
 				Bool item;
@@ -406,7 +406,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 				item.setContainerNamedSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -416,7 +416,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 				item.setContainerNamedSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -427,10 +427,10 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -453,7 +453,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -473,7 +473,7 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSortdef() != null) {
 
@@ -546,4 +546,4 @@ public class NamedSortImpl extends SortDeclImpl implements NamedSort {
 		return retour;
 
 	}
-} //NamedSortImpl
+} // NamedSortImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/NamedSortImpl.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/OperatorDeclImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/OperatorDeclImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.terms.OperatorDecl;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Operator Decl</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Operator Decl</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class OperatorDeclImpl extends TermsDeclarationImpl implements OperatorDecl {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected OperatorDeclImpl() {
@@ -57,8 +56,8 @@ public abstract class OperatorDeclImpl extends TermsDeclarationImpl implements O
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class OperatorDeclImpl extends TermsDeclarationImpl implements O
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //OperatorDeclImpl
+} // OperatorDeclImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/OperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/OperatorImpl.java
@@ -51,15 +51,17 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl#getSubterm <em>Subterm</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl#getOutput <em>Output</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl#getInput <em>Input</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl#getSubterm
+ * <em>Subterm</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl#getOutput
+ * <em>Output</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.OperatorImpl#getInput
+ * <em>Input</em>}</li>
  * </ul>
  * </p>
  *
@@ -67,9 +69,9 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class OperatorImpl extends TermImpl implements Operator {
 	/**
-	 * The cached value of the '{@link #getSubterm() <em>Subterm</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSubterm() <em>Subterm</em>}' containment
+	 * reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSubterm()
 	 * @generated
 	 * @ordered
@@ -78,8 +80,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 
 	/**
 	 * The cached value of the '{@link #getOutput() <em>Output</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getOutput()
 	 * @generated
 	 * @ordered
@@ -88,8 +90,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 
 	/**
 	 * The cached value of the '{@link #getInput() <em>Input</em>}' reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getInput()
 	 * @generated
 	 * @ordered
@@ -97,8 +99,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	protected EList<Sort> input;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected OperatorImpl() {
@@ -106,8 +108,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -116,8 +118,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,8 +132,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -149,8 +151,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public Sort basicGetOutput() {
@@ -158,8 +160,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -171,8 +173,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -184,8 +186,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -199,8 +201,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -213,8 +215,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -233,8 +235,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -257,8 +259,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -278,8 +280,8 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -297,4 +299,4 @@ public abstract class OperatorImpl extends TermImpl implements Operator {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //OperatorImpl
+} // OperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/ProductSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/ProductSortImpl.java
@@ -69,13 +69,13 @@ import fr.lip6.move.pnml.pthlpng.terms.UserSort;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Product Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Product
+ * Sort</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl#getElementSort <em>Element Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.ProductSortImpl#getElementSort
+ * <em>Element Sort</em>}</li>
  * </ul>
  * </p>
  *
@@ -83,9 +83,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class ProductSortImpl extends SortImpl implements ProductSort {
 	/**
-	 * The cached value of the '{@link #getElementSort() <em>Element Sort</em>}' containment reference list.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getElementSort() <em>Element Sort</em>}'
+	 * containment reference list. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getElementSort()
 	 * @generated
 	 * @ordered
@@ -93,8 +93,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	protected EList<Sort> elementSort;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected ProductSortImpl() {
@@ -102,8 +102,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -112,8 +112,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -126,8 +126,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -141,8 +141,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -155,8 +155,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -169,8 +169,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@SuppressWarnings("unchecked")
@@ -186,8 +186,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -201,8 +201,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -219,10 +219,10 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -240,13 +240,13 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getElementSort() != null) {
 
@@ -281,22 +281,22 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -310,7 +310,7 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 				item.setContainerProductSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -320,7 +320,7 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 				item.setContainerProductSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -330,7 +330,7 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 				item.setContainerProductSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("null")) {
 				Bool item;
@@ -340,7 +340,7 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 				item.setContainerProductSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -350,7 +350,7 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 				item.setContainerProductSort(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -361,10 +361,10 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -387,13 +387,13 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getElementSort() != null) {
 
@@ -489,8 +489,8 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 						.equalsIgnoreCase(sort.getContainerNamedSort().getName());
 			} else {
 				// Someone may one day inherit from ProductSort, so we should
-				// strictly check for ProductSort only. Further sub-classes must 
-				//override this method.
+				// strictly check for ProductSort only. Further sub-classes must
+				// override this method.
 				if ("ProductSort".equalsIgnoreCase(this.eClass().getName())) {
 					ProductSort mySort = this;
 					ProductSort thatSort = (ProductSort) sort;
@@ -514,4 +514,4 @@ public class ProductSortImpl extends SortImpl implements ProductSort {
 
 	}
 
-} //ProductSortImpl
+} // ProductSortImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/SortDeclImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/SortDeclImpl.java
@@ -38,9 +38,8 @@ import fr.lip6.move.pnml.pthlpng.terms.SortDecl;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Sort Decl</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>Sort
+ * Decl</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -48,8 +47,8 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class SortDeclImpl extends TermsDeclarationImpl implements SortDecl {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected SortDeclImpl() {
@@ -57,8 +56,8 @@ public abstract class SortDeclImpl extends TermsDeclarationImpl implements SortD
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -68,4 +67,4 @@ public abstract class SortDeclImpl extends TermsDeclarationImpl implements SortD
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //SortDeclImpl
+} // SortDeclImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/SortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/SortImpl.java
@@ -55,20 +55,27 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Sort</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getMulti <em>Multi</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerNamedSort <em>Container Named Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerVariableDecl <em>Container Variable Decl</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerProductSort <em>Container Product Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerType <em>Container Type</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerAll <em>Container All</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerEmpty <em>Container Empty</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerPartition <em>Container Partition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getMulti
+ * <em>Multi</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerNamedSort
+ * <em>Container Named Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerVariableDecl
+ * <em>Container Variable Decl</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerProductSort
+ * <em>Container Product Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerType
+ * <em>Container Type</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerAll
+ * <em>Container All</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerEmpty
+ * <em>Container Empty</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.SortImpl#getContainerPartition
+ * <em>Container Partition</em>}</li>
  * </ul>
  * </p>
  *
@@ -76,8 +83,8 @@ import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
  */
 public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected SortImpl() {
@@ -85,8 +92,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -95,8 +102,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -107,8 +114,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetMulti(MultisetSort newMulti, NotificationChain msgs) {
@@ -117,13 +124,14 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setMulti(MultisetSort newMulti) {
-		if (newMulti != eInternalContainer() || (eContainerFeatureID() != TermsPackage.SORT__MULTI && newMulti != null)) {
+		if (newMulti != eInternalContainer()
+				|| (eContainerFeatureID() != TermsPackage.SORT__MULTI && newMulti != null)) {
 			if (EcoreUtil.isAncestor(this, newMulti))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -140,8 +148,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -152,8 +160,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNamedSort(NamedSort newContainerNamedSort, NotificationChain msgs) {
@@ -163,14 +171,15 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNamedSort(NamedSort newContainerNamedSort) {
 		if (newContainerNamedSort != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.SORT__CONTAINER_NAMED_SORT && newContainerNamedSort != null)) {
+				|| (eContainerFeatureID() != TermsPackage.SORT__CONTAINER_NAMED_SORT
+						&& newContainerNamedSort != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNamedSort))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -188,8 +197,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -200,25 +209,27 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetContainerVariableDecl(VariableDecl newContainerVariableDecl, NotificationChain msgs) {
+	public NotificationChain basicSetContainerVariableDecl(VariableDecl newContainerVariableDecl,
+			NotificationChain msgs) {
 		msgs = eBasicSetContainer((InternalEObject) newContainerVariableDecl,
 				TermsPackage.SORT__CONTAINER_VARIABLE_DECL, msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerVariableDecl(VariableDecl newContainerVariableDecl) {
 		if (newContainerVariableDecl != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.SORT__CONTAINER_VARIABLE_DECL && newContainerVariableDecl != null)) {
+				|| (eContainerFeatureID() != TermsPackage.SORT__CONTAINER_VARIABLE_DECL
+						&& newContainerVariableDecl != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerVariableDecl))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -236,8 +247,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -248,8 +259,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerProductSort(ProductSort newContainerProductSort, NotificationChain msgs) {
@@ -259,14 +270,15 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerProductSort(ProductSort newContainerProductSort) {
 		if (newContainerProductSort != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.SORT__CONTAINER_PRODUCT_SORT && newContainerProductSort != null)) {
+				|| (eContainerFeatureID() != TermsPackage.SORT__CONTAINER_PRODUCT_SORT
+						&& newContainerProductSort != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerProductSort))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -284,8 +296,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -296,8 +308,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerType(Type newContainerType, NotificationChain msgs) {
@@ -306,8 +318,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -331,8 +343,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -343,8 +355,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerAll(All newContainerAll, NotificationChain msgs) {
@@ -353,8 +365,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -378,8 +390,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -390,8 +402,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerEmpty(Empty newContainerEmpty, NotificationChain msgs) {
@@ -400,8 +412,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -420,13 +432,13 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 			if (msgs != null)
 				msgs.dispatch();
 		} else if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, TermsPackage.SORT__CONTAINER_EMPTY,
-					newContainerEmpty, newContainerEmpty));
+			eNotify(new ENotificationImpl(this, Notification.SET, TermsPackage.SORT__CONTAINER_EMPTY, newContainerEmpty,
+					newContainerEmpty));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -437,18 +449,19 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPartition(Partition newContainerPartition, NotificationChain msgs) {
-		msgs = eBasicSetContainer((InternalEObject) newContainerPartition, TermsPackage.SORT__CONTAINER_PARTITION, msgs);
+		msgs = eBasicSetContainer((InternalEObject) newContainerPartition, TermsPackage.SORT__CONTAINER_PARTITION,
+				msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -472,8 +485,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -516,8 +529,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -544,8 +557,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -557,11 +570,11 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 		case TermsPackage.SORT__CONTAINER_NAMED_SORT:
 			return eInternalContainer().eInverseRemove(this, TermsPackage.NAMED_SORT__SORTDEF, NamedSort.class, msgs);
 		case TermsPackage.SORT__CONTAINER_VARIABLE_DECL:
-			return eInternalContainer()
-					.eInverseRemove(this, TermsPackage.VARIABLE_DECL__SORT, VariableDecl.class, msgs);
+			return eInternalContainer().eInverseRemove(this, TermsPackage.VARIABLE_DECL__SORT, VariableDecl.class,
+					msgs);
 		case TermsPackage.SORT__CONTAINER_PRODUCT_SORT:
-			return eInternalContainer().eInverseRemove(this, TermsPackage.PRODUCT_SORT__ELEMENT_SORT,
-					ProductSort.class, msgs);
+			return eInternalContainer().eInverseRemove(this, TermsPackage.PRODUCT_SORT__ELEMENT_SORT, ProductSort.class,
+					msgs);
 		case TermsPackage.SORT__CONTAINER_TYPE:
 			return eInternalContainer().eInverseRemove(this, HlcorestructurePackage.TYPE__STRUCTURE, Type.class, msgs);
 		case TermsPackage.SORT__CONTAINER_ALL:
@@ -575,8 +588,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -603,8 +616,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -639,8 +652,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -675,8 +688,8 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -704,4 +717,4 @@ public abstract class SortImpl extends MinimalEObjectImpl implements Sort {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //SortImpl
+} // SortImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermImpl.java
@@ -53,19 +53,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Term;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Term</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Term</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getSort <em>Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerOperator <em>Container Operator</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerNamedOperator <em>Container Named Operator</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerHLMarking <em>Container HL Marking</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerCondition <em>Container Condition</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerHLAnnotation <em>Container HL Annotation</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerPartitionElement <em>Container Partition Element</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getSort
+ * <em>Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerOperator
+ * <em>Container Operator</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerNamedOperator
+ * <em>Container Named Operator</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerHLMarking
+ * <em>Container HL Marking</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerCondition
+ * <em>Container Condition</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerHLAnnotation
+ * <em>Container HL Annotation</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermImpl#getContainerPartitionElement
+ * <em>Container Partition Element</em>}</li>
  * </ul>
  * </p>
  *
@@ -73,9 +79,9 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	/**
-	 * The cached value of the '{@link #getSort() <em>Sort</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSort() <em>Sort</em>}' reference. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSort()
 	 * @generated
 	 * @ordered
@@ -83,8 +89,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	protected Sort sort;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TermImpl() {
@@ -92,8 +98,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -102,8 +108,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -120,8 +126,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public Sort basicGetSort() {
@@ -129,8 +135,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -142,8 +148,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -154,8 +160,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerOperator(Operator newContainerOperator, NotificationChain msgs) {
@@ -164,8 +170,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -189,8 +195,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -201,8 +207,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNamedOperator(NamedOperator newContainerNamedOperator,
@@ -213,22 +219,23 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNamedOperator(NamedOperator newContainerNamedOperator) {
 		if (newContainerNamedOperator != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_NAMED_OPERATOR && newContainerNamedOperator != null)) {
+				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_NAMED_OPERATOR
+						&& newContainerNamedOperator != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNamedOperator))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
 			if (eInternalContainer() != null)
 				msgs = eBasicRemoveFromContainer(msgs);
 			if (newContainerNamedOperator != null)
-				msgs = ((InternalEObject) newContainerNamedOperator).eInverseAdd(this,
-						TermsPackage.NAMED_OPERATOR__DEF, NamedOperator.class, msgs);
+				msgs = ((InternalEObject) newContainerNamedOperator).eInverseAdd(this, TermsPackage.NAMED_OPERATOR__DEF,
+						NamedOperator.class, msgs);
 			msgs = basicSetContainerNamedOperator(newContainerNamedOperator, msgs);
 			if (msgs != null)
 				msgs.dispatch();
@@ -238,8 +245,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -250,8 +257,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerHLMarking(HLMarking newContainerHLMarking, NotificationChain msgs) {
@@ -261,14 +268,15 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerHLMarking(HLMarking newContainerHLMarking) {
 		if (newContainerHLMarking != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_HL_MARKING && newContainerHLMarking != null)) {
+				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_HL_MARKING
+						&& newContainerHLMarking != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerHLMarking))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -286,8 +294,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -298,18 +306,19 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerCondition(Condition newContainerCondition, NotificationChain msgs) {
-		msgs = eBasicSetContainer((InternalEObject) newContainerCondition, TermsPackage.TERM__CONTAINER_CONDITION, msgs);
+		msgs = eBasicSetContainer((InternalEObject) newContainerCondition, TermsPackage.TERM__CONTAINER_CONDITION,
+				msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -333,8 +342,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -345,25 +354,27 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetContainerHLAnnotation(HLAnnotation newContainerHLAnnotation, NotificationChain msgs) {
+	public NotificationChain basicSetContainerHLAnnotation(HLAnnotation newContainerHLAnnotation,
+			NotificationChain msgs) {
 		msgs = eBasicSetContainer((InternalEObject) newContainerHLAnnotation,
 				TermsPackage.TERM__CONTAINER_HL_ANNOTATION, msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerHLAnnotation(HLAnnotation newContainerHLAnnotation) {
 		if (newContainerHLAnnotation != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_HL_ANNOTATION && newContainerHLAnnotation != null)) {
+				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_HL_ANNOTATION
+						&& newContainerHLAnnotation != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerHLAnnotation))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -381,8 +392,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -393,8 +404,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerPartitionElement(PartitionElement newContainerPartitionElement,
@@ -405,14 +416,15 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerPartitionElement(PartitionElement newContainerPartitionElement) {
 		if (newContainerPartitionElement != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_PARTITION_ELEMENT && newContainerPartitionElement != null)) {
+				|| (eContainerFeatureID() != TermsPackage.TERM__CONTAINER_PARTITION_ELEMENT
+						&& newContainerPartitionElement != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerPartitionElement))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -430,8 +442,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -466,8 +478,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -490,8 +502,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -519,8 +531,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -547,8 +559,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -580,8 +592,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -613,8 +625,8 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -640,4 +652,4 @@ public abstract class TermImpl extends MinimalEObjectImpl implements Term {
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //TermImpl
+} // TermImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermsDeclarationImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermsDeclarationImpl.java
@@ -45,15 +45,17 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration;
 import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Declaration</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Declaration</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl#getId <em>Id</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl#getName <em>Name</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl#getContainerDeclarations <em>Container Declarations</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl#getId
+ * <em>Id</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl#getName
+ * <em>Name</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.TermsDeclarationImpl#getContainerDeclarations
+ * <em>Container Declarations</em>}</li>
  * </ul>
  * </p>
  *
@@ -61,9 +63,9 @@ import fr.lip6.move.pnml.pthlpng.terms.TermsPackage;
  */
 public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements TermsDeclaration {
 	/**
-	 * The default value of the '{@link #getId() <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getId() <em>Id</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getId()
 	 * @generated
 	 * @ordered
@@ -71,9 +73,9 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	protected static final String ID_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getId() <em>Id</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getId()
 	 * @generated
 	 * @ordered
@@ -81,9 +83,9 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	protected String id = ID_EDEFAULT;
 
 	/**
-	 * The default value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The default value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -91,9 +93,9 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	protected static final String NAME_EDEFAULT = null;
 
 	/**
-	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getName() <em>Name</em>}' attribute. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getName()
 	 * @generated
 	 * @ordered
@@ -101,8 +103,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	protected String name = NAME_EDEFAULT;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TermsDeclarationImpl() {
@@ -110,8 +112,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -120,8 +122,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,8 +132,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -143,8 +145,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,8 +155,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -166,8 +168,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -178,25 +180,27 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public NotificationChain basicSetContainerDeclarations(Declarations newContainerDeclarations, NotificationChain msgs) {
+	public NotificationChain basicSetContainerDeclarations(Declarations newContainerDeclarations,
+			NotificationChain msgs) {
 		msgs = eBasicSetContainer((InternalEObject) newContainerDeclarations,
 				TermsPackage.TERMS_DECLARATION__CONTAINER_DECLARATIONS, msgs);
 		return msgs;
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerDeclarations(Declarations newContainerDeclarations) {
 		if (newContainerDeclarations != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.TERMS_DECLARATION__CONTAINER_DECLARATIONS && newContainerDeclarations != null)) {
+				|| (eContainerFeatureID() != TermsPackage.TERMS_DECLARATION__CONTAINER_DECLARATIONS
+						&& newContainerDeclarations != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerDeclarations))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -215,8 +219,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -231,8 +235,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -245,23 +249,23 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public NotificationChain eBasicRemoveFromContainerFeature(NotificationChain msgs) {
 		switch (eContainerFeatureID()) {
 		case TermsPackage.TERMS_DECLARATION__CONTAINER_DECLARATIONS:
-			return eInternalContainer().eInverseRemove(this, TermsPackage.DECLARATIONS__DECLARATION,
-					Declarations.class, msgs);
+			return eInternalContainer().eInverseRemove(this, TermsPackage.DECLARATIONS__DECLARATION, Declarations.class,
+					msgs);
 		}
 		return super.eBasicRemoveFromContainerFeature(msgs);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -278,8 +282,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -299,8 +303,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -320,8 +324,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -338,8 +342,8 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -358,4 +362,4 @@ public abstract class TermsDeclarationImpl extends MinimalEObjectImpl implements
 
 	@Override
 	public abstract boolean validateOCL(DiagnosticChain diagnostics);
-} //TermsDeclarationImpl
+} // TermsDeclarationImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermsFactoryImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermsFactoryImpl.java
@@ -51,16 +51,16 @@ import fr.lip6.move.pnml.pthlpng.terms.Variable;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Factory</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Factory</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	/**
-	 * Creates the default factory implementation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the default factory implementation. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static TermsFactory init() {
@@ -76,9 +76,9 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * Creates an instance of the factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the factory. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public TermsFactoryImpl() {
@@ -86,8 +86,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -119,8 +119,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,8 +130,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -141,8 +141,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -152,8 +152,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,8 +163,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -174,8 +174,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -185,8 +185,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -196,8 +196,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -207,8 +207,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -218,8 +218,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -229,8 +229,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -239,8 +239,8 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @deprecated
 	 * @generated
 	 */
@@ -249,4 +249,4 @@ public class TermsFactoryImpl extends EFactoryImpl implements TermsFactory {
 		return TermsPackage.eINSTANCE;
 	}
 
-} //TermsFactoryImpl
+} // TermsFactoryImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermsPackageImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TermsPackageImpl.java
@@ -75,162 +75,162 @@ import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model <b>Package</b>.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model <b>Package</b>. <!--
+ * end-user-doc -->
+ * 
  * @generated
  */
 public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass declarationsEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass termsDeclarationEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass sortEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass multisetSortEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass termEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass operatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass variableDeclEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass variableEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass builtInSortEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass productSortEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass builtInConstantEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass multisetOperatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass tupleEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass sortDeclEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass builtInOperatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass namedSortEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass userSortEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass operatorDeclEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass namedOperatorEClass = null;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private EClass userOperatorEClass = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
-	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the package
-	 * package URI value.
-	 * <p>Note: the correct way to create the package is via the static
-	 * factory method {@link #init init()}, which also performs
-	 * initialization of the package, or returns the registered package,
-	 * if one already exists.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * {@link org.eclipse.emf.ecore.EPackage.Registry EPackage.Registry} by the
+	 * package package URI value.
+	 * <p>
+	 * Note: the correct way to create the package is via the static factory method
+	 * {@link #init init()}, which also performs initialization of the package, or
+	 * returns the registered package, if one already exists. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.ecore.EPackage.Registry
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage#eNS_URI
 	 * @see #init()
@@ -241,19 +241,22 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private static boolean isInited = false;
 
 	/**
-	 * Creates, registers, and initializes the <b>Package</b> for this model, and for any others upon which it depends.
+	 * Creates, registers, and initializes the <b>Package</b> for this model, and
+	 * for any others upon which it depends.
 	 * 
-	 * <p>This method is used to initialize {@link TermsPackage#eINSTANCE} when that field is accessed.
-	 * Clients should not invoke it directly. Instead, they should simply access that field to obtain the package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <p>
+	 * This method is used to initialize {@link TermsPackage#eINSTANCE} when that
+	 * field is accessed. Clients should not invoke it directly. Instead, they
+	 * should simply access that field to obtain the package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @see #eNS_URI
 	 * @see #createPackageContents()
 	 * @see #initializePackageContents()
@@ -264,29 +267,37 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 			return (TermsPackage) EPackage.Registry.INSTANCE.getEPackage(TermsPackage.eNS_URI);
 
 		// Obtain or create and register package
-		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE.get(eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE
-				.get(eNS_URI) : new TermsPackageImpl());
+		TermsPackageImpl theTermsPackage = (TermsPackageImpl) (EPackage.Registry.INSTANCE
+				.get(eNS_URI) instanceof TermsPackageImpl ? EPackage.Registry.INSTANCE.get(eNS_URI)
+						: new TermsPackageImpl());
 
 		isInited = true;
 
 		// Obtain or create and register interdependencies
 		BooleansPackageImpl theBooleansPackage = (BooleansPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(BooleansPackage.eNS_URI) : BooleansPackage.eINSTANCE);
-		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(DotsPackage.eNS_URI) : DotsPackage.eINSTANCE);
+				.getEPackage(BooleansPackage.eNS_URI) instanceof BooleansPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(BooleansPackage.eNS_URI)
+						: BooleansPackage.eINSTANCE);
+		DotsPackageImpl theDotsPackage = (DotsPackageImpl) (EPackage.Registry.INSTANCE
+				.getEPackage(DotsPackage.eNS_URI) instanceof DotsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(DotsPackage.eNS_URI)
+						: DotsPackage.eINSTANCE);
 		HlcorestructurePackageImpl theHlcorestructurePackage = (HlcorestructurePackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(HlcorestructurePackage.eNS_URI) : HlcorestructurePackage.eINSTANCE);
+				.getEPackage(HlcorestructurePackage.eNS_URI) instanceof HlcorestructurePackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(HlcorestructurePackage.eNS_URI)
+						: HlcorestructurePackage.eINSTANCE);
 		IntegersPackageImpl theIntegersPackage = (IntegersPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(IntegersPackage.eNS_URI) : IntegersPackage.eINSTANCE);
+				.getEPackage(IntegersPackage.eNS_URI) instanceof IntegersPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(IntegersPackage.eNS_URI)
+						: IntegersPackage.eINSTANCE);
 		MultisetsPackageImpl theMultisetsPackage = (MultisetsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(MultisetsPackage.eNS_URI) : MultisetsPackage.eINSTANCE);
+				.getEPackage(MultisetsPackage.eNS_URI) instanceof MultisetsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(MultisetsPackage.eNS_URI)
+						: MultisetsPackage.eINSTANCE);
 		PartitionsPackageImpl thePartitionsPackage = (PartitionsPackageImpl) (EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl ? EPackage.Registry.INSTANCE
-				.getEPackage(PartitionsPackage.eNS_URI) : PartitionsPackage.eINSTANCE);
+				.getEPackage(PartitionsPackage.eNS_URI) instanceof PartitionsPackageImpl
+						? EPackage.Registry.INSTANCE.getEPackage(PartitionsPackage.eNS_URI)
+						: PartitionsPackage.eINSTANCE);
 
 		// Create package meta-data objects
 		theTermsPackage.createPackageContents();
@@ -323,8 +334,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -333,8 +344,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -343,8 +354,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -353,8 +364,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -363,8 +374,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -373,8 +384,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -383,8 +394,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -393,8 +404,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -403,8 +414,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -413,8 +424,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -423,8 +434,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -433,8 +444,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -443,8 +454,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -453,8 +464,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -463,8 +474,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -473,8 +484,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -483,8 +494,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -493,8 +504,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -503,8 +514,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -513,8 +524,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -523,8 +534,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -533,8 +544,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -543,8 +554,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -553,8 +564,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -563,8 +574,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -573,8 +584,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -583,8 +594,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -593,8 +604,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -603,8 +614,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -613,8 +624,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -623,8 +634,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -633,8 +644,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -643,8 +654,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -653,8 +664,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -663,8 +674,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -673,8 +684,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -683,8 +694,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -693,8 +704,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -703,8 +714,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -713,8 +724,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -723,8 +734,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -733,8 +744,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -743,8 +754,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -753,8 +764,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -763,8 +774,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -773,8 +784,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -783,8 +794,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -793,8 +804,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -803,8 +814,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -813,8 +824,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -823,8 +834,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -833,8 +844,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -843,8 +854,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -853,8 +864,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -863,17 +874,17 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isCreated = false;
 
 	/**
-	 * Creates the meta-model objects for the package.  This method is
-	 * guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates the meta-model objects for the package. This method is guarded to
+	 * have no affect on any invocation but its first. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void createPackageContents() {
@@ -957,17 +968,17 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	private boolean isInitialized = false;
 
 	/**
-	 * Complete the initialization of the package and its meta-model.  This
-	 * method is guarded to have no affect on any invocation but its first.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Complete the initialization of the package and its meta-model. This method is
+	 * guarded to have no affect on any invocation but its first. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public void initializePackageContents() {
@@ -1039,8 +1050,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 				Sort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getSort_ContainerNamedSort(), this.getNamedSort(), this.getNamedSort_Sortdef(),
-				"containerNamedSort", null, 0, 1, Sort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
-				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+				"containerNamedSort", null, 0, 1, Sort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
+				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getSort_ContainerVariableDecl(), this.getVariableDecl(), this.getVariableDecl_Sort(),
 				"containerVariableDecl", null, 0, 1, Sort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -1049,19 +1060,18 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getSort_ContainerType(), theHlcorestructurePackage.getType(),
 				theHlcorestructurePackage.getType_Structure(), "containerType", null, 0, 1, Sort.class, !IS_TRANSIENT,
-				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
-				!IS_DERIVED, IS_ORDERED);
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				IS_ORDERED);
 		initEReference(getSort_ContainerAll(), theMultisetsPackage.getAll(), theMultisetsPackage.getAll_Refsort(),
 				"containerAll", null, 0, 1, Sort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getSort_ContainerEmpty(), theMultisetsPackage.getEmpty(),
-				theMultisetsPackage.getEmpty_Refsort(), "containerEmpty", null, 0, 1, Sort.class, !IS_TRANSIENT,
-				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
-				!IS_DERIVED, IS_ORDERED);
+		initEReference(getSort_ContainerEmpty(), theMultisetsPackage.getEmpty(), theMultisetsPackage.getEmpty_Refsort(),
+				"containerEmpty", null, 0, 1, Sort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
+				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getSort_ContainerPartition(), thePartitionsPackage.getPartition(),
 				thePartitionsPackage.getPartition_Def(), "containerPartition", null, 0, 1, Sort.class, !IS_TRANSIENT,
-				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE,
-				!IS_DERIVED, !IS_ORDERED);
+				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED,
+				!IS_ORDERED);
 
 		initEClass(multisetSortEClass, MultisetSort.class, "MultisetSort", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1073,9 +1083,9 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 		initEReference(getTerm_Sort(), this.getSort(), null, "sort", null, 0, 1, Term.class, !IS_TRANSIENT,
 				!IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, IS_DERIVED,
 				!IS_ORDERED);
-		initEReference(getTerm_ContainerOperator(), this.getOperator(), this.getOperator_Subterm(),
-				"containerOperator", null, 0, 1, Term.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
-				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getTerm_ContainerOperator(), this.getOperator(), this.getOperator_Subterm(), "containerOperator",
+				null, 0, 1, Term.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTerm_ContainerNamedOperator(), this.getNamedOperator(), this.getNamedOperator_Def(),
 				"containerNamedOperator", null, 0, 1, Term.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
 				!IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -1092,8 +1102,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTerm_ContainerPartitionElement(), thePartitionsPackage.getPartitionElement(),
-				thePartitionsPackage.getPartitionElement_Partitionelementconstants(), "containerPartitionElement",
-				null, 0, 1, Term.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+				thePartitionsPackage.getPartitionElement_Partitionelementconstants(), "containerPartitionElement", null,
+				0, 1, Term.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(operatorEClass, Operator.class, "Operator", IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
@@ -1109,15 +1119,16 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 
 		initEClass(variableDeclEClass, VariableDecl.class, "VariableDecl", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getVariableDecl_Sort(), this.getSort(), this.getSort_ContainerVariableDecl(), "sort", null, 1,
-				1, VariableDecl.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+		initEReference(getVariableDecl_Sort(), this.getSort(), this.getSort_ContainerVariableDecl(), "sort", null, 1, 1,
+				VariableDecl.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getVariableDecl_ContainerNamedOperator(), this.getNamedOperator(),
 				this.getNamedOperator_Parameters(), "containerNamedOperator", null, 0, 1, VariableDecl.class,
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
-		initEClass(variableEClass, Variable.class, "Variable", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(variableEClass, Variable.class, "Variable", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getVariable_VariableDecl(), this.getVariableDecl(), null, "variableDecl", null, 1, 1,
 				Variable.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
@@ -1127,9 +1138,9 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 
 		initEClass(productSortEClass, ProductSort.class, "ProductSort", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getProductSort_ElementSort(), this.getSort(), this.getSort_ContainerProductSort(),
-				"elementSort", null, 0, -1, ProductSort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE,
-				IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEReference(getProductSort_ElementSort(), this.getSort(), this.getSort_ContainerProductSort(), "elementSort",
+				null, 0, -1, ProductSort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
+				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(builtInConstantEClass, BuiltInConstant.class, "BuiltInConstant", IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
@@ -1146,11 +1157,12 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 
 		initEClass(namedSortEClass, NamedSort.class, "NamedSort", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getNamedSort_Sortdef(), this.getSort(), this.getSort_ContainerNamedSort(), "sortdef", null, 1,
-				1, NamedSort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+		initEReference(getNamedSort_Sortdef(), this.getSort(), this.getSort_ContainerNamedSort(), "sortdef", null, 1, 1,
+				NamedSort.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 
-		initEClass(userSortEClass, UserSort.class, "UserSort", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEClass(userSortEClass, UserSort.class, "UserSort", !IS_ABSTRACT, !IS_INTERFACE,
+				IS_GENERATED_INSTANCE_CLASS);
 		initEReference(getUserSort_Declaration(), this.getSortDecl(), null, "declaration", null, 1, 1, UserSort.class,
 				!IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE, IS_RESOLVE_PROXIES, !IS_UNSETTABLE,
 				IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
@@ -1160,8 +1172,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 
 		initEClass(namedOperatorEClass, NamedOperator.class, "NamedOperator", !IS_ABSTRACT, !IS_INTERFACE,
 				IS_GENERATED_INSTANCE_CLASS);
-		initEReference(getNamedOperator_Def(), this.getTerm(), this.getTerm_ContainerNamedOperator(), "def", null, 1,
-				1, NamedOperator.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
+		initEReference(getNamedOperator_Def(), this.getTerm(), this.getTerm_ContainerNamedOperator(), "def", null, 1, 1,
+				NamedOperator.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES,
 				!IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, !IS_ORDERED);
 		initEReference(getNamedOperator_Parameters(), this.getVariableDecl(),
 				this.getVariableDecl_ContainerNamedOperator(), "parameters", null, 0, -1, NamedOperator.class,
@@ -1192,8 +1204,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 
 	/**
 	 * Initializes the annotations for <b>http://www.pnml.org/models/ToPNML</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createToPNMLAnnotations() {
@@ -1204,8 +1216,8 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 		addAnnotation(getTermsDeclaration_Name(), source, new String[] { "tag", "name", "kind", "attribute" });
 		addAnnotation(multisetSortEClass, source, new String[] { "tag", "multisetsort", "kind", "son" });
 		addAnnotation(getMultisetSort_Basis(), source, new String[] { "kind", "follow" });
-		addAnnotation(getOperator_Subterm(), source, new String[] { "tag", "subterm", "kind", "follow", "toBeFollowed",
-				"yes" });
+		addAnnotation(getOperator_Subterm(), source,
+				new String[] { "tag", "subterm", "kind", "follow", "toBeFollowed", "yes" });
 		addAnnotation(variableDeclEClass, source, new String[] { "tag", "variabledecl", "kind", "son" });
 		addAnnotation(getVariableDecl_Sort(), source, new String[] { "kind", "follow" });
 		addAnnotation(variableEClass, source, new String[] { "tag", "variable", "kind", "son" });
@@ -1218,18 +1230,18 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 		addAnnotation(userSortEClass, source, new String[] { "tag", "usersort", "kind", "son" });
 		addAnnotation(getUserSort_Declaration(), source, new String[] { "tag", "declaration", "kind", "idref" });
 		addAnnotation(namedOperatorEClass, source, new String[] { "tag", "namedoperator", "kind", "son" });
-		addAnnotation(getNamedOperator_Def(), source, new String[] { "tag", "def", "kind", "follow", "toBeFollowed",
-				"yes" });
-		addAnnotation(getNamedOperator_Parameters(), source, new String[] { "tag", "parameter", "kind", "follow",
-				"toBeFollowed", "yes" });
+		addAnnotation(getNamedOperator_Def(), source,
+				new String[] { "tag", "def", "kind", "follow", "toBeFollowed", "yes" });
+		addAnnotation(getNamedOperator_Parameters(), source,
+				new String[] { "tag", "parameter", "kind", "follow", "toBeFollowed", "yes" });
 		addAnnotation(userOperatorEClass, source, new String[] { "tag", "useroperator", "kind", "son" });
 		addAnnotation(getUserOperator_Declaration(), source, new String[] { "tag", "declaration", "kind", "idref" });
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/HLAPI</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createHLAPIAnnotations() {
@@ -1253,72 +1265,48 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/methods/SORT</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for
+	 * <b>http://www.pnml.org/models/methods/SORT</b>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createSORTAnnotations() {
 		String source = "http://www.pnml.org/models/methods/SORT";
-		addAnnotation(
-				sortEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"",
-						"documentation",
-						"/**\n  * Returns true if this sort and argument sort are actually semantically the\n  * same sort, even in two different objects. \n  * <p>Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or\n  * two Integers I1 and I2.</p> \n  * <p><strong>Note</strong> : the implementation available for\n  * MultisetSort is not complete. In particular, we just test equality\n  * of the references or of the enclosing NamedSorts (if any). \n  * You should consider overriding it in that case.\n  * \n  * @return true if so.\n  * @param sort\n  *            the sort to which we compare this one.\n  */" });
-		addAnnotation(
-				multisetSortEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t throw new UnsupportedOperationException(\"Cannot determine if these two multisets are equal.\"\n\t\t\t + \"You should override this method.\");\n\t\t\t}\n\t\t}\n\t\treturn isEqual;",
-						"documentation",
-						"/**\r * Note : there is no implementation available for MultisetSort yet.\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r */" });
-		addAnnotation(
-				productSortEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t\t// Someone may one day inherit from ProductSort, so we should\n\t\t\t\t// strictly check for ProductSort only. Further sub-classes must \n\t\t\t\t//override this method.\n\t\t\t\tif (\"ProductSort\".equalsIgnoreCase(this.eClass().getName())) {\n\t\t\t\t\tProductSort mySort = (ProductSort) this;\n\t\t\t\t\tProductSort thatSort = (ProductSort) sort;\n\t\t\t\t\tList<Sort> myElements = mySort.getElementSort();\n\t\t\t\t\tList<Sort> thoseElements = thatSort.getElementSort();\n\t\t\t\t\tint i = 0;\n\t\t\t\t\tint j = 0;\n\t\t\t\t\tfor (; i < myElements.size() && j < thoseElements.size(); i++, j++) {\n\t\t\t\t\t\tif (myElements\n\t\t\t\t\t\t\t\t.get(i)\n\t\t\t\t\t\t\t\t.eClass()\n\t\t\t\t\t\t\t\t.getName()\n\t\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t\tthoseElements.get(j).eClass().getName())) {\n\t\t\t\t\t\t\tisEqual = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tisEqual = false;\n\t\t\t\t\t\t\tbreak;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t}\t\t\n\t\t\t}\n\t\t}\n\t\treturn isEqual;",
-						"documentation",
-						"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r */" });
-		addAnnotation(
-				userSortEClass,
-				source,
-				new String[] {
-						"signature",
-						"boolean equalSorts(Sort sort)",
-						"body",
-						"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t\t//further sub-classes must override this method.\n\t\t\t\tif (\"UserSort\".equalsIgnoreCase(this.eClass().getName())) {\n\t\t\t\t\tisEqual = ((UserSort) this).getDeclaration().getName()\n\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t((UserSort) sort).getDeclaration()\n\t\t\t\t\t\t\t\t\t\t\t.getName());\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t\treturn isEqual;",
-						"documentation",
-						"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r */" });
+		addAnnotation(sortEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body", "",
+				"documentation",
+				"/**\n  * Returns true if this sort and argument sort are actually semantically the\n  * same sort, even in two different objects. \n  * <p>Ex: two FiniteEnumerations F1 = {1,4,6} and F2 = {1,4,6} or\n  * two Integers I1 and I2.</p> \n  * <p><strong>Note</strong> : the implementation available for\n  * MultisetSort is not complete. In particular, we just test equality\n  * of the references or of the enclosing NamedSorts (if any). \n  * You should consider overriding it in that case.\n  * \n  * @return true if so.\n  * @param sort\n  *            the sort to which we compare this one.\n  */" });
+		addAnnotation(multisetSortEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body",
+				"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t  \tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\t// we test them if they have been explicitly named.\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t throw new UnsupportedOperationException(\"Cannot determine if these two multisets are equal.\"\n\t\t\t + \"You should override this method.\");\n\t\t\t}\n\t\t}\n\t\treturn isEqual;",
+				"documentation",
+				"/**\r * Note : there is no implementation available for MultisetSort yet.\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r * @throws NullPointerException if according to the model, some\r * required reference attributes have not been set.\r */" });
+		addAnnotation(productSortEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body",
+				"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t\t// Someone may one day inherit from ProductSort, so we should\n\t\t\t\t// strictly check for ProductSort only. Further sub-classes must \n\t\t\t\t//override this method.\n\t\t\t\tif (\"ProductSort\".equalsIgnoreCase(this.eClass().getName())) {\n\t\t\t\t\tProductSort mySort = (ProductSort) this;\n\t\t\t\t\tProductSort thatSort = (ProductSort) sort;\n\t\t\t\t\tList<Sort> myElements = mySort.getElementSort();\n\t\t\t\t\tList<Sort> thoseElements = thatSort.getElementSort();\n\t\t\t\t\tint i = 0;\n\t\t\t\t\tint j = 0;\n\t\t\t\t\tfor (; i < myElements.size() && j < thoseElements.size(); i++, j++) {\n\t\t\t\t\t\tif (myElements\n\t\t\t\t\t\t\t\t.get(i)\n\t\t\t\t\t\t\t\t.eClass()\n\t\t\t\t\t\t\t\t.getName()\n\t\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t\tthoseElements.get(j).eClass().getName())) {\n\t\t\t\t\t\t\tisEqual = true;\n\t\t\t\t\t\t} else {\n\t\t\t\t\t\t\tisEqual = false;\n\t\t\t\t\t\t\tbreak;\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t}\t\t\n\t\t\t}\n\t\t}\n\t\treturn isEqual;",
+				"documentation",
+				"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r */" });
+		addAnnotation(userSortEClass, source, new String[] { "signature", "boolean equalSorts(Sort sort)", "body",
+				"boolean isEqual = false;\n\t\tif (this.eClass().getName().equalsIgnoreCase(sort.eClass().getName())) {\n\t\t\tif (this.getContainerNamedSort() != null\n\t\t\t\t\t&& sort.getContainerNamedSort() != null) {\n\t\t\t\tisEqual = this.getContainerNamedSort().getName()\n\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\tsort.getContainerNamedSort().getName());\n\t\t\t} else {\n\t\t\t\t//further sub-classes must override this method.\n\t\t\t\tif (\"UserSort\".equalsIgnoreCase(this.eClass().getName())) {\n\t\t\t\t\tisEqual = ((UserSort) this).getDeclaration().getName()\n\t\t\t\t\t\t\t.equalsIgnoreCase(\n\t\t\t\t\t\t\t\t\t((UserSort) sort).getDeclaration()\n\t\t\t\t\t\t\t\t\t\t\t.getName());\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t\treturn isEqual;",
+				"documentation",
+				"/**\r * Returns true if this sort and argument sort are actually \r * semantically the same sort, even in two different objects.\r * Ex: two FiniteEnumerations or two Integers.\r * @return true if so. \r * @param sort the sort to which we compare this one. \r */" });
 	}
 
 	/**
-	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Initializes the annotations for <b>http://www.pnml.org/models/OCL</b>. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createOCLAnnotations() {
 		String source = "http://www.pnml.org/models/OCL";
 		addAnnotation(operatorEClass, source, new String[] { "sameOperatorNTermSort", "self.sort = self.output" });
-		addAnnotation(namedSortEClass, source, new String[] { "refSortNotMultiset",
-				"not(self.sortdef.oclIsTypeOf(MultisetSort))" });
+		addAnnotation(namedSortEClass, source,
+				new String[] { "refSortNotMultiset", "not(self.sortdef.oclIsTypeOf(MultisetSort))" });
 	}
 
 	/**
 	 * Initializes the annotations for <b>http://www.eclipse.org/emf/2002/Ecore</b>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected void createEcoreAnnotations() {
@@ -1327,4 +1315,4 @@ public class TermsPackageImpl extends EPackageImpl implements TermsPackage {
 		addAnnotation(namedSortEClass, source, new String[] { "constraints", "refSortNotMultiset" });
 	}
 
-} //TermsPackageImpl
+} // TermsPackageImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TupleImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/TupleImpl.java
@@ -61,9 +61,8 @@ import fr.lip6.move.pnml.pthlpng.terms.Tuple;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Tuple</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Tuple</b></em>'. <!-- end-user-doc -->
  * <p>
  * </p>
  *
@@ -71,8 +70,8 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class TupleImpl extends OperatorImpl implements Tuple {
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TupleImpl() {
@@ -80,8 +79,8 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -89,24 +88,24 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 		return TermsPackage.Literals.TUPLE;
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -124,13 +123,13 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -173,22 +172,22 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//0
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 0
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -411,30 +410,30 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 0
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 0
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -457,13 +456,13 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		boolean haveSons = false;
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -565,4 +564,4 @@ public class TupleImpl extends OperatorImpl implements Tuple {
 		return retour;
 
 	}
-} //TupleImpl
+} // TupleImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserOperatorImpl.java
@@ -68,13 +68,13 @@ import fr.lip6.move.pnml.pthlpng.terms.UserOperator;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>User Operator</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>User
+ * Operator</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserOperatorImpl#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -82,9 +82,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	/**
-	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDeclaration()
 	 * @generated
 	 * @ordered
@@ -92,8 +92,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	protected OperatorDecl declaration;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected UserOperatorImpl() {
@@ -101,8 +101,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -111,8 +111,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -130,8 +130,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public OperatorDecl basicGetDeclaration() {
@@ -139,8 +139,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -153,8 +153,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -169,8 +169,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -184,8 +184,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -199,8 +199,8 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -212,24 +212,24 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -247,7 +247,7 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getDeclaration() != null) {
 			sb.append(" declaration");
@@ -260,7 +260,7 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -303,18 +303,18 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//1
-		//0
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 1
+		// 0
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -324,9 +324,9 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -549,7 +549,7 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 				}
 			}
 
-			//tag!=null
+			// tag!=null
 
 		}
 
@@ -561,24 +561,24 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (output) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (output) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
-	//TODO this element (input) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (input) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 1
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -601,7 +601,7 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getDeclaration() != null) {
 			sb.append(" declaration");
@@ -614,7 +614,7 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSubterm() != null) {
 
@@ -716,4 +716,4 @@ public class UserOperatorImpl extends OperatorImpl implements UserOperator {
 		return retour;
 
 	}
-} //UserOperatorImpl
+} // UserOperatorImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserOperatorImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserOperatorImpl.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.DiagnosticChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserSortImpl.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.DiagnosticChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserSortImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/UserSortImpl.java
@@ -63,13 +63,13 @@ import fr.lip6.move.pnml.pthlpng.terms.UserSort;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>User Sort</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object '<em><b>User
+ * Sort</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl#getDeclaration <em>Declaration</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.UserSortImpl#getDeclaration
+ * <em>Declaration</em>}</li>
  * </ul>
  * </p>
  *
@@ -77,9 +77,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class UserSortImpl extends SortImpl implements UserSort {
 	/**
-	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getDeclaration() <em>Declaration</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getDeclaration()
 	 * @generated
 	 * @ordered
@@ -87,8 +87,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	protected SortDecl declaration;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected UserSortImpl() {
@@ -96,8 +96,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -106,8 +106,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -125,8 +125,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public SortDecl basicGetDeclaration() {
@@ -134,8 +134,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -148,8 +148,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -164,8 +164,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,8 +179,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -194,8 +194,8 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -212,10 +212,10 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -233,7 +233,7 @@ public class UserSortImpl extends SortImpl implements UserSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getDeclaration() != null) {
 			sb.append(" declaration");
@@ -245,7 +245,7 @@ public class UserSortImpl extends SortImpl implements UserSort {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -258,18 +258,18 @@ public class UserSortImpl extends SortImpl implements UserSort {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//1
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 1
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -279,9 +279,9 @@ public class UserSortImpl extends SortImpl implements UserSort {
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -296,10 +296,10 @@ public class UserSortImpl extends SortImpl implements UserSort {
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -322,7 +322,7 @@ public class UserSortImpl extends SortImpl implements UserSort {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getDeclaration() != null) {
 			sb.append(" declaration");
@@ -334,7 +334,7 @@ public class UserSortImpl extends SortImpl implements UserSort {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -396,7 +396,7 @@ public class UserSortImpl extends SortImpl implements UserSort {
 				isEqual = this.getContainerNamedSort().getName()
 						.equalsIgnoreCase(sort.getContainerNamedSort().getName());
 			} else {
-				//further sub-classes must override this method.
+				// further sub-classes must override this method.
 				if ("UserSort".equalsIgnoreCase(this.eClass().getName())) {
 					isEqual = ((UserSort) this).getDeclaration().getName()
 							.equalsIgnoreCase(((UserSort) sort).getDeclaration().getName());
@@ -407,4 +407,4 @@ public class UserSortImpl extends SortImpl implements UserSort {
 
 	}
 
-} //UserSortImpl
+} // UserSortImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableDeclImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableDeclImpl.java
@@ -72,14 +72,15 @@ import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Variable Decl</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Variable Decl</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl#getSort <em>Sort</em>}</li>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl#getContainerNamedOperator <em>Container Named Operator</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl#getSort
+ * <em>Sort</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableDeclImpl#getContainerNamedOperator
+ * <em>Container Named Operator</em>}</li>
  * </ul>
  * </p>
  *
@@ -87,9 +88,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDecl {
 	/**
-	 * The cached value of the '{@link #getSort() <em>Sort</em>}' containment reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getSort() <em>Sort</em>}' containment
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getSort()
 	 * @generated
 	 * @ordered
@@ -97,8 +98,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	protected Sort sort;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected VariableDeclImpl() {
@@ -106,8 +107,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -116,8 +117,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -126,8 +127,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetSort(Sort newSort, NotificationChain msgs) {
@@ -145,8 +146,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -167,8 +168,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -179,8 +180,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public NotificationChain basicSetContainerNamedOperator(NamedOperator newContainerNamedOperator,
@@ -191,14 +192,15 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public void setContainerNamedOperator(NamedOperator newContainerNamedOperator) {
 		if (newContainerNamedOperator != eInternalContainer()
-				|| (eContainerFeatureID() != TermsPackage.VARIABLE_DECL__CONTAINER_NAMED_OPERATOR && newContainerNamedOperator != null)) {
+				|| (eContainerFeatureID() != TermsPackage.VARIABLE_DECL__CONTAINER_NAMED_OPERATOR
+						&& newContainerNamedOperator != null)) {
 			if (EcoreUtil.isAncestor(this, newContainerNamedOperator))
 				throw new IllegalArgumentException("Recursive containment not allowed for " + toString());
 			NotificationChain msgs = null;
@@ -216,8 +218,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -225,8 +227,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 		switch (featureID) {
 		case TermsPackage.VARIABLE_DECL__SORT:
 			if (sort != null)
-				msgs = ((InternalEObject) sort).eInverseRemove(this, EOPPOSITE_FEATURE_BASE
-						- TermsPackage.VARIABLE_DECL__SORT, null, msgs);
+				msgs = ((InternalEObject) sort).eInverseRemove(this,
+						EOPPOSITE_FEATURE_BASE - TermsPackage.VARIABLE_DECL__SORT, null, msgs);
 			return basicSetSort((Sort) otherEnd, msgs);
 		case TermsPackage.VARIABLE_DECL__CONTAINER_NAMED_OPERATOR:
 			if (eInternalContainer() != null)
@@ -237,8 +239,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -253,8 +255,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -268,8 +270,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -284,8 +286,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -302,8 +304,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -320,8 +322,8 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -340,10 +342,10 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	 */
 	@Override
 	public String toPNML() {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -361,7 +363,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -381,7 +383,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSort() != null) {
 
@@ -415,16 +417,16 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//1
-		//0
-		//1
-		//1
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 1
+		// 0
+		// 1
+		// 1
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
 		if (locRoot.getAttributeValue(new QName("id")) != null) {
 			this.setId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))));
@@ -432,9 +434,9 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 					.checkId(new java.lang.String(locRoot.getAttributeValue(new QName("id"))).toString(), this);
 		}
 
-		//processing idref
+		// processing idref
 
-		//processing attributes
+		// processing attributes
 
 		if (locRoot.getAttributeValue(new QName("name")) != null) {
 			try {
@@ -444,7 +446,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 			}
 		}
 
-		//processing sons
+		// processing sons
 
 		for (Iterator iterator = locRoot.getChildElements(); iterator.hasNext();) {
 			@SuppressWarnings("unused")
@@ -458,7 +460,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 				item.setContainerVariableDecl(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("productsort")) {
 				ProductSort item;
@@ -468,7 +470,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 				item.setContainerVariableDecl(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("usersort")) {
 				UserSort item;
@@ -478,7 +480,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 				item.setContainerVariableDecl(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("null")) {
 				Bool item;
@@ -488,7 +490,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 				item.setContainerVariableDecl(this);
 
 				continue;
-			}//end if
+			} // end if
 
 			if (type.getLocalName().equals("dot")) {
 				Dot item;
@@ -498,7 +500,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 				item.setContainerVariableDecl(this);
 
 				continue;
-			}//end if
+			} // end if
 
 		}
 
@@ -509,10 +511,10 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 1
-		//idref 0
-		//attributes 1
-		//sons 1
+		// id 1
+		// idref 0
+		// attributes 1
+		// sons 1
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -535,7 +537,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getId() != null) {
 			sb.append(" id");
@@ -555,7 +557,7 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 		sb.append(">");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		if (getSort() != null) {
 
@@ -628,4 +630,4 @@ public class VariableDeclImpl extends TermsDeclarationImpl implements VariableDe
 		return retour;
 
 	}
-} //VariableDeclImpl
+} // VariableDeclImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableDeclImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableDeclImpl.java
@@ -39,7 +39,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.NotificationChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableImpl.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.namespace.QName;
-
 import org.apache.axiom.om.OMElement;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.util.DiagnosticChain;

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableImpl.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/impl/VariableImpl.java
@@ -62,13 +62,13 @@ import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
 
 /**
- * <!-- begin-user-doc -->
- * An implementation of the model object '<em><b>Variable</b></em>'.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> An implementation of the model object
+ * '<em><b>Variable</b></em>'. <!-- end-user-doc -->
  * <p>
  * The following features are implemented:
  * <ul>
- *   <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl#getVariableDecl <em>Variable Decl</em>}</li>
+ * <li>{@link fr.lip6.move.pnml.pthlpng.terms.impl.VariableImpl#getVariableDecl
+ * <em>Variable Decl</em>}</li>
  * </ul>
  * </p>
  *
@@ -76,9 +76,9 @@ import fr.lip6.move.pnml.pthlpng.terms.util.TermsValidator;
  */
 public class VariableImpl extends TermImpl implements Variable {
 	/**
-	 * The cached value of the '{@link #getVariableDecl() <em>Variable Decl</em>}' reference.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached value of the '{@link #getVariableDecl() <em>Variable Decl</em>}'
+	 * reference. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see #getVariableDecl()
 	 * @generated
 	 * @ordered
@@ -86,8 +86,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	protected VariableDecl variableDecl;
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected VariableImpl() {
@@ -95,8 +95,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -105,8 +105,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -124,8 +124,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public VariableDecl basicGetVariableDecl() {
@@ -133,8 +133,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -142,13 +142,13 @@ public class VariableImpl extends TermImpl implements Variable {
 		VariableDecl oldVariableDecl = variableDecl;
 		variableDecl = newVariableDecl;
 		if (eNotificationRequired())
-			eNotify(new ENotificationImpl(this, Notification.SET, TermsPackage.VARIABLE__VARIABLE_DECL,
-					oldVariableDecl, variableDecl));
+			eNotify(new ENotificationImpl(this, Notification.SET, TermsPackage.VARIABLE__VARIABLE_DECL, oldVariableDecl,
+					variableDecl));
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -163,8 +163,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -178,8 +178,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -193,8 +193,8 @@ public class VariableImpl extends TermImpl implements Variable {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -206,18 +206,18 @@ public class VariableImpl extends TermImpl implements Variable {
 		return super.eIsSet(featureID);
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public String toPNML() {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 0
 
 		Boolean prettyPrintStatus = ModelRepository.getInstance().isPrettyPrintActive();
 		String retline = "";
@@ -235,7 +235,7 @@ public class VariableImpl extends TermImpl implements Variable {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getVariableDecl() != null) {
 			sb.append(" refvariable");
@@ -247,7 +247,7 @@ public class VariableImpl extends TermImpl implements Variable {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -260,18 +260,18 @@ public class VariableImpl extends TermImpl implements Variable {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public void fromPNML(OMElement locRoot, IdRefLinker idr) throws InnerBuildException, InvalidIDException,
-			VoidRepositoryException {
-		//0
-		//1
-		//0
-		//0
+	public void fromPNML(OMElement locRoot, IdRefLinker idr)
+			throws InnerBuildException, InvalidIDException, VoidRepositoryException {
+		// 0
+		// 1
+		// 0
+		// 0
 		@SuppressWarnings("unused")
 		TermsFactory fact = TermsFactory.eINSTANCE;
 
-		//processing id
+		// processing id
 
-		//processing idref
+		// processing idref
 
 		List<String> ids = new ArrayList<String>();
 		String[] tmp = {};
@@ -281,9 +281,9 @@ public class VariableImpl extends TermImpl implements Variable {
 		}
 		idr.addIdRef(this, ids.toArray(tmp));
 
-		//processing attributes
+		// processing attributes
 
-		//processing sons
+		// processing sons
 
 	}
 
@@ -293,18 +293,18 @@ public class VariableImpl extends TermImpl implements Variable {
 
 	}
 
-	//TODO this element (sort) seems not to have any ToPNML associated tag.
-	//This is maybe a mistake ?
+	// TODO this element (sort) seems not to have any ToPNML associated tag.
+	// This is maybe a mistake ?
 
 	/**
 	 * Return the string containing the pnml output
 	 */
 	@Override
 	public void toPNML(FileChannel fc) {
-		//id 0
-		//idref 1
-		//attributes 0
-		//sons 0
+		// id 0
+		// idref 1
+		// attributes 0
+		// sons 0
 
 		final int bufferSizeKB = 8;
 		final int bufferSize = bufferSizeKB * 1024;
@@ -327,7 +327,7 @@ public class VariableImpl extends TermImpl implements Variable {
 		if (prettyPrintStatus) {
 			headline = prpd.increaseLineHeaderLevel();
 		}
-		//begin attributes, id and id ref processing
+		// begin attributes, id and id ref processing
 
 		if (getVariableDecl() != null) {
 			sb.append(" refvariable");
@@ -339,7 +339,7 @@ public class VariableImpl extends TermImpl implements Variable {
 		sb.append("/>");
 		sb.append(retline);
 
-		//sons, follow processing
+		// sons, follow processing
 
 		/****/
 
@@ -392,4 +392,4 @@ public class VariableImpl extends TermImpl implements Variable {
 		return retour;
 
 	}
-} //VariableImpl
+} // VariableImpl

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/util/TermsAdapterFactory.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/util/TermsAdapterFactory.java
@@ -59,26 +59,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Variable;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Adapter Factory</b> for the model.
- * It provides an adapter <code>createXXX</code> method for each class of the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Adapter Factory</b> for the model. It provides
+ * an adapter <code>createXXX</code> method for each class of the model. <!--
+ * end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage
  * @generated
  */
 public class TermsAdapterFactory extends AdapterFactoryImpl {
 	/**
-	 * The cached model package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static TermsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the adapter factory.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the adapter factory. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public TermsAdapterFactory() {
@@ -88,10 +87,11 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Returns whether this factory is applicable for the type of the object.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns <code>true</code> if the object is either the model's package or is an instance object of the model.
+	 * Returns whether this factory is applicable for the type of the object. <!--
+	 * begin-user-doc --> This implementation returns <code>true</code> if the
+	 * object is either the model's package or is an instance object of the model.
 	 * <!-- end-user-doc -->
+	 * 
 	 * @return whether this factory is applicable for the type of the object.
 	 * @generated
 	 */
@@ -107,9 +107,9 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * The switch that delegates to the <code>createXXX</code> methods.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The switch that delegates to the <code>createXXX</code> methods. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected TermsSwitch<Adapter> modelSwitch = new TermsSwitch<Adapter>() {
@@ -220,9 +220,9 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	};
 
 	/**
-	 * Creates an adapter for the <code>target</code>.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an adapter for the <code>target</code>. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @param target the object to adapt.
 	 * @return the adapter for the <code>target</code>.
 	 * @generated
@@ -233,11 +233,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations <em>Declarations</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Declarations <em>Declarations</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Declarations
 	 * @generated
@@ -247,11 +248,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration <em>Declaration</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration
+	 * <em>Declaration</em>}'. <!-- begin-user-doc --> This default implementation
+	 * returns null so that we can easily ignore cases; it's useful to ignore a case
+	 * when inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.TermsDeclaration
 	 * @generated
@@ -261,11 +263,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Sort <em>Sort</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Sort
 	 * @generated
@@ -275,11 +278,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort <em>Multiset Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetSort <em>Multiset
+	 * Sort</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.MultisetSort
 	 * @generated
@@ -289,11 +293,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Term <em>Term</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Term
 	 * @generated
@@ -303,11 +308,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Operator <em>Operator</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Operator
 	 * @generated
@@ -317,11 +323,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl <em>Variable Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.VariableDecl <em>Variable
+	 * Decl</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.VariableDecl
 	 * @generated
@@ -331,11 +338,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Variable <em>Variable</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Variable <em>Variable</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Variable
 	 * @generated
@@ -345,11 +353,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInSort <em>Built In Sort</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInSort
 	 * @generated
@@ -359,11 +368,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort <em>Product Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.ProductSort <em>Product Sort</em>}'.
+	 * <!-- begin-user-doc --> This default implementation returns null so that we
+	 * can easily ignore cases; it's useful to ignore a case when inheritance will
+	 * catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.ProductSort
 	 * @generated
@@ -373,11 +383,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In Constant</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant <em>Built In
+	 * Constant</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInConstant
 	 * @generated
@@ -387,11 +398,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetOperator <em>Multiset Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.MultisetOperator <em>Multiset
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.MultisetOperator
 	 * @generated
@@ -401,11 +413,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.Tuple <em>Tuple</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.Tuple <em>Tuple</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.Tuple
 	 * @generated
@@ -415,11 +428,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.SortDecl <em>Sort Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.SortDecl <em>Sort Decl</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.SortDecl
 	 * @generated
@@ -429,11 +443,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator <em>Built In
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.BuiltInOperator
 	 * @generated
@@ -443,11 +458,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort <em>Named Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedSort <em>Named Sort</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedSort
 	 * @generated
@@ -457,11 +473,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort <em>User Sort</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserSort <em>User Sort</em>}'. <!--
+	 * begin-user-doc --> This default implementation returns null so that we can
+	 * easily ignore cases; it's useful to ignore a case when inheritance will catch
+	 * all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.UserSort
 	 * @generated
@@ -471,11 +488,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.OperatorDecl <em>Operator Decl</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.OperatorDecl <em>Operator
+	 * Decl</em>}'. <!-- begin-user-doc --> This default implementation returns null
+	 * so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.OperatorDecl
 	 * @generated
@@ -485,11 +503,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator <em>Named Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.NamedOperator <em>Named
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.NamedOperator
 	 * @generated
@@ -499,11 +518,12 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for an object of class '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator <em>User Operator</em>}'.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null so that we can easily ignore cases;
-	 * it's useful to ignore a case when inheritance will catch all the cases anyway.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for an object of class
+	 * '{@link fr.lip6.move.pnml.pthlpng.terms.UserOperator <em>User
+	 * Operator</em>}'. <!-- begin-user-doc --> This default implementation returns
+	 * null so that we can easily ignore cases; it's useful to ignore a case when
+	 * inheritance will catch all the cases anyway. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @see fr.lip6.move.pnml.pthlpng.terms.UserOperator
 	 * @generated
@@ -513,10 +533,9 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 	}
 
 	/**
-	 * Creates a new adapter for the default case.
-	 * <!-- begin-user-doc -->
-	 * This default implementation returns null.
-	 * <!-- end-user-doc -->
+	 * Creates a new adapter for the default case. <!-- begin-user-doc --> This
+	 * default implementation returns null. <!-- end-user-doc -->
+	 * 
 	 * @return the new adapter.
 	 * @generated
 	 */
@@ -524,4 +543,4 @@ public class TermsAdapterFactory extends AdapterFactoryImpl {
 		return null;
 	}
 
-} //TermsAdapterFactory
+} // TermsAdapterFactory

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/util/TermsSwitch.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/util/TermsSwitch.java
@@ -58,31 +58,28 @@ import fr.lip6.move.pnml.pthlpng.terms.Variable;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Switch</b> for the model's inheritance hierarchy.
- * It supports the call {@link #doSwitch(EObject) doSwitch(object)}
+ * <!-- begin-user-doc --> The <b>Switch</b> for the model's inheritance
+ * hierarchy. It supports the call {@link #doSwitch(EObject) doSwitch(object)}
  * to invoke the <code>caseXXX</code> method for each class of the model,
- * starting with the actual class of the object
- * and proceeding up the inheritance hierarchy
- * until a non-null result is returned,
- * which is the result of the switch.
- * <!-- end-user-doc -->
+ * starting with the actual class of the object and proceeding up the
+ * inheritance hierarchy until a non-null result is returned, which is the
+ * result of the switch. <!-- end-user-doc -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage
  * @generated
  */
 public class TermsSwitch<T> extends Switch<T> {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static TermsPackage modelPackage;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public TermsSwitch() {
@@ -92,9 +89,9 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Checks whether this is a switch for the given package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Checks whether this is a switch for the given package. <!-- begin-user-doc
+	 * --> <!-- end-user-doc -->
+	 * 
 	 * @parameter ePackage the package in question.
 	 * @return whether this is a switch for the given package.
 	 * @generated
@@ -105,9 +102,10 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Calls <code>caseXXX</code> for each class of the model until one returns a non null result; it yields that result.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Calls <code>caseXXX</code> for each class of the model until one returns a
+	 * non null result; it yields that result. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @return the first non-null result returned by a <code>caseXXX</code> call.
 	 * @generated
 	 */
@@ -306,13 +304,14 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Declarations</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Declarations</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Declarations</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Declarations</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -321,13 +320,14 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Declaration</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Declaration</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Declaration</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Declaration</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -336,13 +336,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Sort</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -351,13 +351,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Multiset Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Multiset
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Multiset Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Multiset
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -366,13 +366,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Term</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Term</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Term</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Term</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -381,13 +381,14 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Operator</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -396,13 +397,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Variable Decl</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Variable
+	 * Decl</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Variable Decl</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Variable
+	 *         Decl</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -411,13 +412,14 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Variable</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Variable</em>'. <!-- begin-user-doc --> This implementation returns
+	 * null; returning a non-null result will terminate the switch. <!--
+	 * end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Variable</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Variable</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -426,13 +428,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -441,13 +443,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Product Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Product
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Product Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Product
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -456,13 +458,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Constant</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Constant</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Constant</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -471,13 +473,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Multiset Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Multiset
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Multiset Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Multiset
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -486,13 +488,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Tuple</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>Tuple</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Tuple</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>Tuple</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -501,13 +503,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Sort Decl</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Sort
+	 * Decl</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Sort Decl</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Sort
+	 *         Decl</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -516,13 +518,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Built In
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Built In Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Built In
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -531,13 +533,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Named Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Named
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Named Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Named
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -546,13 +548,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>User Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>User
+	 * Sort</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>User Sort</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>User
+	 *         Sort</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -561,13 +563,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Operator Decl</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Operator
+	 * Decl</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Operator Decl</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Operator
+	 *         Decl</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -576,13 +578,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>Named Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>Named
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>Named Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>Named
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -591,13 +593,13 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>User Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of '<em>User
+	 * Operator</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>User Operator</em>'.
+	 * @return the result of interpreting the object as an instance of '<em>User
+	 *         Operator</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject) doSwitch(EObject)
 	 * @generated
 	 */
@@ -606,13 +608,14 @@ public class TermsSwitch<T> extends Switch<T> {
 	}
 
 	/**
-	 * Returns the result of interpreting the object as an instance of '<em>EObject</em>'.
-	 * <!-- begin-user-doc -->
-	 * This implementation returns null;
-	 * returning a non-null result will terminate the switch, but this is the last case anyway.
-	 * <!-- end-user-doc -->
+	 * Returns the result of interpreting the object as an instance of
+	 * '<em>EObject</em>'. <!-- begin-user-doc --> This implementation returns null;
+	 * returning a non-null result will terminate the switch, but this is the last
+	 * case anyway. <!-- end-user-doc -->
+	 * 
 	 * @param object the target of the switch.
-	 * @return the result of interpreting the object as an instance of '<em>EObject</em>'.
+	 * @return the result of interpreting the object as an instance of
+	 *         '<em>EObject</em>'.
 	 * @see #doSwitch(org.eclipse.emf.ecore.EObject)
 	 * @generated
 	 */
@@ -621,4 +624,4 @@ public class TermsSwitch<T> extends Switch<T> {
 		return null;
 	}
 
-} //TermsSwitch
+} // TermsSwitch

--- a/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/util/TermsValidator.java
+++ b/pnmlFw-PT-HLPNG/src/fr/lip6/move/pnml/pthlpng/terms/util/TermsValidator.java
@@ -62,25 +62,25 @@ import fr.lip6.move.pnml.pthlpng.terms.Variable;
 import fr.lip6.move.pnml.pthlpng.terms.VariableDecl;
 
 /**
- * <!-- begin-user-doc -->
- * The <b>Validator</b> for the model.
- * <!-- end-user-doc -->
+ * <!-- begin-user-doc --> The <b>Validator</b> for the model. <!-- end-user-doc
+ * -->
+ * 
  * @see fr.lip6.move.pnml.pthlpng.terms.TermsPackage
  * @generated
  */
 public class TermsValidator extends EObjectValidator {
 	/**
-	 * The cached model package
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * The cached model package <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public static final TermsValidator INSTANCE = new TermsValidator();
 
 	/**
-	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource() source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode() codes} from this package.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant for the {@link org.eclipse.emf.common.util.Diagnostic#getSource()
+	 * source} of diagnostic {@link org.eclipse.emf.common.util.Diagnostic#getCode()
+	 * codes} from this package. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @see org.eclipse.emf.common.util.Diagnostic#getSource()
 	 * @see org.eclipse.emf.common.util.Diagnostic#getCode()
 	 * @generated
@@ -88,25 +88,27 @@ public class TermsValidator extends EObjectValidator {
 	public static final String DIAGNOSTIC_SOURCE = "fr.lip6.move.pnml.pthlpng.terms";
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	private static final int GENERATED_DIAGNOSTIC_CODE_COUNT = 0;
 
 	/**
-	 * A constant with a fixed name that can be used as the base value for additional hand written constants in a derived class.
-	 * <!-- begin-user-doc -->
+	 * A constant with a fixed name that can be used as the base value for
+	 * additional hand written constants in a derived class. <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	protected static final int DIAGNOSTIC_CODE_COUNT = GENERATED_DIAGNOSTIC_CODE_COUNT;
 
 	/**
-	 * Creates an instance of the switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Creates an instance of the switch. <!-- begin-user-doc --> <!-- end-user-doc
+	 * -->
+	 * 
 	 * @generated
 	 */
 	public TermsValidator() {
@@ -114,9 +116,9 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the package of this validator switch.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the package of this validator switch. <!-- begin-user-doc --> <!--
+	 * end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
@@ -126,12 +128,13 @@ public class TermsValidator extends EObjectValidator {
 
 	/**
 	 * Calls <code>validateXXX</code> for the corresponding classifier of the model.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
-	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	protected boolean validate(int classifierID, Object value, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		switch (classifierID) {
 		case TermsPackage.DECLARATIONS:
 			return validateDeclarations((Declarations) value, diagnostics, context);
@@ -179,8 +182,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateDeclarations(Declarations declarations, DiagnosticChain diagnostics,
@@ -189,8 +192,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateTermsDeclaration(TermsDeclaration termsDeclaration, DiagnosticChain diagnostics,
@@ -199,8 +202,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateSort(Sort sort, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -208,8 +211,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateMultisetSort(MultisetSort multisetSort, DiagnosticChain diagnostics,
@@ -218,8 +221,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateTerm(Term term, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -227,8 +230,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateOperator(Operator operator, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -255,9 +258,9 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the sameOperatorNTermSort constraint of '<em>Operator</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the sameOperatorNTermSort constraint of '<em>Operator</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateOperator_sameOperatorNTermSort(Operator operator, DiagnosticChain diagnostics,
@@ -268,10 +271,10 @@ public class TermsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "sameOperatorNTermSort", getObjectLabel(operator, context) },
-						new Object[] { operator }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "sameOperatorNTermSort", getObjectLabel(operator, context) },
+								new Object[] { operator }, context));
 			}
 			return false;
 		}
@@ -279,8 +282,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateVariableDecl(VariableDecl variableDecl, DiagnosticChain diagnostics,
@@ -289,8 +292,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateVariable(Variable variable, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -298,26 +301,28 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateBuiltInSort(BuiltInSort builtInSort, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateBuiltInSort(BuiltInSort builtInSort, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		return validate_EveryDefaultConstraint(builtInSort, diagnostics, context);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
-	public boolean validateProductSort(ProductSort productSort, DiagnosticChain diagnostics, Map<Object, Object> context) {
+	public boolean validateProductSort(ProductSort productSort, DiagnosticChain diagnostics,
+			Map<Object, Object> context) {
 		return validate_EveryDefaultConstraint(productSort, diagnostics, context);
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateBuiltInConstant(BuiltInConstant builtInConstant, DiagnosticChain diagnostics,
@@ -345,8 +350,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateMultisetOperator(MultisetOperator multisetOperator, DiagnosticChain diagnostics,
@@ -374,8 +379,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateTuple(Tuple tuple, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -402,8 +407,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateSortDecl(SortDecl sortDecl, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -411,8 +416,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateBuiltInOperator(BuiltInOperator builtInOperator, DiagnosticChain diagnostics,
@@ -440,8 +445,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNamedSort(NamedSort namedSort, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -468,9 +473,9 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Validates the refSortNotMultiset constraint of '<em>Named Sort</em>'.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Validates the refSortNotMultiset constraint of '<em>Named Sort</em>'. <!--
+	 * begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNamedSort_refSortNotMultiset(NamedSort namedSort, DiagnosticChain diagnostics,
@@ -481,10 +486,10 @@ public class TermsValidator extends EObjectValidator {
 		// Ensure that you remove @generated or mark it @generated NOT
 		if (false) {
 			if (diagnostics != null) {
-				diagnostics.add(createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0,
-						"_UI_GenericConstraint_diagnostic",
-						new Object[] { "refSortNotMultiset", getObjectLabel(namedSort, context) },
-						new Object[] { namedSort }, context));
+				diagnostics.add(
+						createDiagnostic(Diagnostic.ERROR, DIAGNOSTIC_SOURCE, 0, "_UI_GenericConstraint_diagnostic",
+								new Object[] { "refSortNotMultiset", getObjectLabel(namedSort, context) },
+								new Object[] { namedSort }, context));
 			}
 			return false;
 		}
@@ -492,8 +497,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateUserSort(UserSort userSort, DiagnosticChain diagnostics, Map<Object, Object> context) {
@@ -501,8 +506,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateOperatorDecl(OperatorDecl operatorDecl, DiagnosticChain diagnostics,
@@ -511,8 +516,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateNamedOperator(NamedOperator namedOperator, DiagnosticChain diagnostics,
@@ -521,8 +526,8 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	public boolean validateUserOperator(UserOperator userOperator, DiagnosticChain diagnostics,
@@ -550,17 +555,18 @@ public class TermsValidator extends EObjectValidator {
 	}
 
 	/**
-	 * Returns the resource locator that will be used to fetch messages for this validator's diagnostics.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
+	 * Returns the resource locator that will be used to fetch messages for this
+	 * validator's diagnostics. <!-- begin-user-doc --> <!-- end-user-doc -->
+	 * 
 	 * @generated
 	 */
 	@Override
 	public ResourceLocator getResourceLocator() {
 		// TODO
-		// Specialize this to return a resource locator for messages specific to this validator.
+		// Specialize this to return a resource locator for messages specific to this
+		// validator.
 		// Ensure that you remove @generated or mark it @generated NOT
 		return super.getResourceLocator();
 	}
 
-} //TermsValidator
+} // TermsValidator


### PR DESCRIPTION
This commit changes the nsURI attribute of the integers package of file `pnmlFw-Low_Level_API_Generation/model/pthlpng/integers.ecore` from `http:///hlpn.integers.ecore` to `http:///pthlpng.integers.ecore`.

Additionally, the code of the plugin fr.lip6.pnml.framework.pthlpng (i.e. the one located in `pnmlFw-PT-HLPNG/src`) has been regenerated using the `pnmlFw-Low_Level_API_Generation/model/pthlpng/pthlpng.genmodel` genmodel file.

The changes have been done incrementally to ease the manual inspection and proper code merge:

1. First, an automatic reformatting of the previous code has been performed to match the code layout to the lastest version of the eclipse code formatter.

2. Second, a regeneration of the code has been performed. Still, a considerable amount of changes are introduced in the regenerated code since the actual code generator escapes some HTML entities in Javadoc comments. Moreover, some additional annotations are also included in the comments. Nevertheless, the actual number of changes is considerably smaller now.

Finally, some minor changes have been introduced: a fix of a small typo in the MANIFEST.MF file, and a flag in the genmodel to minimize the code changes introduced by the regeneration.

This PR superseedes #11 